### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -306,8 +306,7 @@ class SummaryInfo(object):
 
                 # if we get a key error, then we've got a problem with alphabets
                 except KeyError:
-                    raise ValueError("Residues %s, %s not found in alphabet %s"
-                                     % (residue1, residue2,
+                    raise ValueError("Residues {0!s}, {1!s} not found in alphabet {2!s}".format(residue1, residue2,
                                         self.alignment._alphabet))
 
         return start_dict
@@ -424,8 +423,7 @@ class SummaryInfo(object):
                         score_dict[this_residue] += weight
                     # if we get a KeyError then we have an alphabet problem
                     except KeyError:
-                        raise ValueError("Residue %s not found in alphabet %s"
-                                     % (this_residue,
+                        raise ValueError("Residue {0!s} not found in alphabet {1!s}".format(this_residue,
                                         self.alignment._alphabet))
 
             pssm_info.append((left_seq[residue_num],
@@ -477,9 +475,8 @@ class SummaryInfo(object):
             chars_to_ignore = []
 
         if start < 0 or end > len(self.alignment[0].seq):
-            raise ValueError("Start (%s) and end (%s) are not in the \
-                    range %s to %s"
-                    % (start, end, 0, len(self.alignment[0].seq)))
+            raise ValueError("Start ({0!s}) and end ({1!s}) are not in the \
+                    range {2!s} to {3!s}".format(start, end, 0, len(self.alignment[0].seq)))
         # determine random expected frequencies, if necessary
         random_expected = None
         if not e_freq_table:
@@ -549,8 +546,7 @@ class SummaryInfo(object):
                     total_count += weight
             # getting a key error means we've got a problem with the alphabet
             except KeyError:
-                raise ValueError("Residue %s not found in alphabet %s"
-                                 % (record.seq[residue_num],
+                raise ValueError("Residue {0!s} not found in alphabet {1!s}".format(record.seq[residue_num],
                                     self.alignment._alphabet))
 
         if total_count == 0:
@@ -669,14 +665,14 @@ class PSSM(object):
 
         # first print out the top header
         for res in all_residues:
-            out += "   %s" % res
+            out += "   {0!s}".format(res)
         out += "\n"
 
         # for each item, write out the substitutions
         for item in self.pssm:
-            out += "%s " % item[0]
+            out += "{0!s} ".format(item[0])
             for res in all_residues:
-                out += " %.1f" % item[1][res]
+                out += " {0:.1f}".format(item[1][res])
 
             out += "\n"
         return out
@@ -695,7 +691,7 @@ def print_info_content(summary_info, fout=None, rep_record=0):
         summary_info.information_content()
     rep_sequence = summary_info.alignment[rep_record].seq
     for pos in sorted(summary_info.ic_vector):
-        fout.write("%d %s %.3f\n" % (pos, rep_sequence[pos],
+        fout.write("{0:d} {1!s} {2:.3f}\n".format(pos, rep_sequence[pos],
                    summary_info.ic_vector[pos]))
 
 if __name__ == "__main__":

--- a/Bio/Align/Generic.py
+++ b/Bio/Align/Generic.py
@@ -67,16 +67,14 @@ class Alignment(object):
         """
         if record.seq.__class__.__name__ == "CodonSeq":
             if len(record.seq) <= length:
-                return "%s %s" % (record.seq, record.id)
+                return "{0!s} {1!s}".format(record.seq, record.id)
             else:
-                return "%s...%s %s" \
-                       % (record.seq[:length - 3], record.seq[-3:], record.id)
+                return "{0!s}...{1!s} {2!s}".format(record.seq[:length - 3], record.seq[-3:], record.id)
         else:
             if len(record.seq) <= length:
-                return "%s %s" % (record.seq, record.id)
+                return "{0!s} {1!s}".format(record.seq, record.id)
             else:
-                return "%s...%s %s" \
-                       % (record.seq[:length - 6], record.seq[-3:], record.id)
+                return "{0!s}...{1!s} {2!s}".format(record.seq[:length - 6], record.seq[-3:], record.id)
 
     def __str__(self):
         """Returns a multi-line string summary of the alignment.
@@ -100,8 +98,7 @@ class Alignment(object):
         See also the alignment's format method.
         """
         rows = len(self._records)
-        lines = ["%s alignment with %i rows and %i columns"
-                 % (str(self._alphabet), rows, self.get_alignment_length())]
+        lines = ["{0!s} alignment with {1:d} rows and {2:d} columns".format(str(self._alphabet), rows, self.get_alignment_length())]
         if rows <= 20:
             lines.extend(self._str_line(rec) for rec in self._records)
         else:
@@ -125,8 +122,7 @@ class Alignment(object):
         """
         # A doctest for __repr__ would be nice, but __class__ comes out differently
         # if run via the __main__ trick.
-        return "<%s instance (%i records of length %i, %s) at %x>" % \
-               (self.__class__, len(self._records),
+        return "<{0!s} instance ({1:d} records of length {2:d}, {3!s}) at {4:x}>".format(self.__class__, len(self._records),
                 self.get_alignment_length(), repr(self._alphabet), id(self))
         # This version is useful for doing eval(repr(alignment)),
         # but it can be VERY long:

--- a/Bio/AlignIO/ClustalIO.py
+++ b/Bio/AlignIO/ClustalIO.py
@@ -40,10 +40,10 @@ class ClustalWriter(SequentialAlignmentWriter):
             version = '1.81'
         if version.startswith("2."):
             # e.g. 2.0.x
-            output = "CLUSTAL %s multiple sequence alignment\n\n\n" % version
+            output = "CLUSTAL {0!s} multiple sequence alignment\n\n\n".format(version)
         else:
             # e.g. 1.81 or 1.83
-            output = "CLUSTAL X (%s) multiple sequence alignment\n\n\n" % version
+            output = "CLUSTAL X ({0!s}) multiple sequence alignment\n\n\n".format(version)
 
         cur_char = 0
         max_length = len(alignment[0])
@@ -106,8 +106,7 @@ class ClustalIterator(AlignmentIterator):
         # Whitelisted headers we know about
         known_headers = ['CLUSTAL', 'PROBCONS', 'MUSCLE', 'MSAPROBS','Kalign']
         if line.strip().split()[0] not in known_headers:
-            raise ValueError("%s is not a known CLUSTAL header: %s" %
-                             (line.strip().split()[0],
+            raise ValueError("{0!s} is not a known CLUSTAL header: {1!s}".format(line.strip().split()[0],
                               ", ".join(known_headers)))
 
         # find the clustal version in the header line
@@ -141,7 +140,7 @@ class ClustalIterator(AlignmentIterator):
                 # We expect there to be two fields, there can be an optional
                 # "sequence number" field containing the letter count.
                 if len(fields) < 2 or len(fields) > 3:
-                    raise ValueError("Could not parse line:\n%s" % line)
+                    raise ValueError("Could not parse line:\n{0!s}".format(line))
 
                 ids.append(fields[0])
                 seqs.append(fields[1])
@@ -159,9 +158,9 @@ class ClustalIterator(AlignmentIterator):
                     try:
                         letters = int(fields[2])
                     except ValueError:
-                        raise ValueError("Could not parse line, bad sequence number:\n%s" % line)
+                        raise ValueError("Could not parse line, bad sequence number:\n{0!s}".format(line))
                     if len(fields[1].replace("-", "")) != letters:
-                        raise ValueError("Could not parse line, invalid sequence number:\n%s" % line)
+                        raise ValueError("Could not parse line, invalid sequence number:\n{0!s}".format(line))
             elif line[0] == " ":
                 # Sequence consensus line...
                 assert len(ids) == len(seqs)
@@ -210,21 +209,20 @@ class ClustalIterator(AlignmentIterator):
                 break
 
             for i in range(len(ids)):
-                assert line[0] != " ", "Unexpected line:\n%s" % repr(line)
+                assert line[0] != " ", "Unexpected line:\n{0!s}".format(repr(line))
                 fields = line.rstrip().split()
 
                 # We expect there to be two fields, there can be an optional
                 # "sequence number" field containing the letter count.
                 if len(fields) < 2 or len(fields) > 3:
-                    raise ValueError("Could not parse line:\n%s" % repr(line))
+                    raise ValueError("Could not parse line:\n{0!s}".format(repr(line)))
 
                 if fields[0] != ids[i]:
-                    raise ValueError("Identifiers out of order? Got '%s' but expected '%s'"
-                                      % (fields[0], ids[i]))
+                    raise ValueError("Identifiers out of order? Got '{0!s}' but expected '{1!s}'".format(fields[0], ids[i]))
 
                 if fields[1] != line[seq_cols]:
                     start = len(fields[0]) + line[len(fields[0]):].find(fields[1])
-                    assert start == seq_cols.start, 'Old location %s -> %i:XX' % (seq_cols, start)
+                    assert start == seq_cols.start, 'Old location {0!s} -> {1:d}:XX'.format(seq_cols, start)
                     end = start + len(fields[1])
                     seq_cols = slice(start, end)
                     del start, end
@@ -238,9 +236,9 @@ class ClustalIterator(AlignmentIterator):
                     try:
                         letters = int(fields[2])
                     except ValueError:
-                        raise ValueError("Could not parse line, bad sequence number:\n%s" % line)
+                        raise ValueError("Could not parse line, bad sequence number:\n{0!s}".format(line))
                     if len(seqs[i].replace("-", "")) != letters:
-                        raise ValueError("Could not parse line, invalid sequence number:\n%s" % line)
+                        raise ValueError("Could not parse line, invalid sequence number:\n{0!s}".format(line))
 
                 # Read in the next line
                 line = handle.readline()
@@ -261,8 +259,7 @@ class ClustalIterator(AlignmentIterator):
 
         if self.records_per_alignment is not None \
         and self.records_per_alignment != len(ids):
-            raise ValueError("Found %i records in this alignment, told to expect %i"
-                             % (len(ids), self.records_per_alignment))
+            raise ValueError("Found {0:d} records in this alignment, told to expect {1:d}".format(len(ids), self.records_per_alignment))
 
         records = (SeqRecord(Seq(s, self.alphabet), id=i, description=i)
                    for (i, s) in zip(ids, seqs))
@@ -274,7 +271,6 @@ class ClustalIterator(AlignmentIterator):
         if consensus:
             alignment_length = len(seqs[0])
             assert len(consensus) == alignment_length, \
-                   "Alignment length is %i, consensus length is %i, '%s'" \
-                   % (alignment_length, len(consensus), consensus)
+                   "Alignment length is {0:d}, consensus length is {1:d}, '{2!s}'".format(alignment_length, len(consensus), consensus)
             alignment._star_info = consensus
         return alignment

--- a/Bio/AlignIO/EmbossIO.py
+++ b/Bio/AlignIO/EmbossIO.py
@@ -35,7 +35,7 @@ class EmbossWriter(SequentialAlignmentWriter):
         handle.write("########################################\n")
         handle.write("# Program: Biopython\n")
         try:
-            handle.write("# Report_file: %s\n" % handle.name)
+            handle.write("# Report_file: {0!s}\n".format(handle.name))
         except AttributeError:
             pass
         handle.write("########################################\n")
@@ -50,11 +50,11 @@ class EmbossWriter(SequentialAlignmentWriter):
         handle = self.handle
         handle.write("#=======================================\n")
         handle.write("#\n")
-        handle.write("# Aligned_sequences: %i\n" % len(alignment))
+        handle.write("# Aligned_sequences: {0:d}\n".format(len(alignment)))
         for i, record in enumerate(alignment):
-            handle.write("# %i: %s\n" % (i + 1, record.id))
+            handle.write("# {0:d}: {1!s}\n".format(i + 1, record.id))
         handle.write("#\n")
-        handle.write("# Length: %i\n" % alignment.get_alignment_length())
+        handle.write("# Length: {0:d}\n".format(alignment.get_alignment_length()))
         handle.write("#\n")
         handle.write("#=======================================\n")
         handle.write("\n")
@@ -125,8 +125,7 @@ class EmbossIterator(AlignmentIterator):
 
         if self.records_per_alignment is not None \
         and self.records_per_alignment != number_of_seqs:
-            raise ValueError("Found %i records in this alignment, told to expect %i"
-                             % (number_of_seqs, self.records_per_alignment))
+            raise ValueError("Found {0:d} records in this alignment, told to expect {1:d}".format(number_of_seqs, self.records_per_alignment))
 
         seqs = ["" for id in ids]
         seq_starts = []
@@ -158,8 +157,7 @@ class EmbossIterator(AlignmentIterator):
 
                     # The identifier is truncated...
                     assert 0 <= index and index < number_of_seqs, \
-                           "Expected index %i in range [0,%i)" \
-                           % (index, number_of_seqs)
+                           "Expected index {0:d} in range [0,{1:d})".format(index, number_of_seqs)
                     assert id == ids[index] or id == ids[index][:len(id)]
 
                     if len(seq_starts) == index:
@@ -171,16 +169,14 @@ class EmbossIterator(AlignmentIterator):
                         assert seq.replace("-", "") == "", line
                     else:
                         assert start - seq_starts[index] == len(seqs[index].replace("-", "")), \
-                        "Found %i chars so far for sequence %i (%s, %s), line says start %i:\n%s" \
-                            % (len(seqs[index].replace("-", "")), index, id, repr(seqs[index]),
+                        "Found {0:d} chars so far for sequence {1:d} ({2!s}, {3!s}), line says start {4:d}:\n{5!s}".format(len(seqs[index].replace("-", "")), index, id, repr(seqs[index]),
                                start, line)
 
                     seqs[index] += seq
 
                     # Check the end ...
                     assert end == seq_starts[index] + len(seqs[index].replace("-", "")), \
-                        "Found %i chars so far for sequence %i (%s, %s, start=%i), file says end %i:\n%s" \
-                            % (len(seqs[index].replace("-", "")), index, id, repr(seqs[index]),
+                        "Found {0:d} chars so far for sequence {1:d} ({2!s}, {3!s}, start={4:d}), file says end {5:d}:\n{6!s}".format(len(seqs[index].replace("-", "")), index, id, repr(seqs[index]),
                                seq_starts[index], end, line)
 
                     index += 1
@@ -208,8 +204,7 @@ class EmbossIterator(AlignmentIterator):
 
         if self.records_per_alignment is not None \
         and self.records_per_alignment != len(ids):
-            raise ValueError("Found %i records in this alignment, told to expect %i"
-                             % (len(ids), self.records_per_alignment))
+            raise ValueError("Found {0:d} records in this alignment, told to expect {1:d}".format(len(ids), self.records_per_alignment))
 
         records = []
         for id, seq in zip(ids, seqs):

--- a/Bio/AlignIO/FastaIO.py
+++ b/Bio/AlignIO/FastaIO.py
@@ -58,8 +58,7 @@ def _extract_alignment_region(alignment_seq_with_flanking, annotation):
               - int(annotation['al_stop']) + 1
     end += align_stripped.count("-")
     assert 0 <= start and start < end and end <= len(align_stripped), \
-           "Problem with sequence start/stop,\n%s[%i:%i]\n%s" \
-           % (alignment_seq_with_flanking, start, end, annotation)
+           "Problem with sequence start/stop,\n{0!s}[{1:d}:{2:d}]\n{3!s}".format(alignment_seq_with_flanking, start, end, annotation)
     return align_stripped[start:end]
 
 
@@ -107,8 +106,7 @@ def FastaM10Iterator(handle, alphabet=single_letter_alphabet):
 
     def build_hsp():
         if not query_tags and not match_tags:
-            raise ValueError("No data for query %r, match %r"
-                             % (query_id, match_id))
+            raise ValueError("No data for query {0!r}, match {1!r}".format(query_id, match_id))
         assert query_tags, query_tags
         assert match_tags, match_tags
         evalue = align_tags.get("fa_expect", None)
@@ -129,10 +127,10 @@ def FastaM10Iterator(handle, alphabet=single_letter_alphabet):
             print(tool)
             print(query_seq)
             print(query_tags)
-            print("%s %i" % (q, len(q)))
+            print("{0!s} {1:d}".format(q, len(q)))
             print(match_seq)
             print(match_tags)
-            print("%s %i" % (m, len(m)))
+            print("{0!s} {1:d}".format(m, len(m)))
             print(handle.name)
             raise err
 
@@ -312,7 +310,7 @@ def FastaM10Iterator(handle, alphabet=single_letter_alphabet):
                 # Can get > as the last line of a histogram
                 pass
             else:
-                assert False, "state %i got %r" % (state, line)
+                assert False, "state {0:d} got {1!r}".format(state, line)
         elif line.startswith("; al_cons"):
             assert state == state_ALIGN_MATCH, line
             state = state_ALIGN_CONS
@@ -324,11 +322,11 @@ def FastaM10Iterator(handle, alphabet=single_letter_alphabet):
                 import warnings
                 # Seen in lalign36, specifically version 36.3.4 Apr, 2011
                 # Fixed in version 36.3.5b Oct, 2011(preload8)
-                warnings.warn("Missing colon in line: %r" % line)
+                warnings.warn("Missing colon in line: {0!r}".format(line))
                 try:
                     key, value = [s.strip() for s in line[2:].split(" ", 1)]
                 except ValueError:
-                    raise ValueError("Bad line: %r" % line)
+                    raise ValueError("Bad line: {0!r}".format(line))
             if state == state_QUERY_HEADER:
                 header_tags[key] = value
             elif state == state_ALIGN_HEADER:
@@ -338,7 +336,7 @@ def FastaM10Iterator(handle, alphabet=single_letter_alphabet):
             elif state == state_ALIGN_MATCH:
                 match_tags[key] = value
             else:
-                assert False, "Unexpected state %r, %r" % (state, line)
+                assert False, "Unexpected state {0!r}, {1!r}".format(state, line)
         elif state == state_ALIGN_QUERY:
             query_seq += line.strip()
         elif state == state_ALIGN_MATCH:
@@ -601,10 +599,9 @@ Function used was FASTA [version 34.26 January 12, 2007]
     assert len(alignments) == 4, len(alignments)
     assert len(alignments[0]) == 2
     for a in alignments:
-        print("Alignment %i sequences of length %i"
-              % (len(a), a.get_alignment_length()))
+        print("Alignment {0:d} sequences of length {1:d}".format(len(a), a.get_alignment_length()))
         for r in a:
-            print("%s %s %i" % (r.seq, r.id, r.annotations["original_length"]))
+            print("{0!s} {1!s} {2:d}".format(r.seq, r.id, r.annotations["original_length"]))
         # print(a.annotations)
     print("Done")
 
@@ -617,7 +614,7 @@ Function used was FASTA [version 34.26 January 12, 2007]
             print(filename)
             print("=" * len(filename))
             for i, a in enumerate(FastaM10Iterator(open(os.path.join(path, filename)))):
-                print("#%i, %s" % (i + 1, a))
+                print("#{0:d}, {1!s}".format(i + 1, a))
                 for r in a:
                     if "-" in r.seq:
                         assert r.seq.alphabet.gap_char == "-"

--- a/Bio/AlignIO/NexusIO.py
+++ b/Bio/AlignIO/NexusIO.py
@@ -49,8 +49,7 @@ def NexusIterator(handle, seq_count=None):
     assert len(n.unaltered_taxlabels) == len(n.taxlabels)
 
     if seq_count and seq_count != len(n.unaltered_taxlabels):
-        raise ValueError("Found %i sequences, but seq_count=%i"
-               % (len(n.unaltered_taxlabels), seq_count))
+        raise ValueError("Found {0:d} sequences, but seq_count={1:d}".format(len(n.unaltered_taxlabels), seq_count))
 
     # TODO - Can we extract any annotation too?
     records = (SeqRecord(n.matrix[new_name], id=new_name,
@@ -108,8 +107,7 @@ class NexusWriter(AlignmentWriter):
         if columns == 0:
             raise ValueError("Non-empty sequences are required")
         minimal_record = "#NEXUS\nbegin data; dimensions ntax=0 nchar=0; " \
-                         + "format datatype=%s; end;"  \
-                         % self._classify_alphabet_for_nexus(alignment._alphabet)
+                         + "format datatype={0!s}; end;".format(self._classify_alphabet_for_nexus(alignment._alphabet))
         n = Nexus.Nexus(minimal_record)
         n.alphabet = alignment._alphabet
         for record in alignment:
@@ -163,7 +161,7 @@ if __name__ == "__main__":
     for a in NexusIterator(handle):
         print(a)
         for r in a:
-            print("%r %s %s" % (r.seq, r.name, r.id))
+            print("{0!r} {1!s} {2!s}".format(r.seq, r.name, r.id))
     print("Done")
 
     print("")
@@ -193,7 +191,7 @@ if __name__ == "__main__":
     for a in NexusIterator(handle):
         print(a)
         for r in a:
-            print("%r %s %s" % (r.seq, r.name, r.id))
+            print("{0!r} {1!s} {2!s}".format(r.seq, r.name, r.id))
     print("Done")
     print("")
     print("Reading an empty file")

--- a/Bio/AlignIO/PhylipIO.py
+++ b/Bio/AlignIO/PhylipIO.py
@@ -121,7 +121,7 @@ class PhylipWriter(SequentialAlignmentWriter):
         # defined in the PHYLIP documentation, simply "These are in free
         # format, separated by blanks".  We'll use spaces to keep EMBOSS
         # happy.
-        handle.write(" %i %s\n" % (len(alignment), length_of_seqs))
+        handle.write(" {0:d} {1!s}\n".format(len(alignment), length_of_seqs))
         block = 0
         while True:
             for name, sequence in zip(names, seqs):
@@ -139,7 +139,7 @@ class PhylipWriter(SequentialAlignmentWriter):
                     # TODO - Force any gaps to be '-' character?  Look at the
                     # alphabet...
                     # TODO - How to cope with '?' or '.' in the sequence?
-                    handle.write(" %s" % seq_segment)
+                    handle.write(" {0!s}".format(seq_segment))
                     if i + 10 > length_of_seqs:
                         break
                 handle.write("\n")
@@ -218,8 +218,7 @@ class PhylipIterator(AlignmentIterator):
 
         if self.records_per_alignment is not None \
         and self.records_per_alignment != number_of_seqs:
-            raise ValueError("Found %i records in this alignment, told to expect %i"
-                             % (number_of_seqs, self.records_per_alignment))
+            raise ValueError("Found {0:d} records in this alignment, told to expect {1:d}".format(number_of_seqs, self.records_per_alignment))
 
         ids = []
         seqs = []
@@ -281,8 +280,7 @@ class RelaxedPhylipWriter(PhylipWriter):
         # Check inputs
         for name in (s.id.strip() for s in alignment):
             if any(c in name for c in string.whitespace):
-                raise ValueError("Whitespace not allowed in identifier: %s"
-                        % name)
+                raise ValueError("Whitespace not allowed in identifier: {0!s}".format(name))
 
         # Calculate a truncation length - maximum length of sequence ID plus a
         # single character for padding
@@ -348,7 +346,7 @@ class SequentialPhylipWriter(SequentialAlignmentWriter):
         # defined in the PHYLIP documentation, simply "These are in free
         # format, separated by blanks".  We'll use spaces to keep EMBOSS
         # happy.
-        handle.write(" %i %s\n" % (len(alignment), length_of_seqs))
+        handle.write(" {0:d} {1!s}\n".format(len(alignment), length_of_seqs))
         for name, record in zip(names, alignment):
             sequence = str(record.seq)
             if "." in sequence:
@@ -401,8 +399,7 @@ class SequentialPhylipIterator(PhylipIterator):
 
         if self.records_per_alignment is not None \
         and self.records_per_alignment != number_of_seqs:
-            raise ValueError("Found %i records in this alignment, told to expect %i"
-                             % (number_of_seqs, self.records_per_alignment))
+            raise ValueError("Found {0:d} records in this alignment, told to expect {1:d}".format(number_of_seqs, self.records_per_alignment))
 
         ids = []
         seqs = []
@@ -422,8 +419,7 @@ class SequentialPhylipIterator(PhylipIterator):
                     continue
                 s = "".join([s, line.strip().replace(" ", "")])
                 if len(s) > length_of_seqs:
-                    raise ValueError("Found a record of length %i, should be %i"
-                            % (len(s), length_of_seqs))
+                    raise ValueError("Found a record of length {0:d}, should be {1:d}".format(len(s), length_of_seqs))
             if "." in s:
                 raise ValueError("PHYLIP format no longer allows dots in sequence")
             seqs.append(s)

--- a/Bio/AlignIO/StockholmIO.py
+++ b/Bio/AlignIO/StockholmIO.py
@@ -179,7 +179,7 @@ class StockholmWriter(SequentialAlignmentWriter):
             raise ValueError("Non-empty sequences are required")
 
         self.handle.write("# STOCKHOLM 1.0\n")
-        self.handle.write("#=GF SQ %i\n" % count)
+        self.handle.write("#=GF SQ {0:d}\n".format(count))
         for record in alignment:
             self._write_record(record)
         self.handle.write("//\n")
@@ -201,17 +201,17 @@ class StockholmWriter(SequentialAlignmentWriter):
 
         if "start" in record.annotations \
         and "end" in record.annotations:
-            suffix = "/%s-%s" % (str(record.annotations["start"]),
+            suffix = "/{0!s}-{1!s}".format(str(record.annotations["start"]),
                                  str(record.annotations["end"]))
             if seq_name[-len(suffix):] != suffix:
-                seq_name = "%s/%s-%s" % (seq_name,
+                seq_name = "{0!s}/{1!s}-{2!s}".format(seq_name,
                                         str(record.annotations["start"]),
                                         str(record.annotations["end"]))
 
         if seq_name in self._ids_written:
-            raise ValueError("Duplicate record identifier: %s" % seq_name)
+            raise ValueError("Duplicate record identifier: {0!s}".format(seq_name))
         self._ids_written.append(seq_name)
-        self.handle.write("%s %s\n" % (seq_name, str(record.seq)))
+        self.handle.write("{0!s} {1!s}\n".format(seq_name, str(record.seq)))
 
         # The recommended placement for GS lines (per sequence annotation)
         # is above the alignment (as a header block) or just below the
@@ -226,29 +226,24 @@ class StockholmWriter(SequentialAlignmentWriter):
 
         # AC = Accession
         if "accession" in record.annotations:
-            self.handle.write("#=GS %s AC %s\n"
-                % (seq_name, self.clean(record.annotations["accession"])))
+            self.handle.write("#=GS {0!s} AC {1!s}\n".format(seq_name, self.clean(record.annotations["accession"])))
         elif record.id:
-            self.handle.write("#=GS %s AC %s\n"
-                % (seq_name, self.clean(record.id)))
+            self.handle.write("#=GS {0!s} AC {1!s}\n".format(seq_name, self.clean(record.id)))
 
         # DE = description
         if record.description:
-            self.handle.write("#=GS %s DE %s\n"
-                % (seq_name, self.clean(record.description)))
+            self.handle.write("#=GS {0!s} DE {1!s}\n".format(seq_name, self.clean(record.description)))
 
         # DE = database links
         for xref in record.dbxrefs:
-            self.handle.write("#=GS %s DR %s\n"
-                % (seq_name, self.clean(xref)))
+            self.handle.write("#=GS {0!s} DR {1!s}\n".format(seq_name, self.clean(xref)))
 
         # GS = other per sequence annotation
         for key, value in record.annotations.items():
             if key in self.pfam_gs_mapping:
                 data = self.clean(str(value))
                 if data:
-                    self.handle.write("#=GS %s %s %s\n"
-                                      % (seq_name,
+                    self.handle.write("#=GS {0!s} {1!s} {2!s}\n".format(seq_name,
                                          self.clean(self.pfam_gs_mapping[key]),
                                          data))
             else:
@@ -261,8 +256,7 @@ class StockholmWriter(SequentialAlignmentWriter):
             if key in self.pfam_gr_mapping and len(str(value)) == len(record.seq):
                 data = self.clean(str(value))
                 if data:
-                    self.handle.write("#=GR %s %s %s\n"
-                                      % (seq_name,
+                    self.handle.write("#=GR {0!s} {1!s} {2!s}\n".format(seq_name,
                                          self.clean(self.pfam_gr_mapping[key]),
                                          data))
             else:
@@ -431,8 +425,7 @@ class StockholmIterator(AlignmentIterator):
 
             if self.records_per_alignment is not None \
             and self.records_per_alignment != len(ids):
-                raise ValueError("Found %i records in this alignment, told to expect %i"
-                                 % (len(ids), self.records_per_alignment))
+                raise ValueError("Found {0:d} records in this alignment, told to expect {1:d}".format(len(ids), self.records_per_alignment))
 
             alignment_length = len(list(seqs.values())[0])
             records = []  # Alignment obj will put them all in a list anyway

--- a/Bio/AlignIO/__init__.py
+++ b/Bio/AlignIO/__init__.py
@@ -203,7 +203,7 @@ def write(alignments, handle, format):
     if not format:
         raise ValueError("Format required (lower case string)")
     if format != format.lower():
-        raise ValueError("Format string '%s' should be lower case" % format)
+        raise ValueError("Format string '{0!s}' should be lower case".format(format))
 
     if isinstance(alignments, Alignment):
         # This raised an exception in older versions of Biopython
@@ -225,10 +225,9 @@ def write(alignments, handle, format):
                 SeqIO.write(alignment, fp, format)
                 count += 1
         elif format in _FormatToIterator or format in SeqIO._FormatToIterator:
-            raise ValueError("Reading format '%s' is supported, but not writing"
-                             % format)
+            raise ValueError("Reading format '{0!s}' is supported, but not writing".format(format))
         else:
-            raise ValueError("Unknown format '%s'" % format)
+            raise ValueError("Unknown format '{0!s}'".format(format))
 
     assert isinstance(count, int), "Internal error - the underlying %s " \
            "writer should have returned the alignment count, not %s" \
@@ -340,10 +339,10 @@ def parse(handle, format, seq_count=None, alphabet=None):
     if not format:
         raise ValueError("Format required (lower case string)")
     if format != format.lower():
-        raise ValueError("Format string '%s' should be lower case" % format)
+        raise ValueError("Format string '{0!s}' should be lower case".format(format))
     if alphabet is not None and not (isinstance(alphabet, Alphabet) or
                                      isinstance(alphabet, AlphabetEncoder)):
-        raise ValueError("Invalid alphabet, %s" % repr(alphabet))
+        raise ValueError("Invalid alphabet, {0!s}".format(repr(alphabet)))
     if seq_count is not None and not isinstance(seq_count, int):
         raise TypeError("Need integer for seq_count (sequences per alignment)")
 
@@ -368,7 +367,7 @@ def parse(handle, format, seq_count=None, alphabet=None):
                                                 alphabet=alphabet,
                                                 seq_count=seq_count)
         else:
-            raise ValueError("Unknown format '%s'" % format)
+            raise ValueError("Unknown format '{0!s}'".format(format))
 
         # This imposes some overhead... wait until we drop Python 2.4 to fix it
         for a in i:

--- a/Bio/Alphabet/__init__.py
+++ b/Bio/Alphabet/__init__.py
@@ -169,7 +169,7 @@ class AlphabetEncoder(object):
         return getattr(self.alphabet, key)
 
     def __repr__(self):
-        return "%s(%r, %r)" % (self.__class__.__name__, self.alphabet,
+        return "{0!s}({1!r}, {2!r})".format(self.__class__.__name__, self.alphabet,
                                self.new_letters)
 
     def contains(self, other):
@@ -242,7 +242,7 @@ def _get_base_alphabet(alphabet):
     while isinstance(a, AlphabetEncoder):
         a = a.alphabet
     assert isinstance(a, Alphabet), \
-           "Invalid alphabet found, %s" % repr(a)
+           "Invalid alphabet found, {0!s}".format(repr(a))
     return a
 
 

--- a/Bio/Application/__init__.py
+++ b/Bio/Application/__init__.py
@@ -84,15 +84,12 @@ class ApplicationError(_ProcessCalledError):
         except Exception:  # TODO, ValueError? AttributeError?
             msg = ""
         if msg:
-            return "Non-zero return code %d from %r, message %r" \
-                   % (self.returncode, self.cmd, msg)
+            return "Non-zero return code {0:d} from {1!r}, message {2!r}".format(self.returncode, self.cmd, msg)
         else:
-            return "Non-zero return code %d from %r" \
-                   % (self.returncode, self.cmd)
+            return "Non-zero return code {0:d} from {1!r}".format(self.returncode, self.cmd)
 
     def __repr__(self):
-        return "ApplicationError(%i, %s, %s, %s)" \
-               % (self.returncode, self.cmd, self.stdout, self.stderr)
+        return "ApplicationError({0:d}, {1!s}, {2!s}, {3!s})".format(self.returncode, self.cmd, self.stdout, self.stderr)
 
 
 class AbstractCommandline(object):
@@ -210,8 +207,7 @@ class AbstractCommandline(object):
                 continue
             for name in p.names:
                 if name in aliases:
-                    raise ValueError("Parameter alias %s multiply defined"
-                                     % name)
+                    raise ValueError("Parameter alias {0!s} multiply defined".format(name))
                 aliases.add(name)
             name = p.names[-1]
             if _re_prop_name.match(name) is None:
@@ -262,8 +258,7 @@ class AbstractCommandline(object):
         for p in self.parameters:
             # Check for missing required parameters:
             if p.is_required and not(p.is_set):
-                raise ValueError("Parameter %s is not set."
-                                 % p.names[-1])
+                raise ValueError("Parameter {0!s} is not set.".format(p.names[-1]))
             # Also repeat the parameter validation here, just in case?
 
     def __str__(self):
@@ -281,7 +276,7 @@ class AbstractCommandline(object):
         'water -outfile=temp_water.txt -asequence=asis:ACCCGGGCGCGGT -bsequence=asis:ACCCGAGCGCGGT -gapopen=10 -gapextend=0.5'
         """
         self._validate()
-        commandline = "%s " % _escape_filename(self.program_name)
+        commandline = "{0!s} ".format(_escape_filename(self.program_name))
         for parameter in self.parameters:
             if parameter.is_set:
                 # This will include a trailing space:
@@ -302,14 +297,13 @@ class AbstractCommandline(object):
         >>> cline
         WaterCommandline(cmd='water', outfile='temp_water.txt', asequence='asis:ACCCGGGCGCGGT', bsequence='asis:ACCCGAGCGCGGT', gapopen=10, gapextend=0.5)
         """
-        answer = "%s(cmd=%s" % (self.__class__.__name__, repr(self.program_name))
+        answer = "{0!s}(cmd={1!s}".format(self.__class__.__name__, repr(self.program_name))
         for parameter in self.parameters:
             if parameter.is_set:
                 if isinstance(parameter, _Switch):
-                    answer += ", %s=True" % parameter.names[-1]
+                    answer += ", {0!s}=True".format(parameter.names[-1])
                 else:
-                    answer += ", %s=%s" \
-                              % (parameter.names[-1], repr(parameter.value))
+                    answer += ", {0!s}={1!s}".format(parameter.names[-1], repr(parameter.value))
         answer += ")"
         return answer
 
@@ -321,7 +315,7 @@ class AbstractCommandline(object):
                     return parameter.is_set
                 else:
                     return parameter.value
-        raise ValueError("Option name %s was not found." % name)
+        raise ValueError("Option name {0!s} was not found.".format(name))
 
     def _clear_parameter(self, name):
         """Reset or clear a commandline option value."""
@@ -332,7 +326,7 @@ class AbstractCommandline(object):
                 parameter.is_set = False
                 cleared_option = True
         if not cleared_option:
-            raise ValueError("Option name %s was not found." % name)
+            raise ValueError("Option name {0!s} was not found.".format(name))
 
     def set_parameter(self, name, value=None):
         """Set a commandline option for a program (OBSOLETE).
@@ -361,7 +355,7 @@ class AbstractCommandline(object):
                     parameter.is_set = True
                     set_option = True
         if not set_option:
-            raise ValueError("Option name %s was not found." % name)
+            raise ValueError("Option name {0!s} was not found.".format(name))
 
     def _check_value(self, value, name, check_function):
         """Check whether the given value is valid.
@@ -377,8 +371,7 @@ class AbstractCommandline(object):
             is_good = check_function(value)  # May raise an exception
             assert is_good in [0, 1, True, False]
             if not is_good:
-                raise ValueError("Invalid parameter value %r for parameter %s"
-                                 % (value, name))
+                raise ValueError("Invalid parameter value {0!r} for parameter {1!s}".format(value, name))
 
     def __setattr__(self, name, value):
         """Set attribute name to value (PRIVATE).
@@ -574,7 +567,7 @@ class _Option(_AbstractParameter):
                  is_required=False, equate=True):
         self.names = names
         assert isinstance(description, basestring), \
-               "%r for %s" % (description, names[-1])
+               "{0!r} for {1!s}".format(description, names[-1])
         self.is_filename = filename
         self.checker_function = checker_function
         self.description = description
@@ -594,15 +587,15 @@ class _Option(_AbstractParameter):
         # or " -name " or " -name value ".  This choice is now
         # now made explicitly when setting up the option.
         if self.value is None:
-            return "%s " % self.names[0]
+            return "{0!s} ".format(self.names[0])
         if self.is_filename:
             v = _escape_filename(self.value)
         else:
             v = str(self.value)
         if self.equate:
-            return "%s=%s " % (self.names[0], v)
+            return "{0!s}={1!s} ".format(self.names[0], v)
         else:
-            return "%s %s " % (self.names[0], v)
+            return "{0!s} {1!s} ".format(self.names[0], v)
 
 
 class _Switch(_AbstractParameter):
@@ -641,7 +634,7 @@ class _Switch(_AbstractParameter):
         """
         assert not hasattr(self, "value")
         if self.is_set:
-            return "%s " % self.names[0]
+            return "{0!s} ".format(self.names[0])
         else:
             return ""
 
@@ -661,7 +654,7 @@ class _Argument(_AbstractParameter):
         #                     "single entry list with a PEP8 property name.")
         self.names = names
         assert isinstance(description, basestring), \
-               "%r for %s" % (description, names[-1])
+               "{0!r} for {1!s}".format(description, names[-1])
         self.is_filename = filename
         self.checker_function = checker_function
         self.description = description
@@ -673,9 +666,9 @@ class _Argument(_AbstractParameter):
         if self.value is None:
             return " "
         elif self.is_filename:
-            return "%s " % _escape_filename(self.value)
+            return "{0!s} ".format(_escape_filename(self.value))
         else:
-            return "%s " % self.value
+            return "{0!s} ".format(self.value)
 
 
 class _ArgumentList(_Argument):
@@ -709,7 +702,7 @@ class _StaticArgument(_AbstractParameter):
         self.value = value
 
     def __str__(self):
-        return "%s " % self.value
+        return "{0!s} ".format(self.value)
 
 
 def _escape_filename(filename):
@@ -742,7 +735,7 @@ def _escape_filename(filename):
         # Its already quoted
         return filename
     else:
-        return '"%s"' % filename
+        return '"{0!s}"'.format(filename)
 
 
 def _test():

--- a/Bio/Blast/Applications.py
+++ b/Bio/Blast/Applications.py
@@ -105,8 +105,7 @@ class _NcbibaseblastCommandline(AbstractCommandline):
             if self._get_parameter(a):
                 for b in incompatibles[a]:
                     if self._get_parameter(b):
-                        raise ValueError("Options %s and %s are incompatible."
-                                         % (a, b))
+                        raise ValueError("Options {0!s} and {1!s} are incompatible.".format(a, b))
 
 
 class _NcbiblastCommandline(_NcbibaseblastCommandline):

--- a/Bio/Blast/NCBIStandalone.py
+++ b/Bio/Blast/NCBIStandalone.py
@@ -850,12 +850,12 @@ class _HeaderConsumer(object):
             # New style way to give the query length in BLAST 2.2.22+ (the C++ code)
             self._header.query_letters = _safe_int(line[7:].strip())
         elif not line.startswith('       '):  # continuation of query_info
-            self._header.query = "%s%s" % (self._header.query, line)
+            self._header.query = "{0!s}{1!s}".format(self._header.query, line)
         else:
             # Hope it is the old style way to give the query length:
             letters, = _re_search(
                 r"([0-9,]+) letters", line,
-                "I could not find the number of letters in line\n%s" % line)
+                "I could not find the number of letters in line\n{0!s}".format(line))
             self._header.query_letters = _safe_int(letters)
 
     def database_info(self, line):
@@ -871,7 +871,7 @@ class _HeaderConsumer(object):
         else:
             sequences, letters = _re_search(
                 r"([0-9,]+) sequences; ([0-9,-]+) total letters", line,
-                "I could not find the sequences and letters in line\n%s" % line)
+                "I could not find the sequences and letters in line\n{0!s}".format(line))
             self._header.database_sequences = _safe_int(sequences)
             self._header.database_letters = _safe_int(letters)
 
@@ -921,7 +921,7 @@ class _DescriptionConsumer(object):
 
     def round(self, line):
         if not line.startswith('Results from round'):
-            raise ValueError("I didn't understand the round line\n%s" % line)
+            raise ValueError("I didn't understand the round line\n{0!s}".format(line))
         self._roundnum = _safe_int(line[18:].strip())
 
     def end_descriptions(self):
@@ -941,7 +941,7 @@ class _DescriptionConsumer(object):
         cols = line.split()
         if len(cols) < 3:
             raise ValueError(
-                  "Line does not appear to contain description:\n%s" % line)
+                  "Line does not appear to contain description:\n{0!s}".format(line))
         if self.__has_n:
             i = line.rfind(cols[-1])        # find start of N
             i = line.rfind(cols[-2], 0, i)  # find start of p-value
@@ -993,7 +993,7 @@ class _AlignmentConsumer(object):
             try:
                 name, start, seq, end = line.split()
             except ValueError:
-                raise ValueError("I do not understand the line\n%s" % line)
+                raise ValueError("I do not understand the line\n{0!s}".format(line))
             self._start_index = line.index(start, len(name))
             self._seq_index = line.index(seq,
                                          self._start_index + len(start))
@@ -1133,13 +1133,13 @@ class _HSPConsumer(object):
     def score(self, line):
         self._hsp.bits, self._hsp.score = _re_search(
             r"Score =\s*([0-9.e+]+) bits \(([0-9]+)\)", line,
-            "I could not find the score in line\n%s" % line)
+            "I could not find the score in line\n{0!s}".format(line))
         self._hsp.score = _safe_float(self._hsp.score)
         self._hsp.bits = _safe_float(self._hsp.bits)
 
         x, y = _re_search(
             r"Expect\(?(\d*)\)? = +([0-9.e\-|\+]+)", line,
-            "I could not find the expect in line\n%s" % line)
+            "I could not find the expect in line\n{0!s}".format(line))
         if x:
             self._hsp.num_alignments = _safe_int(x)
         else:
@@ -1149,28 +1149,28 @@ class _HSPConsumer(object):
     def identities(self, line):
         x, y = _re_search(
             r"Identities = (\d+)\/(\d+)", line,
-            "I could not find the identities in line\n%s" % line)
+            "I could not find the identities in line\n{0!s}".format(line))
         self._hsp.identities = _safe_int(x), _safe_int(y)
         self._hsp.align_length = _safe_int(y)
 
         if 'Positives' in line:
             x, y = _re_search(
                 r"Positives = (\d+)\/(\d+)", line,
-                "I could not find the positives in line\n%s" % line)
+                "I could not find the positives in line\n{0!s}".format(line))
             self._hsp.positives = _safe_int(x), _safe_int(y)
             assert self._hsp.align_length == _safe_int(y)
 
         if 'Gaps' in line:
             x, y = _re_search(
                 r"Gaps = (\d+)\/(\d+)", line,
-                "I could not find the gaps in line\n%s" % line)
+                "I could not find the gaps in line\n{0!s}".format(line))
             self._hsp.gaps = _safe_int(x), _safe_int(y)
             assert self._hsp.align_length == _safe_int(y)
 
     def strand(self, line):
         self._hsp.strand = _re_search(
             r"Strand\s?=\s?(\w+)\s?/\s?(\w+)", line,
-            "I could not find the strand in line\n%s" % line)
+            "I could not find the strand in line\n{0!s}".format(line))
 
     def frame(self, line):
         # Frame can be in formats:
@@ -1179,11 +1179,11 @@ class _HSPConsumer(object):
         if '/' in line:
             self._hsp.frame = _re_search(
                 r"Frame\s?=\s?([-+][123])\s?/\s?([-+][123])", line,
-                "I could not find the frame in line\n%s" % line)
+                "I could not find the frame in line\n{0!s}".format(line))
         else:
             self._hsp.frame = _re_search(
                 r"Frame = ([-+][123])", line,
-                "I could not find the frame in line\n%s" % line)
+                "I could not find the frame in line\n{0!s}".format(line))
 
     # Match a space, if one is available.  Masahir Ishikawa found a
     # case where there's no space between the start and the sequence:
@@ -1202,7 +1202,7 @@ class _HSPConsumer(object):
                 self._query_len = 60  # number of dashes
                 self._query_start_index = 13  # offset of first dash
                 return
-            raise ValueError("I could not find the query in line\n%s" % line)
+            raise ValueError("I could not find the query in line\n{0!s}".format(line))
 
         # line below modified by Yair Benita, Sep 2004.
         # added the end attribute for the query
@@ -1226,8 +1226,7 @@ class _HSPConsumer(object):
             # Make sure the alignment is the same length as the query
             seq += ' ' * (self._query_len - len(seq))
         elif len(seq) < self._query_len:
-            raise ValueError("Match is longer than the query in line\n%s"
-                             % line)
+            raise ValueError("Match is longer than the query in line\n{0!s}".format(line))
         self._hsp.match = self._hsp.match + seq
 
     # To match how we do the query, cache the regular expression.
@@ -1237,7 +1236,7 @@ class _HSPConsumer(object):
     def sbjct(self, line):
         m = self._sbjct_re.search(line)
         if m is None:
-            raise ValueError("I could not find the sbjct in line\n%s" % line)
+            raise ValueError("I could not find the sbjct in line\n{0!s}".format(line))
         colon, start, seq, end = m.groups()
         # mikep 26/9/00
         # On occasion, there is a blast hit with no subject match
@@ -1254,8 +1253,7 @@ class _HSPConsumer(object):
         self._hsp.sbjct_end = _safe_int(end)
         if len(seq) != self._query_len:
             raise ValueError(
-                  "QUERY and SBJCT sequence lengths don't match (%i %r vs %i) in line\n%s"
-                  % (self._query_len, self._hsp.query, len(seq), line))
+                  "QUERY and SBJCT sequence lengths don't match ({0:d} {1!r} vs {2:d}) in line\n{3!s}".format(self._query_len, self._hsp.query, len(seq), line))
 
         del self._query_start_index   # clean up unused variables
         del self._query_len
@@ -1275,13 +1273,13 @@ class _DatabaseReportConsumer(object):
             self._dr.database_name.append(m.group(1))
         elif self._dr.database_name:
             # This must be a continuation of the previous name.
-            self._dr.database_name[-1] = "%s%s" % (self._dr.database_name[-1],
+            self._dr.database_name[-1] = "{0!s}{1!s}".format(self._dr.database_name[-1],
                                                    line.strip())
 
     def posted_date(self, line):
         self._dr.posted_date.append(_re_search(
             r"Posted date:\s*(.+)$", line,
-            "I could not find the posted date in line\n%s" % line))
+            "I could not find the posted date in line\n{0!s}".format(line)))
 
     def num_letters_in_database(self, line):
         letters, = _get_cols(
@@ -1430,7 +1428,7 @@ class _ParametersConsumer(object):
             self._params.threshold, = _get_cols(
                 line, (3,), ncols=4, expected={0: "Neighboring", 1: "words", 2: "threshold:"})
         else:
-            raise ValueError("Unrecognised threshold line:\n%s" % line)
+            raise ValueError("Unrecognised threshold line:\n{0!s}".format(line))
         self._params.threshold = _safe_int(self._params.threshold)
 
     def window_size(self, line):
@@ -1441,37 +1439,37 @@ class _ParametersConsumer(object):
             self._params.window_size, = _get_cols(
                 line, (4,), ncols=5, expected={0: "Window", 2: "multiple", 3: "hits:"})
         else:
-            raise ValueError("Unrecognised window size line:\n%s" % line)
+            raise ValueError("Unrecognised window size line:\n{0!s}".format(line))
         self._params.window_size = _safe_int(self._params.window_size)
 
     def dropoff_1st_pass(self, line):
         score, bits = _re_search(
             r"X1: (\d+) \(\s*([0-9,.]+) bits\)", line,
-            "I could not find the dropoff in line\n%s" % line)
+            "I could not find the dropoff in line\n{0!s}".format(line))
         self._params.dropoff_1st_pass = _safe_int(score), _safe_float(bits)
 
     def gap_x_dropoff(self, line):
         score, bits = _re_search(
             r"X2: (\d+) \(\s*([0-9,.]+) bits\)", line,
-            "I could not find the gap dropoff in line\n%s" % line)
+            "I could not find the gap dropoff in line\n{0!s}".format(line))
         self._params.gap_x_dropoff = _safe_int(score), _safe_float(bits)
 
     def gap_x_dropoff_final(self, line):
         score, bits = _re_search(
             r"X3: (\d+) \(\s*([0-9,.]+) bits\)", line,
-            "I could not find the gap dropoff final in line\n%s" % line)
+            "I could not find the gap dropoff final in line\n{0!s}".format(line))
         self._params.gap_x_dropoff_final = _safe_int(score), _safe_float(bits)
 
     def gap_trigger(self, line):
         score, bits = _re_search(
             r"S1: (\d+) \(\s*([0-9,.]+) bits\)", line,
-            "I could not find the gap trigger in line\n%s" % line)
+            "I could not find the gap trigger in line\n{0!s}".format(line))
         self._params.gap_trigger = _safe_int(score), _safe_float(bits)
 
     def blast_cutoff(self, line):
         score, bits = _re_search(
             r"S2: (\d+) \(\s*([0-9,.]+) bits\)", line,
-            "I could not find the blast cutoff in line\n%s" % line)
+            "I could not find the blast cutoff in line\n{0!s}".format(line))
         self._params.blast_cutoff = _safe_int(score), _safe_float(bits)
 
     def end_parameters(self):
@@ -1612,8 +1610,7 @@ class Iterator(object):
             handle.readline
         except AttributeError:
             raise ValueError(
-                "I expected a file handle or file-like object, got %s"
-                % type(handle))
+                "I expected a file handle or file-like object, got {0!s}".format(type(handle)))
         self._uhandle = File.UndoHandle(handle)
         self._parser = parser
         self._header = []
@@ -1689,14 +1686,12 @@ def _get_cols(line, cols_to_get, ncols=None, expected=None):
 
     # Check to make sure number of columns is correct
     if ncols is not None and len(cols) != ncols:
-        raise ValueError("I expected %d columns (got %d) in line\n%s"
-                         % (ncols, len(cols), line))
+        raise ValueError("I expected {0:d} columns (got {1:d}) in line\n{2!s}".format(ncols, len(cols), line))
 
     # Check to make sure columns contain the correct data
     for k in expected:
         if cols[k] != expected[k]:
-            raise ValueError("I expected '%s' in column %d in line\n%s"
-                             % (expected[k], k, line))
+            raise ValueError("I expected '{0!s}' in column {1:d} in line\n{2!s}".format(expected[k], k, line))
 
     # Construct the answer tuple
     results = []

--- a/Bio/Blast/NCBIWWW.py
+++ b/Bio/Blast/NCBIWWW.py
@@ -216,20 +216,20 @@ def _parse_qblast_ref_page(handle):
             msg = s[i + len('<div class="error msInf">'):].strip()
             msg = msg.split("</div>", 1)[0].split("\n", 1)[0].strip()
             if msg:
-                raise ValueError("Error message from NCBI: %s" % msg)
+                raise ValueError("Error message from NCBI: {0!s}".format(msg))
         # In spring 2010 the markup was like this:
         i = s.find('<p class="error">')
         if i != -1:
             msg = s[i + len('<p class="error">'):].strip()
             msg = msg.split("</p>", 1)[0].split("\n", 1)[0].strip()
             if msg:
-                raise ValueError("Error message from NCBI: %s" % msg)
+                raise ValueError("Error message from NCBI: {0!s}".format(msg))
         # Generic search based on the way the error messages start:
         i = s.find('Message ID#')
         if i != -1:
             # Break the message at the first HTML tag
             msg = s[i:].split("<", 1)[0].split("\n", 1)[0].strip()
-            raise ValueError("Error message from NCBI: %s" % msg)
+            raise ValueError("Error message from NCBI: {0!s}".format(msg))
         # We didn't recognise the error layout :(
         # print s
         raise ValueError("No RID and no RTOE found in the 'please wait' page, "

--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -61,7 +61,7 @@ class _XMLparser(ContentHandler):
         # Note could use try / except AttributeError
         # BUT I found often triggered by nested errors...
         if hasattr(self, method):
-            eval("self.%s()" % method)
+            eval("self.{0!s}()".format(method))
             if self._debug > 4:
                 print("NCBIXML: Parsed:  " + method)
         elif self._debug > 3:
@@ -73,8 +73,7 @@ class _XMLparser(ContentHandler):
         # We don't care about white space in parent tags like Hsp,
         # but that white space doesn't belong to child tags like Hsp_midline
         if self._value.strip():
-            raise ValueError("What should we do with %s before the %s tag?"
-                             % (repr(self._value), name))
+            raise ValueError("What should we do with {0!s} before the {1!s} tag?".format(repr(self._value), name))
         self._value = ""
 
     def characters(self, ch):
@@ -96,13 +95,13 @@ class _XMLparser(ContentHandler):
         # Note could use try / except AttributeError
         # BUT I found often triggered by nested errors...
         if hasattr(self, method):
-            eval("self.%s()" % method)
+            eval("self.{0!s}()".format(method))
             if self._debug > 2:
-                print("NCBIXML: Parsed:  %s %s" % (method, self._value))
+                print("NCBIXML: Parsed:  {0!s} {1!s}".format(method, self._value))
         elif self._debug > 1:
             # Doesn't exist (yet) and may want to warn about it
             if method not in self._debug_ignore_list:
-                print("NCBIXML: Ignored: %s %s" % (method, self._value))
+                print("NCBIXML: Ignored: {0!s} {1!s}".format(method, self._value))
                 self._debug_ignore_list.append(method)
 
         # Reset character buffer
@@ -652,14 +651,13 @@ if __name__ == '__main__':
 
     for r in r_list:
         # Small test
-        print('Blast of %s' % r.query)
-        print('Found %s alignments with a total of %s HSPs'
-                  % (len(r.alignments),
+        print('Blast of {0!s}'.format(r.query))
+        print('Found {0!s} alignments with a total of {1!s} HSPs'.format(len(r.alignments),
                      reduce(lambda a, b: a + b,
                             [len(a.hsps) for a in r.alignments])))
 
         for al in r.alignments:
-            print("%s %i bp %i HSPs" % (al.title[:50], al.length, len(al.hsps)))
+            print("{0!s} {1:d} bp {2:d} HSPs".format(al.title[:50], al.length, len(al.hsps)))
 
         # Cookbook example
         E_VALUE_THRESH = 0.04
@@ -667,9 +665,9 @@ if __name__ == '__main__':
             for hsp in alignment.hsps:
                 if hsp.expect < E_VALUE_THRESH:
                     print('*****')
-                    print('sequence %s' % alignment.title)
-                    print('length %i' % alignment.length)
-                    print('e value %f' % hsp.expect)
+                    print('sequence {0!s}'.format(alignment.title))
+                    print('length {0:d}'.format(alignment.length))
+                    print('e value {0:f}'.format(hsp.expect))
                     print(hsp.query[:75] + '...')
                     print(hsp.match[:75] + '...')
                     print(hsp.sbjct[:75] + '...')

--- a/Bio/Blast/ParseBlastTable.py
+++ b/Bio/Blast/ParseBlastTable.py
@@ -90,7 +90,7 @@ class BlastTableReader(object):
     def _consume_header(self, inline):
         for keyword in reader_keywords:
             if keyword in inline:
-                in_header = self._Parse('_parse_%s' % reader_keywords[keyword], inline)
+                in_header = self._Parse('_parse_{0!s}'.format(reader_keywords[keyword]), inline)
                 break
         return in_header
 

--- a/Bio/Blast/Record.py
+++ b/Bio/Blast/Record.py
@@ -76,7 +76,7 @@ class Description(object):
         self.num_alignments = None
 
     def __str__(self):
-        return "%-66s %5s  %s" % (self.title, self.score, self.e)
+        return "{0:<66!s} {1:5!s}  {2!s}".format(self.title, self.score, self.e)
 
 
 class Alignment(object):
@@ -99,7 +99,7 @@ class Alignment(object):
 
     def __str__(self):
         lines = self.title.split('\n')
-        lines.append("Length = %s\n" % self.length)
+        lines.append("Length = {0!s}\n".format(self.length))
         return '\n           '.join(lines)
 
 
@@ -172,28 +172,23 @@ class HSP(object):
         self.sbjct_end = None
 
     def __str__(self):
-        lines = ["Score %i (%i bits), expectation %0.1e, alignment length %i"
-                 % (self.score, self.bits, self.expect, self.align_length)]
+        lines = ["Score {0:d} ({1:d} bits), expectation {2:0.1e}, alignment length {3:d}".format(self.score, self.bits, self.expect, self.align_length)]
         if self.align_length < 50:
-            lines.append("Query:%s %s %s" % (str(self.query_start).rjust(8),
+            lines.append("Query:{0!s} {1!s} {2!s}".format(str(self.query_start).rjust(8),
                                        str(self.query),
                                        str(self.query_end)))
-            lines.append("               %s"
-                         % (str(self.match)))
-            lines.append("Sbjct:%s %s %s" % (str(self.sbjct_start).rjust(8),
+            lines.append("               {0!s}".format((str(self.match))))
+            lines.append("Sbjct:{0!s} {1!s} {2!s}".format(str(self.sbjct_start).rjust(8),
                                        str(self.sbjct),
                                        str(self.sbjct_end)))
         else:
-            lines.append("Query:%s %s...%s %s"
-                         % (str(self.query_start).rjust(8),
+            lines.append("Query:{0!s} {1!s}...{2!s} {3!s}".format(str(self.query_start).rjust(8),
                             str(self.query)[:45],
                             str(self.query)[-3:],
                             str(self.query_end)))
-            lines.append("               %s...%s"
-                         % (str(self.match)[:45],
+            lines.append("               {0!s}...{1!s}".format(str(self.match)[:45],
                             str(self.match)[-3:]))
-            lines.append("Sbjct:%s %s...%s %s"
-                         % (str(self.sbjct_start).rjust(8),
+            lines.append("Sbjct:{0!s} {1!s}...{2!s} {3!s}".format(str(self.sbjct_start).rjust(8),
                             str(self.sbjct)[:45],
                             str(self.sbjct)[-3:],
                             str(self.sbjct_end)))

--- a/Bio/Cluster/__init__.py
+++ b/Bio/Cluster/__init__.py
@@ -82,7 +82,7 @@ def _savetree(jobname, tree, order, transpose):
         for nodeindex in range(nnodes):
             min1 = tree[nodeindex].left
             min2 = tree[nodeindex].right
-            nodeID[nodeindex] = "NODE%dX" % (nodeindex + 1)
+            nodeID[nodeindex] = "NODE{0:d}X".format((nodeindex + 1))
             outputfile.write(nodeID[nodeindex])
             outputfile.write("\t")
             if min1 < 0:
@@ -94,7 +94,7 @@ def _savetree(jobname, tree, order, transpose):
             else:
                 order1 = order[min1]
                 counts1 = 1
-                outputfile.write("%s%dX\t" % (keyword, min1))
+                outputfile.write("{0!s}{1:d}X\t".format(keyword, min1))
             if min2 < 0:
                 index2 = -min2 - 1
                 order2 = nodeorder[index2]
@@ -104,7 +104,7 @@ def _savetree(jobname, tree, order, transpose):
             else:
                 order2 = order[min2]
                 counts2 = 1
-                outputfile.write("%s%dX\t" % (keyword, min2))
+                outputfile.write("{0!s}{1:d}X\t".format(keyword, min2))
             outputfile.write(str(1.0 - nodedist[nodeindex]))
             outputfile.write("\n")
             counts = counts1 + counts2
@@ -187,8 +187,7 @@ Cluster/TreeView program.
         for line in handle:
             line = line.strip("\r\n").split("\t")
             if len(line) != n:
-                raise ValueError("Line with %d columns found (expected %d)" %
-                                 (len(line), n))
+                raise ValueError("Line with {0:d} columns found (expected {1:d})".format(len(line), n))
             if line[0] == "EWEIGHT":
                 i = max(cols) + 1
                 self.eweight = numpy.array(line[i:], float)
@@ -540,9 +539,9 @@ Arguments:
             # This is a k-means clustering result.
             filename = jobname + "_K"
             k = max(geneclusters) + 1
-            kggfilename = "%s_K_G%d.kgg" % (jobname, k)
+            kggfilename = "{0!s}_K_G{1:d}.kgg".format(jobname, k)
             geneindex = self._savekmeans(kggfilename, geneclusters, gorder, 0)
-            postfix = "_G%d" % k
+            postfix = "_G{0:d}".format(k)
         else:
             geneindex = numpy.argsort(gorder)
         if isinstance(expclusters, Tree):
@@ -553,9 +552,9 @@ Arguments:
             # This is a k-means clustering result.
             filename = jobname + "_K"
             k = max(expclusters) + 1
-            kagfilename = "%s_K_A%d.kag" % (jobname, k)
+            kagfilename = "{0!s}_K_A{1:d}.kag".format(jobname, k)
             expindex = self._savekmeans(kagfilename, expclusters, eorder, 1)
-            postfix += "_A%d" % k
+            postfix += "_A{0:d}".format(k)
         else:
             expindex = numpy.argsort(eorder)
         filename = filename + postfix
@@ -579,7 +578,7 @@ Arguments:
             while counter < n:
                 for j in index:
                     if clusterids[j] == cluster:
-                        outputfile.write("%s\t%s\n" % (names[j], cluster))
+                        outputfile.write("{0!s}\t{1!s}\n".format(names[j], cluster))
                         sortedindex[counter] = j
                         counter += 1
                 cluster += 1
@@ -611,7 +610,7 @@ Arguments:
             outputfile.write('\tNAME\tGWEIGHT')
             # Now add headers for data columns.
             for j in expindex:
-                outputfile.write('\t%s' % self.expid[j])
+                outputfile.write('\t{0!s}'.format(self.expid[j]))
             outputfile.write('\n')
             if aid:
                 outputfile.write("AID")
@@ -619,20 +618,19 @@ Arguments:
                     outputfile.write('\t')
                 outputfile.write("\t\t")
                 for j in expindex:
-                    outputfile.write('\tARRY%dX' % j)
+                    outputfile.write('\tARRY{0:d}X'.format(j))
                 outputfile.write('\n')
             outputfile.write('EWEIGHT')
             if gid:
                 outputfile.write('\t')
             outputfile.write('\t\t')
             for j in expindex:
-                outputfile.write('\t%f' % eweight[j])
+                outputfile.write('\t{0:f}'.format(eweight[j]))
             outputfile.write('\n')
             for i in geneindex:
                 if gid:
-                    outputfile.write('GENE%dX\t' % i)
-                outputfile.write("%s\t%s\t%f" %
-                                 (self.geneid[i], genename[i], gweight[i]))
+                    outputfile.write('GENE{0:d}X\t'.format(i))
+                outputfile.write("{0!s}\t{1!s}\t{2:f}".format(self.geneid[i], genename[i], gweight[i]))
                 for j in expindex:
                     outputfile.write('\t')
                     if mask[i, j]:

--- a/Bio/Compass/__init__.py
+++ b/Bio/Compass/__init__.py
@@ -146,7 +146,7 @@ def __read_names(record, line):
     # Ali1: 60456.blo.gz.aln  Ali2: allscop//14984.blo.gz.aln
     #       ------query-----        -------hit-------------
     if "Ali1:" not in line:
-        raise ValueError("Line does not contain 'Ali1:':\n%s" % line)
+        raise ValueError("Line does not contain 'Ali1:':\n{0!s}".format(line))
     m = __regex["names"].search(line)
     record.query = m.group(1)
     record.hit = m.group(2)
@@ -154,14 +154,14 @@ def __read_names(record, line):
 
 def __read_threshold(record, line):
     if not line.startswith("Threshold"):
-        raise ValueError("Line does not start with 'Threshold':\n%s" % line)
+        raise ValueError("Line does not start with 'Threshold':\n{0!s}".format(line))
     m = __regex["threshold"].search(line)
     record.gap_threshold = float(m.group(1))
 
 
 def __read_lengths(record, line):
     if not line.startswith("length1="):
-        raise ValueError("Line does not start with 'length1=':\n%s" % line)
+        raise ValueError("Line does not start with 'length1=':\n{0!s}".format(line))
     m = __regex["lengths"].search(line)
     record.query_length = int(m.group(1))
     record.query_filtered_length = float(m.group(2))
@@ -171,7 +171,7 @@ def __read_lengths(record, line):
 
 def __read_profilewidth(record, line):
     if "Nseqs1" not in line:
-        raise ValueError("Line does not contain 'Nseqs1':\n%s" % line)
+        raise ValueError("Line does not contain 'Nseqs1':\n{0!s}".format(line))
     m = __regex["profilewidth"].search(line)
     record.query_nseqs = int(m.group(1))
     record.query_neffseqs = float(m.group(2))
@@ -181,7 +181,7 @@ def __read_profilewidth(record, line):
 
 def __read_scores(record, line):
     if not line.startswith("Smith-Waterman"):
-        raise ValueError("Line does not start with 'Smith-Waterman':\n%s" % line)
+        raise ValueError("Line does not start with 'Smith-Waterman':\n{0!s}".format(line))
     m = __regex["scores"].search(line)
     if m:
         record.sw_score = int(m.group(1))

--- a/Bio/Crystal/__init__.py
+++ b/Bio/Crystal/__init__.py
@@ -27,7 +27,7 @@ class CrystalError(Exception):
 def wrap_line(line):
     output = ''
     for i in range(0, len(line), 80):
-        output += '%s\n' % line[i: i + 80]
+        output += '{0!s}\n'.format(line[i: i + 80])
     return output
 
 
@@ -65,10 +65,10 @@ class Hetero(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return "%s" % self.data
+        return "{0!s}".format(self.data)
 
     def __str__(self):
-        return "%s" % self.data
+        return "{0!s}".format(self.data)
 
     def __len__(self):
         return len(self.data)
@@ -107,7 +107,7 @@ class Chain(object):
     def __str__(self):
         output = ''
         for element in self.data:
-            output = output + '%s ' % element
+            output = output + '{0!s} '.format(element)
         output = output.strip()
         output = wrap_line(output)
         return output
@@ -247,13 +247,13 @@ class Crystal(object):
     def __repr__(self):
         output = ''
         for key in sorted(self.data):
-            output += '%s : %s\n' % (key, self.data[key])
+            output += '{0!s} : {1!s}\n'.format(key, self.data[key])
         return output
 
     def __str__(self):
         output = ''
         for key in sorted(self.data):
-            output += '%s : %s\n' % (key, self.data[key])
+            output += '{0!s} : {1!s}\n'.format(key, self.data[key])
         return output
 
     def tostring(self):

--- a/Bio/Data/CodonTable.py
+++ b/Bio/Data/CodonTable.py
@@ -77,7 +77,7 @@ class CodonTable(object):
         """
 
         if self.id:
-            answer = "Table %i" % self.id
+            answer = "Table {0:d}".format(self.id)
         else:
             answer = "Table ID unknown"
         if self.names:
@@ -95,14 +95,14 @@ class CodonTable(object):
             letters = "UCAG"
 
         # Build the table...
-        answer += "\n\n  |" + "|".join("  %s      " % c2 for c2 in letters) + "|"
+        answer += "\n\n  |" + "|".join("  {0!s}      ".format(c2) for c2 in letters) + "|"
         answer += "\n--+" + "+".join("---------" for c2 in letters) + "+--"
         for c1 in letters:
             for c3 in letters:
                 line = c1 + " |"
                 for c2 in letters:
                     codon = c1 + c2 + c3
-                    line += " %s" % codon
+                    line += " {0!s}".format(codon)
                     if codon in self.stop_codons:
                         line += " Stop|"
                     else:
@@ -113,9 +113,9 @@ class CodonTable(object):
                         except TranslationError:
                             amino = "?"
                         if codon in self.start_codons:
-                            line += " %s(s)|" % amino
+                            line += " {0!s}(s)|".format(amino)
                         else:
-                            line += " %s   |" % amino
+                            line += " {0!s}   |".format(amino)
                 line += " " + c3
                 answer += "\n" + line
             answer += "\n--+" + "+".join("---------" for c2 in letters) + "+--"
@@ -206,7 +206,7 @@ def list_possible_proteins(codon, forward_table, ambiguous_nucleotide_values):
                         stops.append(y1 + y2 + y3)
         if stops:
             if possible:
-                raise TranslationError("ambiguous codon '%s' codes " % codon
+                raise TranslationError("ambiguous codon '{0!s}' codes ".format(codon)
                                        + "for both proteins and stop codons")
             # This is a true stop codon - tell the caller about it
             raise KeyError(codon)

--- a/Bio/DocSQL.py
+++ b/Bio/DocSQL.py
@@ -68,8 +68,7 @@ class QueryRow(list):
         try:
             return self[self._names_hash[name]]
         except (KeyError, AttributeError):
-            raise AttributeError("'%s' object has no attribute '%s'"
-                                 % (self.__class__.__name__, name))
+            raise AttributeError("'{0!s}' object has no attribute '{1!s}'".format(self.__class__.__name__, name))
 
     def __setattr__(self, name, value):
         try:
@@ -114,7 +113,7 @@ class Query(object):
         return IterationCursor(self, self.connection)
 
     def __repr__(self):
-        return "%s(message=%s)" % (self.__class__.__name__, self.message)
+        return "{0!s}(message={1!s})".format(self.__class__.__name__, self.message)
 
     def cursor(self):
         return iter(self).cursor
@@ -137,8 +136,8 @@ class IterationCursor(object):
         self.cursor = connection.cursor()
         self.row_class = query.row_class
         if query.diagnostics:
-            sys.stderr.write("Query statement: %s\n" % query.statement)
-            sys.stderr.write("Query params: %s\n" % query.params)
+            sys.stderr.write("Query statement: {0!s}\n".format(query.statement))
+            sys.stderr.write("Query params: {0!s}\n".format(query.params))
         self.cursor.execute(query.statement, query.params)
 
     def __next__(self):

--- a/Bio/Emboss/PrimerSearch.py
+++ b/Bio/Emboss/PrimerSearch.py
@@ -21,7 +21,7 @@ class InputRecord(object):
     def __str__(self):
         output = ""
         for name, primer1, primer2 in self.primer_info:
-            output += "%s %s %s\n" % (name, primer1, primer2)
+            output += "{0!s} {1!s} {2!s}\n".format(name, primer1, primer2)
         return output
 
     def add_primer_set(self, primer_name, first_primer_seq,

--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -60,7 +60,7 @@ class IntegerElement(int):
             attributes = self.attributes
         except AttributeError:
             return text
-        return "IntegerElement(%s, attributes=%s)" % (text, repr(attributes))
+        return "IntegerElement({0!s}, attributes={1!s})".format(text, repr(attributes))
 
 
 class StringElement(str):
@@ -70,7 +70,7 @@ class StringElement(str):
             attributes = self.attributes
         except AttributeError:
             return text
-        return "StringElement(%s, attributes=%s)" % (text, repr(attributes))
+        return "StringElement({0!s}, attributes={1!s})".format(text, repr(attributes))
 
 
 class UnicodeElement(unicode):
@@ -80,7 +80,7 @@ class UnicodeElement(unicode):
             attributes = self.attributes
         except AttributeError:
             return text
-        return "UnicodeElement(%s, attributes=%s)" % (text, repr(attributes))
+        return "UnicodeElement({0!s}, attributes={1!s})".format(text, repr(attributes))
 
 
 class ListElement(list):
@@ -90,7 +90,7 @@ class ListElement(list):
             attributes = self.attributes
         except AttributeError:
             return text
-        return "ListElement(%s, attributes=%s)" % (text, repr(attributes))
+        return "ListElement({0!s}, attributes={1!s})".format(text, repr(attributes))
 
 
 class DictionaryElement(dict):
@@ -100,7 +100,7 @@ class DictionaryElement(dict):
             attributes = self.attributes
         except AttributeError:
             return text
-        return "DictElement(%s, attributes=%s)" % (text, repr(attributes))
+        return "DictElement({0!s}, attributes={1!s})".format(text, repr(attributes))
 
 
 # A StructureElement is like a dictionary, but some of its keys can have
@@ -125,7 +125,7 @@ class StructureElement(dict):
             attributes = self.attributes
         except AttributeError:
             return text
-        return "DictElement(%s, attributes=%s)" % (text, repr(attributes))
+        return "DictElement({0!s}, attributes={1!s})".format(text, repr(attributes))
 
 
 class NotXMLError(ValueError):
@@ -133,7 +133,7 @@ class NotXMLError(ValueError):
         self.msg = message
 
     def __str__(self):
-        return "Failed to parse the XML data (%s). Please make sure that the input data are in XML format." % self.msg
+        return "Failed to parse the XML data ({0!s}). Please make sure that the input data are in XML format.".format(self.msg)
 
 
 class CorruptedXMLError(ValueError):
@@ -141,7 +141,7 @@ class CorruptedXMLError(ValueError):
         self.msg = message
 
     def __str__(self):
-        return "Failed to parse the XML data (%s). Please make sure that the input data are not corrupted." % self.msg
+        return "Failed to parse the XML data ({0!s}). Please make sure that the input data are not corrupted.".format(self.msg)
 
 
 class ValidationError(ValueError):
@@ -150,7 +150,7 @@ class ValidationError(ValueError):
         self.name = name
 
     def __str__(self):
-        return "Failed to find tag '%s' in the DTD. To skip all tags that are not represented in the DTD, please call Bio.Entrez.read or Bio.Entrez.parse with validate=False." % self.name
+        return "Failed to find tag '{0!s}' in the DTD. To skip all tags that are not represented in the DTD, please call Bio.Entrez.read or Bio.Entrez.parse with validate=False.".format(self.name)
 
 
 class DataHandler(object):
@@ -545,7 +545,7 @@ class DataHandler(object):
         try:
             handle = open(path, "wb")
         except IOError:
-            warnings.warn("Failed to save %s at %s" % (filename, path))
+            warnings.warn("Failed to save {0!s} at {1!s}".format(filename, path))
         else:
             handle.write(text)
             handle.close()
@@ -555,7 +555,7 @@ class DataHandler(object):
         try:
             handle = open(path, "wb")
         except IOError:
-            warnings.warn("Failed to save %s at %s" % (filename, path))
+            warnings.warn("Failed to save {0!s} at {1!s}".format(filename, path))
         else:
             handle.write(text)
             handle.close()
@@ -586,7 +586,7 @@ class DataHandler(object):
             # urls always have a forward slash, don't use os.path.join
             url = source.rstrip("/") + "/" + systemId
         else:
-            raise ValueError("Unexpected URL scheme %r" % (urlinfo[0]))
+            raise ValueError("Unexpected URL scheme {0!r}".format((urlinfo[0])))
         self.dtd_urls.append(url)
         # First, try to load the local version of the DTD file
         location, filename = os.path.split(systemId)
@@ -597,7 +597,7 @@ class DataHandler(object):
             try:
                 handle = _urlopen(url)
             except IOError:
-                raise RuntimeError("Failed to access %s at %s" % (filename, url))
+                raise RuntimeError("Failed to access {0!s} at {1!s}".format(filename, url))
             text = handle.read()
             handle.close()
             self.save_dtd_file(filename, text)

--- a/Bio/ExPASy/Enzyme.py
+++ b/Bio/ExPASy/Enzyme.py
@@ -87,13 +87,13 @@ Each record contains the following keys:
     def __repr__(self):
         if self["ID"]:
             if self["DE"]:
-                return "%s (%s, %s)" % (self.__class__.__name__,
+                return "{0!s} ({1!s}, {2!s})".format(self.__class__.__name__,
                                         self["ID"], self["DE"])
             else:
-                return "%s (%s)" % (self.__class__.__name__,
+                return "{0!s} ({1!s})".format(self.__class__.__name__,
                                        self["ID"])
         else:
-            return "%s ( )" % (self.__class__.__name__)
+            return "{0!s} ( )".format((self.__class__.__name__))
 
     def __str__(self):
         output = "ID: " + self["ID"]
@@ -103,7 +103,7 @@ Each record contains the following keys:
         output += " CF: " + self["CF"]
         output += " CC: " + repr(self["CC"])
         output += " PR: " + repr(self["PR"])
-        output += " DR: %d Records" % len(self["DR"])
+        output += " DR: {0:d} Records".format(len(self["DR"]))
         return output
 
 # Everything below is private

--- a/Bio/ExPASy/Prodoc.py
+++ b/Bio/ExPASy/Prodoc.py
@@ -82,7 +82,7 @@ class Reference(object):
 def __read_prosite_reference_line(record, line):
     line = line.rstrip()
     if line[-1] != '}':
-        raise ValueError("I don't understand the Prosite reference on line\n%s" % line)
+        raise ValueError("I don't understand the Prosite reference on line\n{0!s}".format(line))
     acc, name = line[1:-1].split('; ')
     record.prosite_refs.append((acc, name))
 
@@ -115,7 +115,7 @@ def __read_reference_line(record, line):
         else:
             reference.citation += line[5:]
         return True
-    raise Exception("I don't understand the reference line\n%s" % line)
+    raise Exception("I don't understand the reference line\n{0!s}".format(line))
 
 
 def __read_copyright_line(record, line):
@@ -136,9 +136,9 @@ def __read(handle):
     record = Record()
     # Read the accession number
     if not line.startswith("{PDOC"):
-        raise ValueError("Line does not start with '{PDOC':\n%s" % line)
+        raise ValueError("Line does not start with '{{PDOC':\n{0!s}".format(line))
     if line[-1] != '}':
-        raise ValueError("I don't understand accession line\n%s" % line)
+        raise ValueError("I don't understand accession line\n{0!s}".format(line))
     record.accession = line[1:-1]
     # Read the Prosite references
     for line in handle:
@@ -150,7 +150,7 @@ def __read(handle):
         raise ValueError("Unexpected end of stream.")
     # Read the actual text
     if not line.startswith('{BEGIN'):
-        raise ValueError("Line does not start with '{BEGIN':\n%s" % line)
+        raise ValueError("Line does not start with '{{BEGIN':\n{0!s}".format(line))
     read_line = __read_text_line
     for line in handle:
         if line.startswith('{END}'):

--- a/Bio/ExPASy/Prosite.py
+++ b/Bio/ExPASy/Prosite.py
@@ -162,8 +162,7 @@ def __read(handle):
             record = Record()
             cols = value.split("; ")
             if len(cols) != 2:
-                raise ValueError("I don't understand identification line\n%s"
-                         % line)
+                raise ValueError("I don't understand identification line\n{0!s}".format(line))
             record.name = cols[0]
             record.type = cols[1].rstrip('.')    # don't want '.'
         elif keyword == 'AC':
@@ -173,7 +172,7 @@ def __read(handle):
             if (not dates[0].endswith('(CREATED)')) or \
                (not dates[1].endswith('(DATA UPDATE)')) or \
                (not dates[2].endswith('(INFO UPDATE)')):
-                raise ValueError("I don't understand date line\n%s" % line)
+                raise ValueError("I don't understand date line\n{0!s}".format(line))
             record.created = dates[0].rstrip(' (CREATED)')
             record.data_update = dates[1].rstrip(' (DATA UPDATE)')
             record.info_update = dates[2].rstrip(' (INFO UPDATE)')
@@ -204,8 +203,7 @@ def __read(handle):
                 elif qual in ['/TOTAL', '/POSITIVE', '/UNKNOWN', '/FALSE_POS']:
                     m = re.match(r'(\d+)\((\d+)\)', data)
                     if not m:
-                        raise Exception("Broken data %s in comment line\n%s"
-                                        % (repr(data), line))
+                        raise Exception("Broken data {0!s} in comment line\n{1!s}".format(repr(data), line))
                     hits = tuple(map(int, m.groups()))
                     if(qual == "/TOTAL"):
                         record.nr_total = hits
@@ -216,8 +214,7 @@ def __read(handle):
                     elif(qual == "/FALSE_POS"):
                         record.nr_false_pos = hits
                 else:
-                    raise ValueError("Unknown qual %s in comment line\n%s"
-                                     % (repr(qual), line))
+                    raise ValueError("Unknown qual {0!s} in comment line\n{1!s}".format(repr(qual), line))
         elif keyword == 'CC':
             # Expect CC lines like this:
             # CC   /TAXO-RANGE=??EPV; /MAX-REPEAT=2;
@@ -257,8 +254,7 @@ def __read(handle):
                 elif qual == '/VERSION':
                     record.cc_version = data
                 else:
-                    raise ValueError("Unknown qual %s in comment line\n%s"
-                                     % (repr(qual), line))
+                    raise ValueError("Unknown qual {0!s} in comment line\n{1!s}".format(repr(qual), line))
         elif keyword == 'DR':
             refs = value.split(";")
             for ref in refs:
@@ -276,7 +272,7 @@ def __read(handle):
                 elif type == '?':
                     record.dr_unknown.append((acc, name))
                 else:
-                    raise ValueError("I don't understand type flag %s" % type)
+                    raise ValueError("I don't understand type flag {0!s}".format(type))
         elif keyword == '3D':
             cols = value.split()
             for id in cols:
@@ -294,7 +290,7 @@ def __read(handle):
                 continue
             break
         else:
-            raise ValueError("Unknown keyword %s found" % keyword)
+            raise ValueError("Unknown keyword {0!s} found".format(keyword))
     else:
         return
     if not record:

--- a/Bio/ExPASy/ScanProsite.py
+++ b/Bio/ExPASy/ScanProsite.py
@@ -54,7 +54,7 @@ def scan(seq="", mirror='http://www.expasy.org', output='xml', **keywords):
         if value is not None:
             parameters[key] = value
     command = _urlencode(parameters)
-    url = "%s/cgi-bin/prosite/PSScan.cgi?%s" % (mirror, command)
+    url = "{0!s}/cgi-bin/prosite/PSScan.cgi?{1!s}".format(mirror, command)
     handle = _urlopen(url)
     return handle
 

--- a/Bio/ExPASy/__init__.py
+++ b/Bio/ExPASy/__init__.py
@@ -35,7 +35,7 @@ def get_prodoc_entry(id, cgi='http://www.expasy.ch/cgi-bin/get-prodoc-entry'):
     'There is no PROSITE documentation entry XXX. Please try again.'
     """
     # Open a handle to ExPASy.
-    return _urlopen("%s?%s" % (cgi, id))
+    return _urlopen("{0!s}?{1!s}".format(cgi, id))
 
 
 def get_prosite_entry(id,
@@ -49,7 +49,7 @@ def get_prosite_entry(id,
     containing this line:
     'There is currently no PROSITE entry for XXX. Please try again.'
     """
-    return _urlopen("%s?%s" % (cgi, id))
+    return _urlopen("{0!s}?{1!s}".format(cgi, id))
 
 
 def get_prosite_raw(id, cgi='http://www.expasy.ch/cgi-bin/get-prosite-raw.pl'):
@@ -61,7 +61,7 @@ def get_prosite_raw(id, cgi='http://www.expasy.ch/cgi-bin/get-prosite-raw.pl'):
 
     For a non-existing key, ExPASy returns nothing.
     """
-    return _urlopen("%s?%s" % (cgi, id))
+    return _urlopen("{0!s}?{1!s}".format(cgi, id))
 
 
 def get_sprot_raw(id):
@@ -70,7 +70,7 @@ def get_sprot_raw(id):
     For an ID of XXX, fetches http://www.uniprot.org/uniprot/XXX.txt
     (as per the http://www.expasy.ch/expasy_urls.html documentation).
     """
-    return _urlopen("http://www.uniprot.org/uniprot/%s.txt" % id)
+    return _urlopen("http://www.uniprot.org/uniprot/{0!s}.txt".format(id))
 
 
 def sprot_search_ful(text, make_wild=None, swissprot=1, trembl=None,
@@ -89,7 +89,7 @@ def sprot_search_ful(text, make_wild=None, swissprot=1, trembl=None,
     if trembl:
         variables['T'] = 'on'
     options = _urlencode(variables)
-    fullcgi = "%s?%s" % (cgi, options)
+    fullcgi = "{0!s}?{1!s}".format(cgi, options)
     handle = _urlopen(fullcgi)
     return handle
 
@@ -109,6 +109,6 @@ def sprot_search_de(text, swissprot=1, trembl=None,
     if trembl:
         variables['T'] = 'on'
     options = _urlencode(variables)
-    fullcgi = "%s?%s" % (cgi, options)
+    fullcgi = "{0!s}?{1!s}".format(cgi, options)
     handle = _urlopen(fullcgi)
     return handle

--- a/Bio/FSSP/__init__.py
+++ b/Bio/FSSP/__init__.py
@@ -202,7 +202,7 @@ class FSSPAlignDict(dict):
                 mult_align_dict[j] += fssp_rec.pos_align_dict[j].aa
         out_str = ''
         for i in sorted(mult_align_dict):
-            out_str += '> %d\n' % i
+            out_str += '> {0:d}\n'.format(i)
             k = 0
             for j in mult_align_dict[i]:
                 k += 1

--- a/Bio/File.py
+++ b/Bio/File.py
@@ -283,7 +283,7 @@ class _IndexedSeqFileDict(_dict_base):
             #       % (key, offset, length, filename, format)
             if key in offsets:
                 self._proxy._handle.close()
-                raise ValueError("Duplicate key '%s'" % key)
+                raise ValueError("Duplicate key '{0!s}'".format(key))
             else:
                 offsets[key] = offset
         self._offsets = offsets
@@ -294,7 +294,7 @@ class _IndexedSeqFileDict(_dict_base):
     def __str__(self):
         # TODO - How best to handle the __str__ for SeqIO and SearchIO?
         if self:
-            return "{%r : %s(...), ...}" % (list(self.keys())[0], self._obj_repr)
+            return "{{{0!r} : {1!s}(...), ...}}".format(list(self.keys())[0], self._obj_repr)
         else:
             return "{}"
 
@@ -360,7 +360,7 @@ class _IndexedSeqFileDict(_dict_base):
         else:
             key2 = record.id
         if key != key2:
-            raise ValueError("Key did not match (%s vs %s)" % (key, key2))
+            raise ValueError("Key did not match ({0!s} vs {1!s})".format(key, key2))
         return record
 
     def get(self, k, d=None):
@@ -497,15 +497,13 @@ class _SQLiteManySeqFilesDict(_IndexedSeqFileDict):
                 "SELECT COUNT(key) FROM offset_data;").fetchone()
             if self._length != int(count):
                 con.close()
-                raise ValueError("Corrupt database? %i entries not %i"
-                                 % (int(count), self._length))
+                raise ValueError("Corrupt database? {0:d} entries not {1:d}".format(int(count), self._length))
             self._format, = con.execute(
                 "SELECT value FROM meta_data WHERE key=?;",
                 ("format",)).fetchone()
             if format and format != self._format:
                 con.close()
-                raise ValueError("Index file says format %s, not %s"
-                                 % (self._format, format))
+                raise ValueError("Index file says format {0!s}, not {1!s}".format(self._format, format))
             try:
                 filenames_relative_to_index, = con.execute(
                     "SELECT value FROM meta_data WHERE key=?;",
@@ -532,16 +530,14 @@ class _SQLiteManySeqFilesDict(_IndexedSeqFileDict):
                 del tmp
             if filenames and len(filenames) != len(self._filenames):
                 con.close()
-                raise ValueError("Index file says %i files, not %i"
-                                 % (len(self._filenames), len(filenames)))
+                raise ValueError("Index file says {0:d} files, not {1:d}".format(len(self._filenames), len(filenames)))
             if filenames and filenames != self._filenames:
                 for old, new in zip(self._filenames, filenames):
                     # Want exact match (after making relative to the index above)
                     if os.path.abspath(old) != os.path.abspath(new):
                         con.close()
                         if filenames_relative_to_index:
-                            raise ValueError("Index file has different filenames, e.g. %r != %r"
-                                             % (os.path.abspath(old), os.path.abspath(new)))
+                            raise ValueError("Index file has different filenames, e.g. {0!r} != {1!r}".format(os.path.abspath(old), os.path.abspath(new)))
                         else:
                             raise ValueError("Index file has different filenames "
                                              "[This is an old index where any relative paths "
@@ -551,11 +547,11 @@ class _SQLiteManySeqFilesDict(_IndexedSeqFileDict):
                 # Filenames are equal (after imposing abspath)
         except _OperationalError as err:
             con.close()
-            raise ValueError("Not a Biopython index database? %s" % err)
+            raise ValueError("Not a Biopython index database? {0!s}".format(err))
         # Now we have the format (from the DB if not given to us),
         if not proxy_factory(self._format):
             con.close()
-            raise ValueError("Unsupported format '%s'" % self._format)
+            raise ValueError("Unsupported format '{0!s}'".format(self._format))
 
     def _build_index(self):
         """Called from __init__ to create a new index (PRIVATE)."""
@@ -569,9 +565,9 @@ class _SQLiteManySeqFilesDict(_IndexedSeqFileDict):
         random_access_proxies = self._proxies
 
         if not format or not filenames:
-            raise ValueError("Filenames to index and format required to build %r" % index_filename)
+            raise ValueError("Filenames to index and format required to build {0!r}".format(index_filename))
         if not proxy_factory(format):
-            raise ValueError("Unsupported format '%s'" % format)
+            raise ValueError("Unsupported format '{0!s}'".format(format))
         # Create the index
         con = _sqlite.connect(index_filename)
         self._con = con
@@ -645,7 +641,7 @@ class _SQLiteManySeqFilesDict(_IndexedSeqFileDict):
             self._proxies = random_access_proxies
             self.close()
             con.close()
-            raise ValueError("Duplicate key? %s" % err)
+            raise ValueError("Duplicate key? {0!s}".format(err))
         con.execute("PRAGMA locking_mode=NORMAL")
         con.execute("UPDATE meta_data SET value = ? WHERE key = ?;",
                     (count, "count"))
@@ -703,7 +699,7 @@ class _SQLiteManySeqFilesDict(_IndexedSeqFileDict):
         else:
             key2 = record.id
         if key != key2:
-            raise ValueError("Key did not match (%s vs %s)" % (key, key2))
+            raise ValueError("Key did not match ({0!s} vs {1!s})".format(key, key2))
         return record
 
     def get(self, k, d=None):

--- a/Bio/GA/Organism.py
+++ b/Bio/GA/Organism.py
@@ -71,7 +71,7 @@ def random_population(genome_alphabet, genome_size, num_organisms,
         alphabet_type = "d"
     else:
         raise ValueError(
-            "Alphabet type is unsupported: %s" % genome_alphabet.letters)
+            "Alphabet type is unsupported: {0!s}".format(genome_alphabet.letters))
 
     for org_num in range(num_organisms):
         new_genome = MutableSeq(array.array(alphabet_type), genome_alphabet)
@@ -131,7 +131,7 @@ class Organism(object):
     def __str__(self):
         """Provide a string output for debugging.
         """
-        return "Genome: %s; Fitness %s" % (str(self.genome), self.fitness)
+        return "Genome: {0!s}; Fitness {1!s}".format(str(self.genome), self.fitness)
 
     def __eq__(self, other):
         """Compare organisms by their genomes (as strings of letters).

--- a/Bio/GenBank/Record.py
+++ b/Bio/GenBank/Record.py
@@ -243,9 +243,9 @@ class Record(object):
         """
         output = "LOCUS"
         output += " " * 7  # 6-12 spaces
-        output += "%-9s" % self.locus
+        output += "{0:<9!s}".format(self.locus)
         output += " "  # 22 space
-        output += "%7s" % self.size
+        output += "{0:7!s}".format(self.size)
         if "PROTEIN" in self.residue_type:
             output += " aa"
         else:
@@ -254,20 +254,20 @@ class Record(object):
         # treat circular types differently, since they'll have long residue
         # types
         if "circular" in self.residue_type:
-            output += "%17s" % self.residue_type
+            output += "{0:17!s}".format(self.residue_type)
         # second case: ss-DNA types of records
         elif "-" in self.residue_type:
-            output += "%7s" % self.residue_type
+            output += "{0:7!s}".format(self.residue_type)
             output += " " * 10  # spaces for circular
         else:
             output += " " * 3  # spaces for stuff like ss-
-            output += "%-4s" % self.residue_type
+            output += "{0:<4!s}".format(self.residue_type)
             output += " " * 10  # spaces for circular
 
         output += " " * 2
-        output += "%3s" % self.data_file_division
+        output += "{0:3!s}".format(self.data_file_division)
         output += " " * 7  # spaces for 56-63
-        output += "%11s" % self.date
+        output += "{0:11!s}".format(self.date)
         output += "\n"
         return output
 
@@ -286,7 +286,7 @@ class Record(object):
 
             acc_info = ""
             for accession in self.accession:
-                acc_info += "%s " % accession
+                acc_info += "{0!s} ".format(accession)
             # strip off an extra space at the end
             acc_info = acc_info.rstrip()
             output += _wrapped_genbank(acc_info, Record.GB_BASE_INDENT)
@@ -302,7 +302,7 @@ class Record(object):
             output = Record.BASE_FORMAT % "VERSION"
             output += self.version
             output += "  GI:"
-            output += "%s\n" % self.gi
+            output += "{0!s}\n".format(self.gi)
         else:
             output = ""
         return output
@@ -311,7 +311,7 @@ class Record(object):
         output = ""
         if len(self.projects) > 0:
             output = Record.BASE_FORMAT % "PROJECT"
-            output += "%s\n" % "  ".join(self.projects)
+            output += "{0!s}\n".format("  ".join(self.projects))
         return output
 
     def _dblink_line(self):
@@ -327,7 +327,7 @@ class Record(object):
         """
         if self.nid:
             output = Record.BASE_FORMAT % "NID"
-            output += "%s\n" % self.nid
+            output += "{0!s}\n".format(self.nid)
         else:
             output = ""
         return output
@@ -337,7 +337,7 @@ class Record(object):
         """
         if self.pid:
             output = Record.BASE_FORMAT % "PID"
-            output += "%s\n" % self.pid
+            output += "{0!s}\n".format(self.pid)
         else:
             output = ""
         return output
@@ -350,7 +350,7 @@ class Record(object):
             output += Record.BASE_FORMAT % "KEYWORDS"
             keyword_info = ""
             for keyword in self.keywords:
-                keyword_info += "%s; " % keyword
+                keyword_info += "{0!s}; ".format(keyword)
             # replace the ; at the end with a period
             keyword_info = keyword_info[:-2]
             keyword_info += "."
@@ -365,7 +365,7 @@ class Record(object):
         """
         if self.db_source:
             output = Record.BASE_FORMAT % "DBSOURCE"
-            output += "%s\n" % self.db_source
+            output += "{0!s}\n".format(self.db_source)
         else:
             output = ""
         return output
@@ -395,7 +395,7 @@ class Record(object):
         output += " " * Record.GB_BASE_INDENT
         taxonomy_info = ""
         for tax in self.taxonomy:
-            taxonomy_info += "%s; " % tax
+            taxonomy_info += "{0!s}; ".format(tax)
         # replace the ; at the end with a period
         taxonomy_info = taxonomy_info[:-2]
         taxonomy_info += "."
@@ -439,7 +439,7 @@ class Record(object):
                     count_info = count_parts.pop(0)
                     count_type = count_parts.pop(0)
 
-                    output += "%7s %s" % (count_info, count_type)
+                    output += "{0:7!s} {1!s}".format(count_info, count_type)
             # deal with ugly ORIGIN lines like:
             # 1311257 a2224835 c2190093 g1309889 t
             # by just outputting the raw information
@@ -475,7 +475,7 @@ class Record(object):
                     start_pos = cur_seq_pos + section * 10
                     end_pos = start_pos + 10
                     seq_section = self.sequence[start_pos:end_pos]
-                    output += " %s" % seq_section.lower()
+                    output += " {0!s}".format(seq_section.lower())
 
                     # stop looping if we are out of sequence
                     if end_pos > len(self.sequence):
@@ -554,10 +554,10 @@ class Reference(object):
         output = Record.BASE_FORMAT % "REFERENCE"
         if self.number:
             if self.bases:
-                output += "%-3s" % self.number
-                output += "%s" % self.bases
+                output += "{0:<3!s}".format(self.number)
+                output += "{0!s}".format(self.bases)
             else:
-                output += "%s" % self.number
+                output += "{0!s}".format(self.number)
 
         output += "\n"
         return output

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -176,7 +176,7 @@ class InsdcScanner(object):
                 line = self.handle.readline()
                 continue
             if len(line) < self.FEATURE_QUALIFIER_INDENT:
-                warnings.warn("line too short to contain a feature: %r" % line,
+                warnings.warn("line too short to contain a feature: {0!r}".format(line),
                               BiopythonParserWarning)
                 line = self.handle.readline()
                 continue
@@ -194,7 +194,7 @@ class InsdcScanner(object):
                     # over indenting the location and qualifiers.
                     feature_key, line = line[2:].strip().split(None, 1)
                     feature_lines = [line]
-                    warnings.warn("Overindented %s feature?" % feature_key,
+                    warnings.warn("Overindented {0!s} feature?".format(feature_key),
                                   BiopythonParserWarning)
                 else:
                     feature_key = line[2:self.FEATURE_QUALIFIER_INDENT].strip()
@@ -303,7 +303,7 @@ class InsdcScanner(object):
                     elif value == '"':
                         # One single quote
                         if self.debug:
-                            print("Single quote %s:%s" % (key, value))
+                            print("Single quote {0!s}:{1!s}".format(key, value))
                         # DO NOT remove the quote...
                         qualifiers.append((key, value))
                     elif value[0] == '"':
@@ -329,8 +329,7 @@ class InsdcScanner(object):
             return (feature_key, feature_location, qualifiers)
         except StopIteration:
             # Bummer
-            raise ValueError("Problem with '%s' feature:\n%s"
-                             % (feature_key, "\n".join(lines)))
+            raise ValueError("Problem with '{0!s}' feature:\n{1!s}".format(feature_key, "\n".join(lines)))
 
     def parse_footer(self):
         """returns a tuple containing a list of any misc strings, and the sequence"""
@@ -583,7 +582,7 @@ class EmblScanner(InsdcScanner):
     def parse_footer(self):
         """returns a tuple containing a list of any misc strings, and the sequence"""
         assert self.line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS, \
-            "Eh? '%s'" % self.line
+            "Eh? '{0!s}'".format(self.line)
 
         # Note that the SQ line can be split into several lines...
         misc_lines = []
@@ -595,7 +594,7 @@ class EmblScanner(InsdcScanner):
             self.line = self.line.rstrip()
 
         assert self.line[:self.HEADER_WIDTH] == " " * self.HEADER_WIDTH \
-            or self.line.strip() == '//', "Unexpected content after SQ or CO line: %r" % self.line
+            or self.line.strip() == '//', "Unexpected content after SQ or CO line: {0!r}".format(self.line)
 
         seq_lines = []
         line = self.line
@@ -713,7 +712,7 @@ class EmblScanner(InsdcScanner):
 
     def _feed_seq_length(self, consumer, text):
         length_parts = text.split()
-        assert len(length_parts) == 2, "Invalid sequence length string %r" % text
+        assert len(length_parts) == 2, "Invalid sequence length string {0!r}".format(text)
         assert length_parts[1].upper() in ["BP", "BP.", "AA", "AA."]
         consumer.size(length_parts[0])
 
@@ -757,7 +756,7 @@ class EmblScanner(InsdcScanner):
                 # and '160-550, 904-1055' becomes '(bases 160 to 550; 904 to 1055)'
                 # Note could be multi-line, and end with a comma
                 parts = [bases.replace("-", " to ").strip() for bases in data.split(",") if bases.strip()]
-                consumer.reference_bases("(bases %s)" % "; ".join(parts))
+                consumer.reference_bases("(bases {0!s})".format("; ".join(parts)))
             elif line_type == 'RT':
                 # Remove the enclosing quotes and trailing semi colon.
                 # Note the title can be split over multiple lines.
@@ -803,7 +802,7 @@ class EmblScanner(InsdcScanner):
                 parts = data.rstrip(".").split(";")
                 # Turn it into "database_identifier:primary_identifier" to
                 # mimic the GenBank parser. e.g. "MGI:98599"
-                consumer.dblink("%s:%s" % (parts[0].strip(),
+                consumer.dblink("{0!s}:{1!s}".format(parts[0].strip(),
                                            parts[1].strip()))
             elif line_type == 'RA':
                 # Remove trailing ; at end of authors list
@@ -834,7 +833,7 @@ class EmblScanner(InsdcScanner):
                 getattr(consumer, consumer_dict[line_type])(data)
             else:
                 if self.debug:
-                    print("Ignoring EMBL header line:\n%s" % line)
+                    print("Ignoring EMBL header line:\n{0!s}".format(line))
 
     def _feed_misc_lines(self, consumer, lines):
         # TODO - Should we do something with the information on the SQ line(s)?
@@ -980,7 +979,7 @@ class GenBankScanner(InsdcScanner):
     def parse_footer(self):
         """returns a tuple containing a list of any misc strings, and the sequence"""
         assert self.line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS, \
-            "Eh? '%s'" % self.line
+            "Eh? '{0!s}'".format(self.line)
 
         misc_lines = []
         while self.line[:self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS \
@@ -993,7 +992,7 @@ class GenBankScanner(InsdcScanner):
             self.line = self.line
 
         assert self.line[:self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS, \
-            "Eh? '%s'" % self.line
+            "Eh? '{0!s}'".format(self.line)
 
         # Now just consume the sequence lines until reach the // marker
         # or a CONTIG line
@@ -1022,7 +1021,7 @@ class GenBankScanner(InsdcScanner):
                               BiopythonParserWarning)
                 line = line[1:]
                 if len(line) > 9 and line[9:10] != ' ':
-                    raise ValueError("Sequence line mal-formed, '%s'" % line)
+                    raise ValueError("Sequence line mal-formed, '{0!s}'".format(line))
             seq_lines.append(line[10:])  # remove spaces later
             line = self.handle.readline()
 
@@ -1426,7 +1425,7 @@ class GenBankScanner(InsdcScanner):
                             break
                 else:
                     if self.debug:
-                        print("Ignoring GenBank header line:\n" % line)
+                        print("Ignoring GenBank header line:\n".format(*line))
                     # Read in next line
                     line = next(line_iter)
         except StopIteration:
@@ -1820,22 +1819,22 @@ SQ   Sequence 1859 BP; 609 A; 314 C; 355 G; 581 T; 0 other;
     print("=================")
     g = GenBankScanner()
     for record in g.parse_records(StringIO(gbk_example), do_features=False):
-        print("%s %s %s" % (record.id, record.name, record.description))
+        print("{0!s} {1!s} {2!s}".format(record.id, record.name, record.description))
         print(record.seq)
 
     g = GenBankScanner()
     for record in g.parse_records(StringIO(gbk_example), do_features=True):
-        print("%s %s %s" % (record.id, record.name, record.description))
+        print("{0!s} {1!s} {2!s}".format(record.id, record.name, record.description))
         print(record.seq)
 
     g = GenBankScanner()
     for record in g.parse_records(StringIO(gbk_example2), do_features=False):
-        print("%s %s %s" % (record.id, record.name, record.description))
+        print("{0!s} {1!s} {2!s}".format(record.id, record.name, record.description))
         print(record.seq)
 
     g = GenBankScanner()
     for record in g.parse_records(StringIO(gbk_example2), do_features=True):
-        print("%s %s %s" % (record.id, record.name, record.description))
+        print("{0!s} {1!s} {2!s}".format(record.id, record.name, record.description))
         print(record.seq)
 
     print("")
@@ -1851,5 +1850,5 @@ SQ   Sequence 1859 BP; 609 A; 314 C; 355 G; 581 T; 0 other;
     print("==============")
     e = EmblScanner()
     for record in e.parse_records(StringIO(embl_example), do_features=True):
-        print("%s %s %s" % (record.id, record.name, record.description))
+        print("{0!s} {1!s} {2!s}".format(record.id, record.name, record.description))
         print(record.seq)

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -72,8 +72,7 @@ _between_location = r"\d+\^\d+"
 
 _within_position = r"\(\d+\.\d+\)"
 _re_within_position = re.compile(_within_position)
-_within_location = r"([<>]?\d+|%s)\.\.([<>]?\d+|%s)" \
-                   % (_within_position, _within_position)
+_within_location = r"([<>]?\d+|{0!s})\.\.([<>]?\d+|{1!s})".format(_within_position, _within_position)
 assert _re_within_position.match("(3.9)")
 assert re.compile(_within_location).match("(3.9)..10")
 assert re.compile(_within_location).match("26..(30.33)")
@@ -81,8 +80,7 @@ assert re.compile(_within_location).match("(13.19)..(20.28)")
 
 _oneof_position = r"one\-of\(\d+(,\d+)+\)"
 _re_oneof_position = re.compile(_oneof_position)
-_oneof_location = r"([<>]?\d+|%s)\.\.([<>]?\d+|%s)" \
-                   % (_oneof_position, _oneof_position)
+_oneof_location = r"([<>]?\d+|{0!s})\.\.([<>]?\d+|{1!s})".format(_oneof_position, _oneof_position)
 assert _re_oneof_position.match("one-of(6,9)")
 assert re.compile(_oneof_location).match("one-of(6,9)..101")
 assert re.compile(_oneof_location).match("one-of(6,9)..one-of(101,104)")
@@ -94,17 +92,13 @@ assert _re_oneof_position.match("one-of(3,6,9)")
 
 
 _simple_location = r"\d+\.\.\d+"
-_re_simple_location = re.compile(r"^%s$" % _simple_location)
-_re_simple_compound = re.compile(r"^(join|order|bond)\(%s(,%s)*\)$"
-                                 % (_simple_location, _simple_location))
-_complex_location = r"([a-zA-Z][a-zA-Z0-9_\.]*[a-zA-Z0-9]?\:)?(%s|%s|%s|%s|%s)" \
-                    % (_pair_location, _solo_location, _between_location,
+_re_simple_location = re.compile(r"^{0!s}$".format(_simple_location))
+_re_simple_compound = re.compile(r"^(join|order|bond)\({0!s}(,{1!s})*\)$".format(_simple_location, _simple_location))
+_complex_location = r"([a-zA-Z][a-zA-Z0-9_\.]*[a-zA-Z0-9]?\:)?({0!s}|{1!s}|{2!s}|{3!s}|{4!s})".format(_pair_location, _solo_location, _between_location,
                        _within_location, _oneof_location)
-_re_complex_location = re.compile(r"^%s$" % _complex_location)
-_possibly_complemented_complex_location = r"(%s|complement\(%s\))" \
-                                          % (_complex_location, _complex_location)
-_re_complex_compound = re.compile(r"^(join|order|bond)\(%s(,%s)*\)$"
-                                 % (_possibly_complemented_complex_location,
+_re_complex_location = re.compile(r"^{0!s}$".format(_complex_location))
+_possibly_complemented_complex_location = r"({0!s}|complement\({1!s}\))".format(_complex_location, _complex_location)
+_re_complex_compound = re.compile(r"^(join|order|bond)\({0!s}(,{1!s})*\)$".format(_possibly_complemented_complex_location,
                                     _possibly_complemented_complex_location))
 
 
@@ -148,7 +142,7 @@ assert not _re_simple_compound.match("join(complement(149815..150200),complement
 assert not _re_complex_location.match("join(complement(149815..150200),complement(293787..295573),NC_016402.1:6618..6676,181647..181905)")
 assert not _re_simple_location.match("join(complement(149815..150200),complement(293787..295573),NC_016402.1:6618..6676,181647..181905)")
 
-_solo_bond = re.compile("bond\(%s\)" % _solo_location)
+_solo_bond = re.compile("bond\({0!s}\)".format(_solo_location))
 assert _solo_bond.match("bond(196)")
 assert _solo_bond.search("bond(196)")
 assert _solo_bond.search("join(bond(284),bond(305),bond(309),bond(305))")
@@ -294,7 +288,7 @@ def _loc(loc_str, expected_seq_length, strand):
             elif int(s) == expected_seq_length and e == "1":
                 pos = _pos(s)
             else:
-                raise ValueError("Invalid between location %s" % repr(loc_str))
+                raise ValueError("Invalid between location {0!s}".format(repr(loc_str)))
             return SeqFeature.FeatureLocation(pos, pos, strand)
         else:
             # e.g. "123"
@@ -874,8 +868,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
             pass
         # otherwise raise an error
         else:
-            raise ValueError("Could not parse base info %s in record %s" %
-                             (ref_base_info, self.data.id))
+            raise ValueError("Could not parse base info {0!s} in record {1!s}".format(ref_base_info, self.data.id))
 
         self._cur_reference.location = all_locations
 
@@ -1117,8 +1110,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         cur_feature.location = None
         import warnings
         from Bio import BiopythonParserWarning
-        warnings.warn(BiopythonParserWarning("Couldn't parse feature location: %r"
-                                             % (location_line)))
+        warnings.warn(BiopythonParserWarning("Couldn't parse feature location: {0!r}".format((location_line))))
 
     def feature_qualifier(self, key, value):
         """When we get a qualifier key and its value.
@@ -1205,7 +1197,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
             self.data.id = self.data.name  # Good fall back?
         elif self.data.id.count('.') == 0:
             try:
-                self.data.id += '.%i' % self.data.annotations['sequence_version']
+                self.data.id += '.{0:d}'.format(self.data.annotations['sequence_version'])
             except KeyError:
                 pass
 
@@ -1223,8 +1215,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         and self._expected_size != len(sequence):
             import warnings
             from Bio import BiopythonParserWarning
-            warnings.warn("Expected sequence length %i, found %i (%s)."
-                          % (self._expected_size, len(sequence), self.data.id),
+            warnings.warn("Expected sequence length {0:d}, found {1:d} ({2!s}).".format(self._expected_size, len(sequence), self.data.id),
                           BiopythonParserWarning)
 
         if self._seq_type:
@@ -1248,8 +1239,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                 pass
             # we have a bug if we get here
             else:
-                raise ValueError("Could not determine alphabet for seq_type %s"
-                                 % self._seq_type)
+                raise ValueError("Could not determine alphabet for seq_type {0!s}".format(self._seq_type))
 
         if not sequence and self.__expected_size:
             self.data.seq = UnknownSeq(self._expected_size, seq_alphabet)
@@ -1287,7 +1277,7 @@ class _RecordConsumer(_BaseGenBankConsumer):
         if 'dna' in content or 'rna' in content:
             import warnings
             from Bio import BiopythonParserWarning
-            warnings.warn("Invalid seq_type (%s): DNA/RNA should be uppercase." % content,
+            warnings.warn("Invalid seq_type ({0!s}): DNA/RNA should be uppercase.".format(content),
                           BiopythonParserWarning)
         self.data.residue_type = content
 
@@ -1449,7 +1439,7 @@ class _RecordConsumer(_BaseGenBankConsumer):
         for content in content_list:
             # the record parser keeps the /s -- add them if we don't have 'em
             if not content.startswith("/"):
-                content = "/%s" % content
+                content = "/{0!s}".format(content)
             # add on a qualifier if we've got one
             if self._cur_qualifier is not None:
                 self._cur_feature.qualifiers.append(self._cur_qualifier)
@@ -1460,7 +1450,7 @@ class _RecordConsumer(_BaseGenBankConsumer):
     def feature_qualifier_description(self, content):
         # if we have info then the qualifier key should have a ='s
         if '=' not in self._cur_qualifier.key:
-            self._cur_qualifier.key = "%s=" % self._cur_qualifier.key
+            self._cur_qualifier.key = "{0!s}=".format(self._cur_qualifier.key)
         cur_content = self._remove_newlines(content)
         # remove all spaces from the value if it is a type where spaces
         # are not important

--- a/Bio/GenBank/utils.py
+++ b/Bio/GenBank/utils.py
@@ -45,11 +45,10 @@ class FeatureValueCleaner(object):
         """
         if key_name in self._to_process:
             try:
-                cleaner = getattr(self, "_clean_%s" % key_name)
+                cleaner = getattr(self, "_clean_{0!s}".format(key_name))
                 value = cleaner(value)
             except AttributeError:
-                raise AssertionError("No function to clean key: %s"
-                                     % key_name)
+                raise AssertionError("No function to clean key: {0!s}".format(key_name))
         return value
 
     def _clean_translation(self, value):

--- a/Bio/Geo/Record.py
+++ b/Bio/Geo/Record.py
@@ -38,45 +38,45 @@ class Record(object):
 
     def __str__(self):
         output = ''
-        output += 'GEO Type: %s\n' % self.entity_type
-        output += 'GEO Id: %s\n' % self.entity_id
+        output += 'GEO Type: {0!s}\n'.format(self.entity_type)
+        output += 'GEO Id: {0!s}\n'.format(self.entity_id)
         att_keys = sorted(self.entity_attributes)
         for key in att_keys:
             contents = self.entity_attributes[key]
             if isinstance(contents, list):
                 for item in contents:
                     try:
-                        output += '%s: %s\n' % (key, item[:40])
+                        output += '{0!s}: {1!s}\n'.format(key, item[:40])
                         output += out_block(item[40:])
                     except Exception:  # TODO: IndexError?
                         pass
             elif isinstance(contents, str):
-                output += '%s: %s\n' % (key, contents[:40])
+                output += '{0!s}: {1!s}\n'.format(key, contents[:40])
                 output += out_block(contents[40:])
             else:
                 print(contents)
-                output += '%s: %s\n' % (key, contents[:40])
+                output += '{0!s}: {1!s}\n'.format(key, contents[:40])
                 output += out_block(contents[40:])
         col_keys = sorted(self.col_defs)
         output += 'Column Header Definitions\n'
         for key in col_keys:
             val = self.col_defs[key]
-            output += '    %s: %s\n' % (key, val[:40])
+            output += '    {0!s}: {1!s}\n'.format(key, val[:40])
             output += out_block(val[40:], '    ')
         # May have to display VERY large tables,
         # so only show the first 20 lines of data
         MAX_ROWS = 20 + 1  # include header in count
         for row in self.table_rows[0:MAX_ROWS]:
-            output += '%s: ' % self.table_rows.index(row)
+            output += '{0!s}: '.format(self.table_rows.index(row))
             for col in row:
-                output += '%s\t' % col
+                output += '{0!s}\t'.format(col)
             output += '\n'
         if len(self.table_rows) > MAX_ROWS:
             output += '...\n'
             row = self.table_rows[-1]
-            output += '%s: ' % self.table_rows.index(row)
+            output += '{0!s}: '.format(self.table_rows.index(row))
             for col in row:
-                output += '%s\t' % col
+                output += '{0!s}\t'.format(col)
             output += '\n'
 
         return output
@@ -85,6 +85,6 @@ class Record(object):
 def out_block(text, prefix=''):
     output = ''
     for j in range(0, len(text), 80):
-        output += '%s%s\n' % (prefix, text[j:j + 80])
+        output += '{0!s}{1!s}\n'.format(prefix, text[j:j + 80])
     output += '\n'
     return output

--- a/Bio/Graphics/BasicChromosome.py
+++ b/Bio/Graphics/BasicChromosome.py
@@ -71,7 +71,7 @@ class _ChromosomeComponent(Widget):
         """Add a sub_component to the list of components under this item.
         """
         assert isinstance(component, _ChromosomeComponent), \
-               "Expected a _ChromosomeComponent object, got %s" % component
+               "Expected a _ChromosomeComponent object, got {0!s}".format(component)
 
         self._sub_components.append(component)
 
@@ -84,8 +84,8 @@ class _ChromosomeComponent(Widget):
         try:
             self._sub_components.remove(component)
         except ValueError:
-            raise ValueError("Component %s not found in sub_components." %
-                             component)
+            raise ValueError("Component {0!s} not found in sub_components.".format(
+                             component))
 
     def draw(self):
         """Draw the specified component.
@@ -517,10 +517,9 @@ def _spring_layout(desired, minimum, maximum, gap=0):
     if count <= 1:
         return desired  # Easy!
     if minimum >= maximum:
-        raise ValueError("Bad min/max %f and %f" % (minimum, maximum))
+        raise ValueError("Bad min/max {0:f} and {1:f}".format(minimum, maximum))
     if min(desired) < minimum or max(desired) > maximum:
-        raise ValueError("Data %f to %f out of bounds (%f to %f)"
-                         % (min(desired), max(desired), minimum, maximum))
+        raise ValueError("Data {0:f} to {1:f} out of bounds ({2:f} to {3:f})".format(min(desired), max(desired), minimum, maximum))
     equal_step = float(maximum - minimum) / (count - 1)
 
     if equal_step < gap:

--- a/Bio/Graphics/DisplayRepresentation.py
+++ b/Bio/Graphics/DisplayRepresentation.py
@@ -76,7 +76,7 @@ class ChromosomeCounts(object):
         try:
             self._count_info[segment_name] += count
         except KeyError:
-            raise KeyError("Segment name %s not found." % segment_name)
+            raise KeyError("Segment name {0!s} not found.".format(segment_name))
 
     def scale_segment_value(self, segment_name, scale_value=None):
         """Divide the counts for a segment by some kind of scale value.
@@ -88,7 +88,7 @@ class ChromosomeCounts(object):
             self._count_info[segment_name] = \
               float(self._count_info[segment_name]) / float(scale_value)
         except KeyError:
-            raise KeyError("Segment name %s not found." % segment_name)
+            raise KeyError("Segment name {0!s} not found.".format(segment_name))
 
     def add_label(self, segment_name, label):
         """Add a label to a specfic segment.
@@ -98,7 +98,7 @@ class ChromosomeCounts(object):
         if segment_name in self._label_info:
             self._label_info[segment_name] = label
         else:
-            raise KeyError("Segment name %s not found." % segment_name)
+            raise KeyError("Segment name {0!s} not found.".format(segment_name))
 
     def set_scale(self, segment_name, scale):
         """Set the scale for a specific chromosome segment.
@@ -111,7 +111,7 @@ class ChromosomeCounts(object):
         if segment_name in self._label_info:
             self._scale_info[segment_name] = scale
         else:
-            raise KeyError("Segment name %s not found." % segment_name)
+            raise KeyError("Segment name {0!s} not found.".format(segment_name))
 
     def get_segment_info(self):
         """Retrieve the color and label info about the segments.
@@ -183,5 +183,4 @@ class ChromosomeCounts(object):
                 return self._color_scheme[(count_start, count_end)]
 
         # if we got here we didn't find a color for the count
-        raise ValueError("Count value %s was not found in the color scheme."
-                         % count)
+        raise ValueError("Count value {0!s} was not found in the color scheme.".format(count))

--- a/Bio/Graphics/GenomeDiagram/_AbstractDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_AbstractDrawer.py
@@ -82,13 +82,13 @@ def page_sizes(size):
     try:
         return sizes[size]
     except:
-        raise ValueError("%s not in list of page sizes" % size)
+        raise ValueError("{0!s} not in list of page sizes".format(size))
 
 
 def _stroke_and_fill_colors(color, border):
     """Helper function handle border and fill colors (PRIVATE)."""
     if not isinstance(color, colors.Color):
-        raise ValueError("Invalid color %r" % color)
+        raise ValueError("Invalid color {0!r}".format(color))
 
     if color == colors.white and border is None:   # Force black border on
         strokecolor = colors.black                 # white boxes with
@@ -96,7 +96,7 @@ def _stroke_and_fill_colors(color, border):
         strokecolor = color                        # use fill color
     elif border:
         if not isinstance(border, colors.Color):
-            raise ValueError("Invalid border color %r" % border)
+            raise ValueError("Invalid border color {0!r}".format(border))
         strokecolor = border
     else:
         # e.g. False
@@ -239,8 +239,7 @@ def draw_arrow(point1, point2, color=colors.lightgreen, border=None,
     elif orientation == 'left':
         x1, x2, y1, y2 = xmax, xmin, ymin, ymax
     else:
-        raise ValueError("Invalid orientation %s, should be 'left' or 'right'"
-                         % repr(orientation))
+        raise ValueError("Invalid orientation {0!s}, should be 'left' or 'right'".format(repr(orientation)))
 
     # We define boxheight and boxwidth accordingly, and calculate the shaft
     # height from these.  We also ensure that the maximum head length is
@@ -450,12 +449,12 @@ class AbstractDrawer(object):
         elif isinstance(pagesize, tuple):  # A tuple, so don't translate
             pagesize = pagesize
         else:
-            raise ValueError("Page size %s not recognised" % pagesize)
+            raise ValueError("Page size {0!s} not recognised".format(pagesize))
         shortside, longside = min(pagesize), max(pagesize)
 
         orientation = orientation.lower()
         if orientation not in ('landscape', 'portrait'):
-            raise ValueError("Orientation %s not recognised" % orientation)
+            raise ValueError("Orientation {0!s} not recognised".format(orientation))
         if orientation == 'landscape':
             self.pagesize = (longside, shortside)
         else:

--- a/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
@@ -408,7 +408,7 @@ class CircularDrawer(AbstractDrawer):
         if feature.label:   # Feature needs a label
             # The spaces are a hack to force a little space between the label
             # and the edge of the feature
-            label = String(0, 0, " %s " % feature.name.strip(),
+            label = String(0, 0, " {0!s} ".format(feature.name.strip()),
                            fontName=feature.label_font,
                            fontSize=feature.label_size,
                            fillColor=feature.label_color)
@@ -842,18 +842,18 @@ class CircularDrawer(AbstractDrawer):
                             minval, maxval = quartiles[0], quartiles[4]
                             if graph.center is None:
                                 midval = (maxval + minval) / 2.
-                                graph_label_min.append("%.3f" % minval)
-                                graph_label_max.append("%.3f" % maxval)
-                                graph_label_mid.append("%.3f" % midval)
+                                graph_label_min.append("{0:.3f}".format(minval))
+                                graph_label_max.append("{0:.3f}".format(maxval))
+                                graph_label_mid.append("{0:.3f}".format(midval))
                             else:
                                 diff = max((graph.center - minval),
                                            (maxval - graph.center))
                                 minval = graph.center - diff
                                 maxval = graph.center + diff
                                 midval = graph.center
-                                graph_label_mid.append("%.3f" % midval)
-                                graph_label_min.append("%.3f" % minval)
-                                graph_label_max.append("%.3f" % maxval)
+                                graph_label_mid.append("{0:.3f}".format(midval))
+                                graph_label_min.append("{0:.3f}".format(minval))
+                                graph_label_max.append("{0:.3f}".format(maxval))
                         xmid, ymid = (x0 + x1) / 2., (y0 + y1) / 2.
                         for limit, x, y, in [(graph_label_min, x0, y0),
                                              (graph_label_max, x1, y1),
@@ -1266,8 +1266,7 @@ class CircularDrawer(AbstractDrawer):
         # else:
         startangle, endangle = min(startangle, endangle), max(startangle, endangle)
         if orientation != "left" and orientation != "right":
-            raise ValueError("Invalid orientation %s, should be 'left' or 'right'"
-                             % repr(orientation))
+            raise ValueError("Invalid orientation {0!s}, should be 'left' or 'right'".format(repr(orientation)))
 
         angle = float(endangle - startangle)    # angle subtended by arc
         middle_radius = 0.5 * (inner_radius + outer_radius)

--- a/Bio/Graphics/GenomeDiagram/_Colors.py
+++ b/Bio/Graphics/GenomeDiagram/_Colors.py
@@ -152,7 +152,7 @@ class ColorTranslator(object):
         if value in self._artemis_colorscheme:
             return self._artemis_colorscheme[value][0]
         else:
-            raise ValueError("Artemis color out of range: %d" % value)
+            raise ValueError("Artemis color out of range: {0:d}".format(value))
 
     def get_colorscheme(self):
         """Return the user-defined color scheme as a dictionary."""
@@ -170,7 +170,7 @@ class ColorTranslator(object):
         if value in self._colorscheme:
             return self._colorscheme[value][0]
         else:
-            raise ValueError("Scheme color out of range: %d" % value)
+            raise ValueError("Scheme color out of range: {0:d}".format(value))
 
     def int255_color(self, values):
         """ int255_color(self, values)

--- a/Bio/Graphics/GenomeDiagram/_Diagram.py
+++ b/Bio/Graphics/GenomeDiagram/_Diagram.py
@@ -354,9 +354,9 @@ class Diagram(object):
 
         __str__(self)
         """
-        outstr = ["\n<%s: %s>" % (self.__class__, self.name)]
-        outstr.append("%d tracks" % len(self.tracks))
+        outstr = ["\n<{0!s}: {1!s}>".format(self.__class__, self.name)]
+        outstr.append("{0:d} tracks".format(len(self.tracks)))
         for level in self.get_levels():
-            outstr.append("Track %d: %s\n" % (level, self.tracks[level]))
+            outstr.append("Track {0:d}: {1!s}\n".format(level, self.tracks[level]))
         outstr = '\n'.join(outstr)
         return outstr

--- a/Bio/Graphics/GenomeDiagram/_FeatureSet.py
+++ b/Bio/Graphics/GenomeDiagram/_FeatureSet.py
@@ -188,12 +188,12 @@ class FeatureSet(object):
            complete account of the set is required
         """
         if not verbose:         # Short account only required
-            return "%s" % self
+            return "{0!s}".format(self)
         else:                   # Long account desired
-            outstr = ["\n<%s: %s>" % (self.__class__, self.name)]
-            outstr.append("%d features" % len(self.features))
+            outstr = ["\n<{0!s}: {1!s}>".format(self.__class__, self.name)]
+            outstr.append("{0:d} features".format(len(self.features)))
             for key in self.features:
-                outstr.append("feature: %s" % self.features[key])
+                outstr.append("feature: {0!s}".format(self.features[key]))
             return "\n".join(outstr)
 
     def __len__(self):
@@ -206,7 +206,7 @@ class FeatureSet(object):
 
     def __str__(self):
         """Returns a formatted string with information about the feature set."""
-        outstr = ["\n<%s: %s %d features>" % (self.__class__, self.name,
+        outstr = ["\n<{0!s}: {1!s} {2:d} features>".format(self.__class__, self.name,
                                               len(self.features))]
         return "\n".join(outstr)
 

--- a/Bio/Graphics/GenomeDiagram/_Graph.py
+++ b/Bio/Graphics/GenomeDiagram/_Graph.py
@@ -251,10 +251,10 @@ class GraphData(object):
 
             Returns a string describing the graph data
         """
-        outstr = ["\nGraphData: %s, ID: %s" % (self.name, self.id)]
-        outstr.append("Number of points: %d" % len(self.data))
-        outstr.append("Mean data value: %s" % self.mean())
-        outstr.append("Sample SD: %.3f" % self.stdev())
-        outstr.append("Minimum: %s\n1Q: %s\n2Q: %s\n3Q: %s\nMaximum: %s" % self.quartiles())
-        outstr.append("Sequence Range: %s..%s" % self.range())
+        outstr = ["\nGraphData: {0!s}, ID: {1!s}".format(self.name, self.id)]
+        outstr.append("Number of points: {0:d}".format(len(self.data)))
+        outstr.append("Mean data value: {0!s}".format(self.mean()))
+        outstr.append("Sample SD: {0:.3f}".format(self.stdev()))
+        outstr.append("Minimum: {0!s}\n1Q: {1!s}\n2Q: {2!s}\n3Q: {3!s}\nMaximum: {4!s}".format(*self.quartiles()))
+        outstr.append("Sequence Range: {0!s}..{1!s}".format(*self.range()))
         return "\n".join(outstr)

--- a/Bio/Graphics/GenomeDiagram/_GraphSet.py
+++ b/Bio/Graphics/GenomeDiagram/_GraphSet.py
@@ -187,12 +187,12 @@ class GraphSet(object):
             Returns a formatted string with information about the set
         """
         if not verbose:
-            return "%s" % self
+            return "{0!s}".format(self)
         else:
-            outstr = ["\n<%s: %s>" % (self.__class__, self.name)]
-            outstr.append("%d graphs" % len(self._graphs))
+            outstr = ["\n<{0!s}: {1!s}>".format(self.__class__, self.name)]
+            outstr.append("{0:d} graphs".format(len(self._graphs)))
             for key in self._graphs:
-                outstr.append("%s" % self._graphs[key])
+                outstr.append("{0!s}".format(self._graphs[key]))
             return "\n".join(outstr)
 
     def __len__(self):
@@ -214,8 +214,8 @@ class GraphSet(object):
 
             Returns a formatted string with information about the feature set
         """
-        outstr = ["\n<%s: %s>" % (self.__class__, self.name)]
-        outstr.append("%d graphs" % len(self._graphs))
+        outstr = ["\n<{0!s}: {1!s}>".format(self.__class__, self.name)]
+        outstr.append("{0:d} graphs".format(len(self._graphs)))
         outstr = "\n".join(outstr)
         return outstr
 

--- a/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
@@ -438,15 +438,13 @@ class LinearDrawer(AbstractDrawer):
             Returns a drawing element that is the tick on the scale
         """
         assert self.start <= tickpos and tickpos <= self.end, \
-               "Tick at %i, but showing %i to %i" \
-               % (tickpos, self.start, self.end)
+               "Tick at {0:d}, but showing {1:d} to {2:d}".format(tickpos, self.start, self.end)
         assert (track.start is None or track.start <= tickpos) and \
                (track.end is None or tickpos <= track.end), \
-               "Tick at %i, but showing %r to %r for track" \
-               % (tickpos, track.start, track.end)
+               "Tick at {0:d}, but showing {1!r} to {2!r} for track".format(tickpos, track.start, track.end)
         fragment, tickx = self.canvas_location(tickpos)  # Tick co-ordinates
         assert fragment >= 0, \
-               "Fragment %i, tickpos %i" % (fragment, tickpos)
+               "Fragment {0:d}, tickpos {1:d}".format(fragment, tickpos)
         tctr = ctr + self.fragment_lines[fragment][0]   # Center line of the track
         tickx += self.x0                # Tick X co-ord
         ticktop = tctr + ticklen        # Y co-ord of tick top
@@ -568,17 +566,17 @@ class LinearDrawer(AbstractDrawer):
                         minval, maxval = quartiles[0], quartiles[4]
                         if graph.center is None:
                             midval = (maxval + minval) / 2.
-                            graph_label_min.append("%.3f" % minval)
-                            graph_label_max.append("%.3f" % maxval)
+                            graph_label_min.append("{0:.3f}".format(minval))
+                            graph_label_max.append("{0:.3f}".format(maxval))
                         else:
                             diff = max((graph.center - minval),
                                        (maxval - graph.center))
                             minval = graph.center - diff
                             maxval = graph.center + diff
                             midval = graph.center
-                            graph_label_mid.append("%.3f" % midval)
-                            graph_label_min.append("%.3f" % minval)
-                            graph_label_max.append("%.3f" % maxval)
+                            graph_label_mid.append("{0:.3f}".format(midval))
+                            graph_label_min.append("{0:.3f}".format(minval))
+                            graph_label_max.append("{0:.3f}".format(maxval))
                     for fragment in range(start_f, end_f + 1):  # Add to all used fragment axes
                         tbtm = btm + self.fragment_lines[fragment][0]
                         tctr = ctr + self.fragment_lines[fragment][0]
@@ -992,13 +990,13 @@ class LinearDrawer(AbstractDrawer):
             top += self.fragment_lines[fragment][0]
         except:     # Only called if the method screws up big time
             print("We've got a screw-up")
-            print("%s %s" % (self.start, self.end))
+            print("{0!s} {1!s}".format(self.start, self.end))
             print(self.fragment_bases)
-            print("%r %r" % (x0, x1))
+            print("{0!r} {1!r}".format(x0, x1))
             for locstart, locend in feature.locations:
                 print(self.canvas_location(locstart))
                 print(self.canvas_location(locend))
-            print('FEATURE\n%s' % feature)
+            print('FEATURE\n{0!s}'.format(feature))
             raise
 
         # Distribution dictionary for various ways of drawing the feature

--- a/Bio/Graphics/GenomeDiagram/_Track.py
+++ b/Bio/Graphics/GenomeDiagram/_Track.py
@@ -346,12 +346,12 @@ class Track(object):
             Returns a formatted string with information about the track
         """
         if not verbose:             # Return the short description
-            return "%s" % self      # Use __str__ method instead
+            return "{0!s}".format(self)      # Use __str__ method instead
         else:                       # Return the long description
-            outstr = ["\n<%s: %s>" % (self.__class__, self.name)]
-            outstr.append("%d sets" % len(self._sets))
+            outstr = ["\n<{0!s}: {1!s}>".format(self.__class__, self.name)]
+            outstr.append("{0:d} sets".format(len(self._sets)))
             for key in self._sets:
-                outstr.append("set: %s" % self._sets[key])
+                outstr.append("set: {0!s}".format(self._sets[key]))
             return "\n".join(outstr)
 
     def __getitem__(self, key):
@@ -368,8 +368,8 @@ class Track(object):
 
             Returns a formatted string with information about the Track
         """
-        outstr = ["\n<%s: %s>" % (self.__class__, self.name)]
-        outstr.append("%d sets" % len(self._sets))
+        outstr = ["\n<{0!s}: {1!s}>".format(self.__class__, self.name)]
+        outstr.append("{0:d} sets".format(len(self._sets)))
         return "\n".join(outstr)
 
 

--- a/Bio/Graphics/__init__.py
+++ b/Bio/Graphics/__init__.py
@@ -65,8 +65,7 @@ def _write(drawing, output_file, format, dpi=72):
         # an attribute error...
         drawmethod = formatdict[format.upper()]  # select drawing method
     except (KeyError, AttributeError):
-        raise ValueError("Output format should be one of %s"
-                         % ", ".join(formatdict))
+        raise ValueError("Output format should be one of {0!s}".format(", ".join(formatdict)))
 
     if drawmethod is None:
         # i.e. We wanted renderPM but it isn't installed

--- a/Bio/HMM/MarkovModel.py
+++ b/Bio/HMM/MarkovModel.py
@@ -199,7 +199,7 @@ class MarkovModelBuilder(object):
         # ensure that all referenced states are valid
         for state in initial_prob:
             assert state in self._state_alphabet.letters, \
-                   "State %s was not found in the sequence alphabet" % state
+                   "State {0!s} was not found in the sequence alphabet".format(state)
 
         # distribute the residual probability, if any
         num_states_not_set =\
@@ -348,7 +348,7 @@ class MarkovModelBuilder(object):
         # check the sanity of adding these states
         for state in [from_state, to_state]:
             assert state in self._state_alphabet.letters, \
-                   "State %s was not found in the sequence alphabet" % state
+                   "State {0!s} was not found in the sequence alphabet".format(state)
 
         # ensure that the states are not already set
         if (from_state, to_state) not in self.transition_prob and \
@@ -363,8 +363,7 @@ class MarkovModelBuilder(object):
                 pseudcount = self.DEFAULT_PSEUDO
             self.transition_pseudo[(from_state, to_state)] = pseudocount
         else:
-            raise KeyError("Transition from %s to %s is already allowed."
-                           % (from_state, to_state))
+            raise KeyError("Transition from {0!s} to {1!s} is already allowed.".format(from_state, to_state))
 
     def destroy_transition(self, from_state, to_state):
         """Restrict transitions between the two states.
@@ -376,8 +375,7 @@ class MarkovModelBuilder(object):
             del self.transition_prob[(from_state, to_state)]
             del self.transition_pseudo[(from_state, to_state)]
         except KeyError:
-            raise KeyError("Transition from %s to %s is already disallowed."
-                           % (from_state, to_state))
+            raise KeyError("Transition from {0!s} to {1!s} is already disallowed.".format(from_state, to_state))
 
     def set_transition_score(self, from_state, to_state, probability):
         """Set the probability of a transition between two states.
@@ -388,8 +386,7 @@ class MarkovModelBuilder(object):
         if (from_state, to_state) in self.transition_prob:
             self.transition_prob[(from_state, to_state)] = probability
         else:
-            raise KeyError("Transition from %s to %s is not allowed."
-                           % (from_state, to_state))
+            raise KeyError("Transition from {0!s} to {1!s} is not allowed.".format(from_state, to_state))
 
     def set_transition_pseudocount(self, from_state, to_state, count):
         """Set the default pseudocount for a transition.
@@ -406,8 +403,7 @@ class MarkovModelBuilder(object):
         if (from_state, to_state) in self.transition_pseudo:
             self.transition_pseudo[(from_state, to_state)] = count
         else:
-            raise KeyError("Transition from %s to %s is not allowed."
-                           % (from_state, to_state))
+            raise KeyError("Transition from {0!s} to {1!s} is not allowed.".format(from_state, to_state))
 
     # --- functions to deal with emissions from the sequence
 
@@ -420,8 +416,7 @@ class MarkovModelBuilder(object):
         if (seq_state, emission_state) in self.emission_prob:
             self.emission_prob[(seq_state, emission_state)] = probability
         else:
-            raise KeyError("Emission of %s from %s is not allowed."
-                           % (emission_state, seq_state))
+            raise KeyError("Emission of {0!s} from {1!s} is not allowed.".format(emission_state, seq_state))
 
     def set_emission_pseudocount(self, seq_state, emission_state, count):
         """Set the default pseudocount for an emission.
@@ -438,8 +433,7 @@ class MarkovModelBuilder(object):
         if (seq_state, emission_state) in self.emission_pseudo:
             self.emission_pseudo[(seq_state, emission_state)] = count
         else:
-            raise KeyError("Emission of %s from %s is not allowed."
-                           % (emission_state, seq_state))
+            raise KeyError("Emission of {0!s} from {1!s} is not allowed.".format(emission_state, seq_state))
 
 
 class HiddenMarkovModel(object):

--- a/Bio/HMM/Trainer.py
+++ b/Bio/HMM/Trainer.py
@@ -403,8 +403,7 @@ class KnownStateTrainer(AbstractTrainer):
             try:
                 emission_counts[(cur_state, cur_emission)] += 1
             except KeyError:
-                raise KeyError("Unexpected emission (%s, %s)"
-                               % (cur_state, cur_emission))
+                raise KeyError("Unexpected emission ({0!s}, {1!s})".format(cur_state, cur_emission))
         return emission_counts
 
     def _count_transitions(self, state_seq, transition_counts):
@@ -424,7 +423,6 @@ class KnownStateTrainer(AbstractTrainer):
             try:
                 transition_counts[(cur_state, next_state)] += 1
             except KeyError:
-                raise KeyError("Unexpected transition (%s, %s)" %
-                               (cur_state, next_state))
+                raise KeyError("Unexpected transition ({0!s}, {1!s})".format(cur_state, next_state))
 
         return transition_counts

--- a/Bio/HMM/Utilities.py
+++ b/Bio/HMM/Utilities.py
@@ -46,11 +46,11 @@ def pretty_print_prediction(emissions, real_state, predicted_state,
         else:
             extension = len(emissions) - cur_position
 
-        print("%s%s" % (emission_title,
+        print("{0!s}{1!s}".format(emission_title,
                         emissions[cur_position:cur_position + seq_length]))
-        print("%s%s" % (real_title,
+        print("{0!s}{1!s}".format(real_title,
                         real_state[cur_position:cur_position + seq_length]))
-        print("%s%s\n" % (predicted_title,
+        print("{0!s}{1!s}\n".format(predicted_title,
                           predicted_state[cur_position:
                                           cur_position + seq_length]))
 

--- a/Bio/Index.py
+++ b/Bio/Index.py
@@ -61,8 +61,7 @@ class _ShelveIndex(dict):
             if version is None:
                 raise IOError("Unrecognized index format")
             elif version != self.__version:
-                raise IOError("Version %s doesn't match my version %s"
-                              % (version, self.__version))
+                raise IOError("Version {0!s} doesn't match my version {1!s}".format(version, self.__version))
 
     def __del__(self):
         if 'data' in self.__dict__:
@@ -96,8 +95,7 @@ class _InMemoryIndex(dict):
             with open(indexname) as handle:
                 version = self._toobj(handle.readline().rstrip())
                 if version != self.__version:
-                    raise IOError("Version %s doesn't match my version %s"
-                                  % (version, self.__version))
+                    raise IOError("Version {0!s} doesn't match my version {1!s}".format(version, self.__version))
                 for line in handle:
                     key, value = line.split()
                     key, value = self._toobj(key), self._toobj(value)
@@ -123,10 +121,9 @@ class _InMemoryIndex(dict):
     def __del__(self):
         if self.__changed:
             with open(self._indexname, 'w') as handle:
-                handle.write("%s\n" % self._tostr(self.__version))
+                handle.write("{0!s}\n".format(self._tostr(self.__version)))
                 for key, value in self.items():
-                    handle.write("%s %s\n" %
-                                 (self._tostr(key), self._tostr(value)))
+                    handle.write("{0!s} {1!s}\n".format(self._tostr(key), self._tostr(value)))
 
     def _tostr(self, obj):
         # I need a representation of the object that's saveable to

--- a/Bio/KDTree/KDTree.py
+++ b/Bio/KDTree/KDTree.py
@@ -63,7 +63,7 @@ def _neighbor_test(nr_points, dim, bucket_size, radius):
         # print("Passed.")
         return True
     else:
-        print("Not passed: %i != %i." % (l1, l2))
+        print("Not passed: {0:d} != {1:d}.".format(l1, l2))
         return False
 
 
@@ -101,7 +101,7 @@ def _test(nr_points, dim, bucket_size, radius):
         # print("Passed.")
         return True
     else:
-        print("Not passed: %i != %i." % (l1, l2))
+        print("Not passed: {0:d} != {1:d}.".format(l1, l2))
         return False
 
 
@@ -155,7 +155,7 @@ class KDTree(object):
         if coords.min() <= -1e6 or coords.max() >= 1e6:
             raise Exception("Points should lie between -1e6 and 1e6")
         if len(coords.shape) != 2 or coords.shape[1] != self.dim:
-            raise Exception("Expected a Nx%i NumPy array" % self.dim)
+            raise Exception("Expected a Nx{0:d} NumPy array".format(self.dim))
         self.kdt.set_data(coords)
         self.built = 1
 
@@ -172,8 +172,7 @@ class KDTree(object):
         if not self.built:
             raise Exception("No point set specified")
         if center.shape != (self.dim,):
-            raise Exception("Expected a %i-dimensional NumPy array"
-                            % self.dim)
+            raise Exception("Expected a {0:d}-dimensional NumPy array".format(self.dim))
         self.kdt.search_center_radius(center, radius)
 
     def get_radii(self):
@@ -260,7 +259,7 @@ if __name__ == "__main__":
     indices = kdtree.all_get_indices()
     radii = kdtree.all_get_radii()
 
-    print("Found %i point pairs within radius %f." % (len(indices), query_radius))
+    print("Found {0:d} point pairs within radius {1:f}.".format(len(indices), query_radius))
 
     # Do 10 individual queries
 
@@ -276,4 +275,4 @@ if __name__ == "__main__":
         radii = kdtree.get_radii()
 
         x, y, z = center
-        print("Found %i points in radius %f around center (%.2f, %.2f, %.2f)." % (len(indices), query_radius, x, y, z))
+        print("Found {0:d} points in radius {1:f} around center ({2:.2f}, {3:.2f}, {4:.2f}).".format(len(indices), query_radius, x, y, z))

--- a/Bio/KEGG/KGML/KGML_parser.py
+++ b/Bio/KEGG/KGML/KGML_parser.py
@@ -158,8 +158,8 @@ class KGMLParser(object):
                 # This should warn us of any unimplemented tags
                 import warnings
                 from Bio import BiopythonParserWarning
-                warnings.warn("Warning: tag %s not implemented in parser" %
-                              element.tag, BiopythonParserWarning)
+                warnings.warn("Warning: tag {0!s} not implemented in parser".format(
+                              element.tag), BiopythonParserWarning)
         return self.pathway
 
 

--- a/Bio/KEGG/KGML/KGML_pathway.py
+++ b/Bio/KEGG/KGML/KGML_pathway.py
@@ -80,8 +80,8 @@ class Pathway(object):
                             '<!DOCTYPE pathway SYSTEM ' +
                             '"http://www.genome.jp/kegg/xml/' +
                             'KGML_v0.7.1_.dtd">',
-                            '<!-- Created by KGML_Pathway.py %s -->' %
-                            time.asctime()])
+                            '<!-- Created by KGML_Pathway.py {0!s} -->'.format(
+                            time.asctime())])
         rough_xml = header + _as_string(ET.tostring(self.element, 'utf-8'))
         reparsed = minidom.parseString(rough_xml)
         return reparsed.toprettyxml(indent="  ")
@@ -90,7 +90,7 @@ class Pathway(object):
         """Add an Entry element to the pathway."""
         # We insist that the node ID is an integer
         assert _is_int_or_long(entry.id), \
-            "Node ID must be an integer, got %s (%s)" % (type(entry.id),
+            "Node ID must be an integer, got {0!s} ({1!s})".format(type(entry.id),
                                                          entry.id)
         entry._pathway = self           # Let the entry know about the pathway
         self.entries[entry.id] = entry
@@ -98,7 +98,7 @@ class Pathway(object):
     def remove_entry(self, entry):
         """Remove an Entry element from the pathway."""
         assert _is_int_or_long(entry.id), \
-            "Node ID must be an integer, got %s (%s)" % (type(entry.id),
+            "Node ID must be an integer, got {0!s} ({1!s})".format(type(entry.id),
                                                          entry.id)
         # We need to remove the entry from any other elements that may
         # contain it, which means removing those elements
@@ -109,17 +109,17 @@ class Pathway(object):
         """Add a Reaction element to the pathway."""
         # We insist that the node ID is an integer and corresponds to an entry
         assert _is_int_or_long(reaction.id), \
-            "Node ID must be an integer, got %s (%s)" % (type(reaction.id),
+            "Node ID must be an integer, got {0!s} ({1!s})".format(type(reaction.id),
                                                          reaction.id)
         assert reaction.id in self.entries, \
-            "Reaction ID %d has no corresponding entry" % reaction.id
+            "Reaction ID {0:d} has no corresponding entry".format(reaction.id)
         reaction._pathway = self    # Let the reaction know about the pathway
         self._reactions[reaction.id] = reaction
 
     def remove_reaction(self, reaction):
         """Remove a Reaction element from the pathway."""
         assert _is_int_or_long(reaction.id), \
-            "Node ID must be an integer, got %s (%s)" % (type(reaction.id),
+            "Node ID must be an integer, got {0!s} ({1!s})".format(type(reaction.id),
                                                          reaction.id)
         # We need to remove the reaction from any other elements that may
         # contain it, which means removing those elements
@@ -137,17 +137,17 @@ class Pathway(object):
 
     def __str__(self):
         """Returns a readable summary description string."""
-        outstr = ['Pathway: %s' % self.title,
-                  'KEGG ID: %s' % self.name,
-                  'Image file: %s' % self.image,
-                  'Organism: %s' % self.org,
-                  'Entries: %d' % len(self.entries),
+        outstr = ['Pathway: {0!s}'.format(self.title),
+                  'KEGG ID: {0!s}'.format(self.name),
+                  'Image file: {0!s}'.format(self.image),
+                  'Organism: {0!s}'.format(self.org),
+                  'Entries: {0:d}'.format(len(self.entries)),
                   'Entry types:']
         for t in ['ortholog', 'enzyme', 'reaction',
                   'gene', 'group', 'compound', 'map']:
             etype = [e for e in self.entries.values() if e.type == t]
             if len(etype):
-                outstr.append('\t%s: %d' % (t, len(etype)))
+                outstr.append('\t{0!s}: {1:d}'.format(t, len(etype)))
         return '\n'.join(outstr) + '\n'
 
     # Assert correct formatting of the pathway name, and other attributes
@@ -156,7 +156,7 @@ class Pathway(object):
 
     def _setname(self, value):
         assert value.startswith('path:'), \
-            "Pathway name should begin with 'path:', got %s" % value
+            "Pathway name should begin with 'path:', got {0!s}".format(value)
         self._name = value
 
     def _delname(self):
@@ -285,12 +285,12 @@ class Entry(object):
 
     def __str__(self):
         """Return readable descriptive string."""
-        outstr = ['Entry node ID: %d' % self.id,
-                  'Names: %s' % self.name,
-                  'Type: %s' % self.type,
-                  'Components: %s' % self.components,
-                  'Reactions: %s' % self.reaction,
-                  'Graphics elements: %d %s' % (len(self.graphics),
+        outstr = ['Entry node ID: {0:d}'.format(self.id),
+                  'Names: {0!s}'.format(self.name),
+                  'Type: {0!s}'.format(self.type),
+                  'Components: {0!s}'.format(self.components),
+                  'Reactions: {0!s}'.format(self.reaction),
+                  'Graphics elements: {0:d} {1!s}'.format(len(self.graphics),
                                                 self.graphics)]
         return '\n'.join(outstr) + '\n'
 
@@ -302,7 +302,7 @@ class Entry(object):
         """
         if self._pathway is not None:
             assert element.id in self._pathway.entries, \
-                "Component %s is not an entry in the pathway" % element.id
+                "Component {0!s} is not an entry in the pathway".format(element.id)
         self.components.add(element)
 
     def remove_component(self, value):
@@ -635,13 +635,13 @@ class Reaction(object):
 
     def __str__(self):
         """Return an informative human-readable string."""
-        outstr = ['Reaction node ID: %s' % self.id,
-                  'Reaction KEGG IDs: %s' % self.name,
-                  'Type: %s' % self.type,
-                  'Substrates: %s' %
-                  ','.join([s.name for s in self.substrates]),
-                  'Products: %s' %
-                  ','.join([s.name for s in self.products]),
+        outstr = ['Reaction node ID: {0!s}'.format(self.id),
+                  'Reaction KEGG IDs: {0!s}'.format(self.name),
+                  'Type: {0!s}'.format(self.type),
+                  'Substrates: {0!s}'.format(
+                  ','.join([s.name for s in self.substrates])),
+                  'Products: {0!s}'.format(
+                  ','.join([s.name for s in self.products])),
                   ]
         return '\n'.join(outstr) + '\n'
 
@@ -649,15 +649,15 @@ class Reaction(object):
         """Add a substrate, identified by its node ID, to the reaction."""
         if self._pathway is not None:
             assert int(substrate_id) in self._pathway.entries, \
-                "Couldn't add substrate, no node ID %d in Pathway" % \
-                int(substrate_id)
+                "Couldn't add substrate, no node ID {0:d} in Pathway".format( \
+                int(substrate_id))
         self._substrates.add(substrate_id)
 
     def add_product(self, product_id):
         """Add a product, identified by its node ID, to the reaction."""
         if self._pathway is not None:
             assert int(product_id) in self._pathway.entries, \
-                "Couldn't add product, no node ID %d in Pathway" % product_id
+                "Couldn't add product, no node ID {0:d} in Pathway".format(product_id)
         self._products.add(int(product_id))
 
     # The node ID is also the node ID of the Entry that corresponds to the
@@ -761,11 +761,11 @@ class Relation(object):
 
     def __str__(self):
         """A useful human-readable string."""
-        outstr = ['Relation (subtypes: %d):' % len(self.subtypes),
+        outstr = ['Relation (subtypes: {0:d}):'.format(len(self.subtypes)),
                   'Entry1:', str(self.entry1),
                   'Entry2:', str(self.entry2)]
         for s in self.subtypes:
-            outstr.extend(['Subtype: %s' % s[0], str(s[1])])
+            outstr.extend(['Subtype: {0!s}'.format(s[0]), str(s[1])])
         return '\n'.join(outstr)
 
     # Properties entry1 and entry2

--- a/Bio/KEGG/REST.py
+++ b/Bio/KEGG/REST.py
@@ -33,11 +33,11 @@ from Bio._py3k import urlopen as _urlopen
 def _q(op, arg1, arg2=None, arg3=None):
     URL = "http://rest.kegg.jp/%s"
     if arg2 and arg3:
-        args = "%s/%s/%s/%s" % (op, arg1, arg2, arg3)
+        args = "{0!s}/{1!s}/{2!s}/{3!s}".format(op, arg1, arg2, arg3)
     elif arg2:
-        args = "%s/%s/%s" % (op, arg1, arg2)
+        args = "{0!s}/{1!s}/{2!s}".format(op, arg1, arg2)
     else:
-        args = "%s/%s" % (op, arg1)
+        args = "{0!s}/{1!s}".format(op, arg1)
     return _urlopen(URL % (args))
 
 

--- a/Bio/MarkovModel.py
+++ b/Bio/MarkovModel.py
@@ -31,7 +31,7 @@ except AttributeError:
     # module to see if we can simplify some of the other functions in
     # this module.
     import warnings
-    warnings.warn("For optimal speed, please update to Numpy version 1.3 or later (current version is %s)" % numpy.__version__)
+    warnings.warn("For optimal speed, please update to Numpy version 1.3 or later (current version is {0!s})".format(numpy.__version__))
 
     def logaddexp(logx, logy):
         if logy - logx > 100:
@@ -76,7 +76,7 @@ class MarkovModel(object):
 def _readline_and_check_start(handle, start):
     line = handle.readline()
     if not line.startswith(start):
-        raise ValueError("I expected %r but got %r" % (start, line))
+        raise ValueError("I expected {0!r} but got {1!r}".format(start, line))
     return line
 
 
@@ -97,21 +97,21 @@ def load(handle):
     mm.p_initial = numpy.zeros(N)
     line = _readline_and_check_start(handle, "INITIAL:")
     for i in range(len(states)):
-        line = _readline_and_check_start(handle, "  %s:" % states[i])
+        line = _readline_and_check_start(handle, "  {0!s}:".format(states[i]))
         mm.p_initial[i] = float(line.split()[-1])
 
     # Load the transition.
     mm.p_transition = numpy.zeros((N, N))
     line = _readline_and_check_start(handle, "TRANSITION:")
     for i in range(len(states)):
-        line = _readline_and_check_start(handle, "  %s:" % states[i])
+        line = _readline_and_check_start(handle, "  {0!s}:".format(states[i]))
         mm.p_transition[i, :] = [float(v) for v in line.split()[1:]]
 
     # Load the emission.
     mm.p_emission = numpy.zeros((N, M))
     line = _readline_and_check_start(handle, "EMISSION:")
     for i in range(len(states)):
-        line = _readline_and_check_start(handle, "  %s:" % states[i])
+        line = _readline_and_check_start(handle, "  {0!s}:".format(states[i]))
         mm.p_emission[i, :] = [float(v) for v in line.split()[1:]]
 
     return mm
@@ -121,17 +121,17 @@ def save(mm, handle):
     """save(mm, handle)"""
     # This will fail if there are spaces in the states or alphabet.
     w = handle.write
-    w("STATES: %s\n" % ' '.join(mm.states))
-    w("ALPHABET: %s\n" % ' '.join(mm.alphabet))
+    w("STATES: {0!s}\n".format(' '.join(mm.states)))
+    w("ALPHABET: {0!s}\n".format(' '.join(mm.alphabet)))
     w("INITIAL:\n")
     for i in range(len(mm.p_initial)):
-        w("  %s: %g\n" % (mm.states[i], mm.p_initial[i]))
+        w("  {0!s}: {1:g}\n".format(mm.states[i], mm.p_initial[i]))
     w("TRANSITION:\n")
     for i in range(len(mm.p_transition)):
-        w("  %s: %s\n" % (mm.states[i], ' '.join(str(x) for x in mm.p_transition[i])))
+        w("  {0!s}: {1!s}\n".format(mm.states[i], ' '.join(str(x) for x in mm.p_transition[i])))
     w("EMISSION:\n")
     for i in range(len(mm.p_emission)):
-        w("  %s: %s\n" % (mm.states[i], ' '.join(str(x) for x in mm.p_emission[i])))
+        w("  {0!s}: {1!s}\n".format(mm.states[i], ' '.join(str(x) for x in mm.p_emission[i])))
 
 
 # XXX allow them to specify starting points
@@ -255,8 +255,7 @@ def _baum_welch(N, M, training_outputs,
             break
         prev_llik = llik
     else:
-        raise RuntimeError("HMM did not converge in %d iterations"
-                           % MAX_ITERATIONS)
+        raise RuntimeError("HMM did not converge in {0:d} iterations".format(MAX_ITERATIONS))
 
     # Return everything back in normal space.
     return [numpy.exp(x) for x in (lp_initial, lp_transition, lp_emission)]
@@ -586,7 +585,7 @@ def _copy_and_check(matrix, desired_shape):
     elif len(matrix.shape) == 2:
         for i in range(len(matrix)):
             if numpy.fabs(sum(matrix[i]) - 1.0) > 0.01:
-                raise ValueError("matrix %d not normalized to 1.0" % i)
+                raise ValueError("matrix {0:d} not normalized to 1.0".format(i))
     else:
         raise ValueError("I don't handle matrices > 2 dimensions")
     return matrix

--- a/Bio/MaxEntropy.py
+++ b/Bio/MaxEntropy.py
@@ -321,4 +321,4 @@ if __name__ == "__main__":
     xe = train(xcar, ycar, user_functions)
     for xv, yv in zip(xcar, ycar):
         xc = classify(xe, xv)
-        print('Pred: %s gives %s y is %s' % (xv, xc, yv))
+        print('Pred: {0!s} gives {1!s} y is {2!s}'.format(xv, xc, yv))

--- a/Bio/NaiveBayes.py
+++ b/Bio/NaiveBayes.py
@@ -73,8 +73,7 @@ def calculate(nb, observation, scale=0):
 
     # Make sure the observation has the right dimensionality.
     if len(observation) != nb.dimensionality:
-        raise ValueError("observation in %d dimension, but classifier in %d"
-                         % (len(observation), nb.dimensionality))
+        raise ValueError("observation in {0:d} dimension, but classifier in {1:d}".format(len(observation), nb.dimensionality))
 
     # Calculate log P(observation|class) for every class.
     n = len(nb.classes)
@@ -232,6 +231,6 @@ if __name__ == "__main__":
 
     carmodel = train(xcar, ycar)
     carresult = classify(carmodel, ['Red', 'Sports', 'Domestic'])
-    print('Is Yes? %s' % carresult)
+    print('Is Yes? {0!s}'.format(carresult))
     carresult = classify(carmodel, ['Red', 'SUV', 'Domestic'])
-    print('Is No? %s' % carresult)
+    print('Is No? {0!s}'.format(carresult))

--- a/Bio/NeuralNetwork/BackPropagation/Layer.py
+++ b/Bio/NeuralNetwork/BackPropagation/Layer.py
@@ -51,7 +51,7 @@ class AbstractLayer(object):
     def __str__(self):
         """Debugging output.
         """
-        return "weights: %s" % self.weights
+        return "weights: {0!s}".format(self.weights)
 
     def set_weight(self, this_node, next_node, value):
         """Set a weight value from one node to the next.

--- a/Bio/NeuralNetwork/Gene/Motif.py
+++ b/Bio/NeuralNetwork/Gene/Motif.py
@@ -72,8 +72,7 @@ class MotifFinder(object):
             # if we are working with alphabets, make sure we are consistent
             if alphabet is not None:
                 assert seq_record.seq.alphabet == alphabet, \
-                       "Working with alphabet %s and got %s" % \
-                       (alphabet, seq_record.seq.alphabet)
+                       "Working with alphabet {0!s} and got {1!s}".format(alphabet, seq_record.seq.alphabet)
 
             # now start finding motifs in the sequence
             for start in range(len(seq_record.seq) - (motif_size - 1)):
@@ -171,8 +170,7 @@ class MotifCoder(object):
         self._motif_size = len(self._motifs[0])
         for motif in self._motifs:
             if len(motif) != self._motif_size:
-                raise ValueError("Motif %s given, expected motif size %s"
-                                 % (motif, self._motif_size))
+                raise ValueError("Motif {0!s} given, expected motif size {1!s}".format(motif, self._motif_size))
 
     def representation(self, sequence):
         """Represent a sequence as a set of motifs.

--- a/Bio/NeuralNetwork/Gene/Pattern.py
+++ b/Bio/NeuralNetwork/Gene/Pattern.py
@@ -56,7 +56,7 @@ class PatternIO(object):
             else:
                 string_pattern = pattern
 
-            output_handle.write("%s\n" % string_pattern)
+            output_handle.write("{0!s}\n".format(string_pattern))
 
     def write_seq(self, seq_pattern_list, output_handle):
         """Convenience function to write Seq objects to a file.
@@ -74,7 +74,7 @@ class PatternIO(object):
             elif isinstance(seq_pattern, Seq):
                 all_patterns.append(str(seq_pattern))
             else:
-                raise ValueError("Unexpected pattern type %r" % seq_pattern)
+                raise ValueError("Unexpected pattern type {0!r}".format(seq_pattern))
 
         self.write(all_patterns, output_handle)
 
@@ -104,8 +104,7 @@ class PatternIO(object):
                 for pattern_item in test_pattern:
                     pattern_seq = Seq(pattern_item, self._alphabet)
                     if not(_verify_alphabet(pattern_seq)):
-                        raise ValueError("Pattern %s not matching alphabet %s"
-                                         % (cur_pattern, self._alphabet))
+                        raise ValueError("Pattern {0!s} not matching alphabet {1!s}".format(cur_pattern, self._alphabet))
 
             all_patterns.append(cur_pattern)
 

--- a/Bio/NeuralNetwork/Gene/Schema.py
+++ b/Bio/NeuralNetwork/Gene/Schema.py
@@ -83,16 +83,14 @@ class Schema(object):
             try:
                 letter_matches = self._ambiguity_info[motif_letter]
             except KeyError:
-                raise KeyError("No match information for letter %s"
-                               % motif_letter)
+                raise KeyError("No match information for letter {0!s}".format(motif_letter))
 
             if len(letter_matches) > 1:
                 regexp_match = "[" + letter_matches + "]"
             elif len(letter_matches) == 1:
                 regexp_match = letter_matches
             else:
-                raise ValueError("Unexpected match information %s"
-                                 % letter_matches)
+                raise ValueError("Unexpected match information {0!s}".format(letter_matches))
 
             regexp_string += regexp_match
 
@@ -111,8 +109,7 @@ class Schema(object):
             try:
                 letter_matches = self._ambiguity_info[motif_letter]
             except KeyError:
-                raise KeyError("No match information for letter %s"
-                               % motif_letter)
+                raise KeyError("No match information for letter {0!s}".format(motif_letter))
 
             if len(letter_matches) > 1:
                 ambig_positions.append(motif_letter_pos)
@@ -683,8 +680,7 @@ class SchemaFactory(object):
 
             # check for big loops in which we can't find a new schema
             assert num_tries < 150, \
-                   "Could not generate schema in %s tries from %s with %s" \
-                   % (num_tries, motif_list, cur_schemas)
+                   "Could not generate schema in {0!s} tries from {1!s} with {2!s}".format(num_tries, motif_list, cur_schemas)
 
         return new_schema, matching_motifs
 

--- a/Bio/NeuralNetwork/Gene/Signature.py
+++ b/Bio/NeuralNetwork/Gene/Signature.py
@@ -74,8 +74,7 @@ class SignatureFinder(object):
             # if we are working with alphabets, make sure we are consistent
             if alphabet is not None:
                 assert seq_record.seq.alphabet == alphabet, \
-                       "Working with alphabet %s and got %s" % \
-                       (alphabet, seq_record.seq.alphabet)
+                       "Working with alphabet {0!s} and got {1!s}".format(alphabet, seq_record.seq.alphabet)
 
             # now start finding signatures in the sequence
             largest_sig_size = sig_size * 2 + max_gap
@@ -148,16 +147,13 @@ class SignatureCoder(object):
             second_sig_size = len(self._signatures[0][1])
 
             assert first_sig_size == second_sig_size, \
-                   "Ends of the signature do not match: %s" \
-                   % self._signatures[0]
+                   "Ends of the signature do not match: {0!s}".format(self._signatures[0])
 
             for sig in self._signatures:
                 assert len(sig[0]) == first_sig_size, \
-                       "Got first part of signature %s, expected size %s" % \
-                       (sig[0], first_sig_size)
+                       "Got first part of signature {0!s}, expected size {1!s}".format(sig[0], first_sig_size)
                 assert len(sig[1]) == second_sig_size, \
-                       "Got second part of signature %s, expected size %s" % \
-                       (sig[1], second_sig_size)
+                       "Got second part of signature {0!s}, expected size {1!s}".format(sig[1], second_sig_size)
 
     def representation(self, sequence):
         """Convert a sequence into a representation of its signatures.

--- a/Bio/NeuralNetwork/StopTraining.py
+++ b/Bio/NeuralNetwork/StopTraining.py
@@ -58,8 +58,7 @@ class ValidationIncreaseStop(object):
         """
         if num_iterations % 10 == 0:
             if self.verbose:
-                print("%s; Training Error:%s; Validation Error:%s"
-                      % (num_iterations, training_error, validation_error))
+                print("{0!s}; Training Error:{1!s}; Validation Error:{2!s}".format(num_iterations, training_error, validation_error))
 
         if num_iterations > self.min_iterations:
             if self.last_error is not None:

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -200,8 +200,8 @@ class StepMatrix(object):
         return self
 
     def smprint(self, name='your_name_here'):
-        matrix = 'usertype %s stepmatrix=%d\n' % (name, len(self.symbols))
-        matrix += '        %s\n' % '        '.join(self.symbols)
+        matrix = 'usertype {0!s} stepmatrix={1:d}\n'.format(name, len(self.symbols))
+        matrix += '        {0!s}\n'.format('        '.join(self.symbols))
         for x in self.symbols:
             matrix += '[%s]'.ljust(8) % x
             for y in self.symbols:
@@ -321,9 +321,9 @@ def _compact4nexus(orig_list):
                     shortlist.append(str(sub[0] + 1))
                 else:
                     if step == 1:
-                        shortlist.append('%d-%d' % (sub[0] + 1, sub[-1] + 1))
+                        shortlist.append('{0:d}-{1:d}'.format(sub[0] + 1, sub[-1] + 1))
                     else:
-                        shortlist.append('%d-%d\\%d' % (sub[0] + 1, sub[-1] + 1, step))
+                        shortlist.append('{0:d}-{1:d}\\{2:d}'.format(sub[0] + 1, sub[-1] + 1, step))
                 clist = clist[i:]
                 break
     return ' '.join(shortlist)
@@ -354,10 +354,10 @@ def combine(matrices):
 
     # rename taxon sets and character sets and name them with prefix
     for cn, cs in combined.charsets.items():
-        combined.charsets['%s.%s' % (name, cn)] = cs
+        combined.charsets['{0!s}.{1!s}'.format(name, cn)] = cs
         del combined.charsets[cn]
     for tn, ts in combined.taxsets.items():
-        combined.taxsets['%s.%s' % (name, tn)] = ts
+        combined.taxsets['{0!s}.{1!s}'.format(name, tn)] = ts
         del combined.taxsets[tn]
     # previous partitions usually don't make much sense in combined matrix
     # just initiate one new partition parted by single matrices
@@ -385,12 +385,12 @@ def combine(matrices):
                                     combined.alphabet)
         combined.taxlabels.extend(m_only)    # new taxon list
         for cn, cs in m.charsets.items():  # adjust character sets for new matrix
-            combined.charsets['%s.%s' % (n, cn)] = [x + combined.nchar for x in cs]
+            combined.charsets['{0!s}.{1!s}'.format(n, cn)] = [x + combined.nchar for x in cs]
         if m.taxsets:
             if not combined.taxsets:
                 combined.taxsets = {}
             # update taxon sets
-            combined.taxsets.update(dict(('%s.%s' % (n, tn), ts)
+            combined.taxsets.update(dict(('{0!s}.{1!s}'.format(n, tn), ts)
                                          for tn, ts in m.taxsets.items()))
         # update new charpartition
         combined.charpartitions['combined'][n] = list(range(combined.nchar, combined.nchar + m.nchar))
@@ -550,7 +550,7 @@ class Commandline(object):
                     for token in token_indices:
                         self.options[options[token].lower()] = None
                 except ValueError:
-                    raise NexusError('Incorrect formatting in line: %s' % line)
+                    raise NexusError('Incorrect formatting in line: {0!s}'.format(line))
 
 
 class Block(object):
@@ -629,7 +629,7 @@ class Nexus(object):
                 self.filename = 'input_string'
             else:
                 print(input.strip()[:50])
-                raise NexusError('Unrecognized input: %s ...' % input[:100])
+                raise NexusError('Unrecognized input: {0!s} ...'.format(input[:100]))
         file_contents = file_contents.strip()
         if file_contents.startswith('#NEXUS'):
             file_contents = file_contents[6:]
@@ -664,7 +664,7 @@ class Nexus(object):
                     inblock = True
                     title = cl.split()[1].lower()
                 else:
-                    raise NexusError('Illegal block nesting in block %s' % title)
+                    raise NexusError('Illegal block nesting in block {0!s}'.format(title))
             elif cl.lower().startswith('end'):
                 if inblock:
                     inblock = False
@@ -692,7 +692,7 @@ class Nexus(object):
             try:
                 getattr(self, '_' + line.command)(line.options)
             except AttributeError:
-                raise NexusError('Unknown command: %s ' % line.command)
+                raise NexusError('Unknown command: {0!s} '.format(line.command))
 
     def _title(self, options):
         pass
@@ -852,7 +852,7 @@ class Nexus(object):
             if c is None:
                 break
             elif c != ',':
-                raise NexusError('Missing \',\' in line %s.' % options)
+                raise NexusError('Missing \',\' in line {0!s}.'.format(options))
 
     def _charstatelabels(self, options):
         self.charlabels = {}
@@ -886,21 +886,21 @@ class Nexus(object):
             elif c != ',':
                 # Check if states are defined, otherwise report error
                 if c != '/':
-                    raise NexusError('Missing \',\' in line %s.' % options)
+                    raise NexusError('Missing \',\' in line {0!s}.'.format(options))
 
                 # Get the first state
                 state = quotestrip(opts.next_word())
 
                 if state is None:
                     raise NexusError(
-                        'Missing character state in line %s.' % options)
+                        'Missing character state in line {0!s}.'.format(options))
 
                 while True:
                     # Make sure current state does not exceed number of
                     # available symbols
                     if len(self.statelabels[identifier]) > len(self.symbols):
                         raise NexusError(
-                            'Character states exceed number of available symbols in line %s.' % options)
+                            'Character states exceed number of available symbols in line {0!s}.'.format(options))
 
                     # Add the character state to the statelabels
                     self.statelabels[identifier].append(state)
@@ -1019,8 +1019,7 @@ class Nexus(object):
         # check all sequences for length according to nchar
         for taxon in self.matrix:
             if len(self.matrix[taxon]) != self.nchar:
-                raise NexusError('Matrix Nchar %d does not match data length (%d) for taxon %s'
-                                 % (self.nchar, len(self.matrix[taxon]), taxon))
+                raise NexusError('Matrix Nchar {0:d} does not match data length ({1:d}) for taxon {2!s}'.format(self.nchar, len(self.matrix[taxon]), taxon))
         # check that taxlabels is identical with matrix.keys. If not, it's a problem
         matrixkeys = sorted(self.matrix)
         taxlabelssort = sorted(self.taxlabels[:])
@@ -1042,11 +1041,11 @@ class Nexus(object):
                 if c is None:
                     break
                 elif c != ',':
-                    raise NexusError('Missing \',\' in line %s.' % options)
+                    raise NexusError('Missing \',\' in line {0!s}.'.format(options))
             except NexusError:
                 raise
             except Exception:  # TODO: ValueError?
-                raise NexusError('Format error in line %s.' % options)
+                raise NexusError('Format error in line {0!s}.'.format(options))
 
     def _utree(self, options):
         """Some software (clustalx) uses 'utree' to denote an unrooted tree."""
@@ -1059,16 +1058,14 @@ class Nexus(object):
             dummy = opts.next_nonwhitespace()
         name = opts.next_word()
         if opts.next_nonwhitespace() != '=':
-            raise NexusError('Syntax error in tree description: %s'
-                             % options[:50])
+            raise NexusError('Syntax error in tree description: {0!s}'.format(options[:50]))
         rooted = False
         weight = 1.0
         while opts.peek_nonwhitespace() == '[':
             opts.next_nonwhitespace()  # discard opening bracket
             symbol = next(opts)
             if symbol != '&':
-                raise NexusError('Illegal special comment [%s...] in tree description: %s'
-                                 % (symbol, options[:50]))
+                raise NexusError('Illegal special comment [{0!s}...] in tree description: {1!s}'.format(symbol, options[:50]))
             special = next(opts)
             value = opts.next_until(']')
             next(opts)  # discard closing bracket
@@ -1086,8 +1083,7 @@ class Nexus(object):
                 try:
                     tree.node(n).data.taxon = safename(self.translate[int(tree.node(n).data.taxon)])
                 except (ValueError, KeyError):
-                    raise NexusError('Unable to substitute %s using \'translate\' data.'
-                                     % tree.node(n).data.taxon)
+                    raise NexusError('Unable to substitute {0!s} using \'translate\' data.'.format(tree.node(n).data.taxon))
         self.trees.append(tree)
 
     def _apply_block_structure(self, title, lines):
@@ -1111,7 +1107,7 @@ class Nexus(object):
         opts = CharBuffer(options)
         name = self._name_n_vector(opts)
         if not name:
-            raise NexusError('Formatting error in taxpartition: %s ' % options)
+            raise NexusError('Formatting error in taxpartition: {0!s} '.format(options))
         # now collect thesubbpartitions and parse them
         # subpartitons separated by commas - which unfortunately could be part of a quoted identifier...
         # this is rather unelegant, but we have to avoid double-parsing and potential change of special nexus-words
@@ -1142,7 +1138,7 @@ class Nexus(object):
         # mcclade calls it CodonPositions, but you never know...
         codonname = [n for n in self.charpartitions if n not in prev_partitions]
         if codonname == [] or len(codonname) > 1:
-            raise NexusError('Formatting Error in codonposset: %s ' % options)
+            raise NexusError('Formatting Error in codonposset: {0!s} '.format(options))
         else:
             self.codonposset = codonname[0]
 
@@ -1155,7 +1151,7 @@ class Nexus(object):
         opts = CharBuffer(options)
         name = self._name_n_vector(opts)
         if not name:
-            raise NexusError('Formatting error in charpartition: %s ' % options)
+            raise NexusError('Formatting error in charpartition: {0!s} '.format(options))
         # now collect the subpartitions and parse them
         # subpartitions separated by commas - which unfortunately could be part
         # of a quoted identifier...
@@ -1184,7 +1180,7 @@ class Nexus(object):
         name = self._name_n_vector(opts, separator=separator)
         indices = self._parse_list(opts, set_type=set_type)
         if indices is None:
-            raise NexusError('Formatting error in line: %s ' % options)
+            raise NexusError('Formatting error in line: {0!s} '.format(options))
         return name, indices
 
     def _name_n_vector(self, opts, separator='='):
@@ -1195,20 +1191,18 @@ class Nexus(object):
         if name == '*':
             name = opts.next_word()
         if not name:
-            raise NexusError('Formatting error in line: %s ' % rest)
+            raise NexusError('Formatting error in line: {0!s} '.format(rest))
         name = quotestrip(name)
         if opts.peek_nonwhitespace == '(':
             open = opts.next_nonwhitespace()
             qualifier = open.next_word()
             close = opts.next_nonwhitespace()
             if qualifier.lower() == 'vector':
-                raise NexusError('Unsupported VECTOR format in line %s'
-                                 % (opts))
+                raise NexusError('Unsupported VECTOR format in line {0!s}'.format((opts)))
             elif qualifier.lower() != 'standard':
-                raise NexusError('Unknown qualifier %s in line %s'
-                                 % (qualifier, opts))
+                raise NexusError('Unknown qualifier {0!s} in line {1!s}'.format(qualifier, opts))
         if opts.next_nonwhitespace() != separator:
-            raise NexusError('Formatting error in line: %s ' % rest)
+            raise NexusError('Formatting error in line: {0!s} '.format(rest))
         return name
 
     def _parse_list(self, options_buffer, set_type):
@@ -1240,8 +1234,7 @@ class Nexus(object):
                             plain_list.extend(range(start, end + 1, step))
                         else:
                             if isinstance(start, list) or isinstance(end, list):
-                                raise NexusError('Name if character sets not allowed in range definition: %s'
-                                                 % identifier)
+                                raise NexusError('Name if character sets not allowed in range definition: {0!s}'.format(identifier))
                             start = self.taxlabels.index(start)
                             end = self.taxlabels.index(end)
                             taxrange = self.taxlabels[start:end + 1]
@@ -1286,14 +1279,12 @@ class Nexus(object):
                 elif self.charsets and identifier in self.charsets:
                     return self.charsets[identifier]
                 else:
-                    raise NexusError('Unknown character identifier: %s'
-                                     % identifier)
+                    raise NexusError('Unknown character identifier: {0!s}'.format(identifier))
             else:
                 if n <= self.nchar:
                     return n - 1
                 else:
-                    raise NexusError('Illegal character identifier: %d>nchar (=%d).'
-                                     % (identifier, self.nchar))
+                    raise NexusError('Illegal character identifier: {0:d}>nchar (={1:d}).'.format(identifier, self.nchar))
         elif set_type == TAXSET:
             try:
                 n = int(identifier)
@@ -1304,16 +1295,14 @@ class Nexus(object):
                 elif self.taxsets and identifier in self.taxsets:
                     return self.taxsets[identifier]
                 else:
-                    raise NexusError('Unknown taxon identifier: %s'
-                                     % identifier)
+                    raise NexusError('Unknown taxon identifier: {0!s}'.format(identifier))
             else:
                 if n > 0 and n <= self.ntax:
                     return self.taxlabels[n - 1]
                 else:
-                    raise NexusError('Illegal taxon identifier: %d>ntax (=%d).'
-                                     % (identifier, self.ntax))
+                    raise NexusError('Illegal taxon identifier: {0:d}>ntax (={1:d}).'.format(identifier, self.ntax))
         else:
-            raise NexusError('Unknown set specification: %s.' % set_type)
+            raise NexusError('Unknown set specification: {0!s}.'.format(set_type))
 
     def _stateset(self, options):
         # Not implemented
@@ -1397,11 +1386,10 @@ class Nexus(object):
         if not filename:
             filename = self.filename
         if [t for t in delete if not self._check_taxlabels(t)]:
-            raise NexusError('Unknown taxa: %s'
-                             % ', '.join(set(delete).difference(set(self.taxlabels))))
+            raise NexusError('Unknown taxa: {0!s}'.format(', '.join(set(delete).difference(set(self.taxlabels)))))
         if interleave_by_partition:
             if interleave_by_partition not in self.charpartitions:
-                raise NexusError('Unknown partition: %r' % interleave_by_partition)
+                raise NexusError('Unknown partition: {0!r}'.format(interleave_by_partition))
             else:
                 partition = self.charpartitions[interleave_by_partition]
                 # we need to sort the partition names by starting position
@@ -1424,7 +1412,7 @@ class Nexus(object):
             if comment:
                 fh.write('[' + comment + ']\n')
             fh.write('begin data;\n')
-            fh.write('\tdimensions ntax=%d nchar=%d;\n' % (ntax_adjusted, nchar_adjusted))
+            fh.write('\tdimensions ntax={0:d} nchar={1:d};\n'.format(ntax_adjusted, nchar_adjusted))
             fh.write('\tformat datatype=' + self.datatype)
             if self.respectcase:
                 fh.write(' respectcase')
@@ -1447,7 +1435,7 @@ class Nexus(object):
                 newcharlabels = self._adjust_charlabels(exclude=exclude)
                 clkeys = sorted(newcharlabels)
                 fh.write('charlabels '
-                         + ', '.join("%s %s" % (k + 1, safename(newcharlabels[k])) for k in clkeys)
+                         + ', '.join("{0!s} {1!s}".format(k + 1, safename(newcharlabels[k])) for k in clkeys)
                          + ';\n')
             fh.write('matrix\n')
             if not blocksize:
@@ -1462,7 +1450,7 @@ class Nexus(object):
                 # to excluded characters
                 seek = 0
                 for p in names:
-                    fh.write('[%s: %s]\n' % (interleave_by_partition, p))
+                    fh.write('[{0!s}: {1!s}]\n'.format(interleave_by_partition, p))
                     if len(newpartition[p]) > 0:
                         for taxon in undelete:
                             fh.write(safename(taxon, mrbayes=mrbayes).ljust(namelength + 1))
@@ -1521,11 +1509,11 @@ class Nexus(object):
             for n, ns in self.charsets.items():
                 cset = [offlist[c] for c in ns if c not in exclude]
                 if cset:
-                    setsb.append('charset %s = %s' % (safename(n), _compact4nexus(cset)))
+                    setsb.append('charset {0!s} = {1!s}'.format(safename(n), _compact4nexus(cset)))
             for n, s in self.taxsets.items():
                 tset = [safename(t, mrbayes=mrbayes) for t in s if t not in delete]
                 if tset:
-                    setsb.append('taxset %s = %s' % (safename(n), ' '.join(tset)))
+                    setsb.append('taxset {0!s} = {1!s}'.format(safename(n), ' '.join(tset)))
         for n, p in self.charpartitions.items():
             if not include_codons and n == CODONPOSITIONS:
                 continue
@@ -1545,8 +1533,8 @@ class Nexus(object):
                     command = 'codonposset'
                 else:
                     command = 'charpartition'
-                setsb.append('%s %s = %s' % (command, safename(n),
-                                             ', '.join('%s: %s' % (sn, _compact4nexus(newpartition[sn]))
+                setsb.append('{0!s} {1!s} = {2!s}'.format(command, safename(n),
+                                             ', '.join('{0!s}: {1!s}'.format(sn, _compact4nexus(newpartition[sn]))
                                                        for sn in names if sn in newpartition)))
         # now write charpartititions, much easier than charpartitions
         for n, p in self.taxpartitions.items():
@@ -1557,8 +1545,8 @@ class Nexus(object):
                 if nsp:
                     newpartition[sn] = nsp
             if newpartition:
-                setsb.append('taxpartition %s = %s' % (safename(n),
-                             ', '.join('%s: %s' % (safename(sn),
+                setsb.append('taxpartition {0!s} = {1!s}'.format(safename(n),
+                             ', '.join('{0!s}: {1!s}'.format(safename(sn),
                                                    ' '.join(safename(x) for x in newpartition[sn]))
                                        for sn in names if sn in newpartition)))
         # add 'end' and return everything
@@ -1593,9 +1581,9 @@ class Nexus(object):
             else:
                 filename = self.filename + '.phy'
         with open(filename, 'w') as fh:
-            fh.write('%d %d\n' % (self.ntax, self.nchar))
+            fh.write('{0:d} {1:d}\n'.format(self.ntax, self.nchar))
             for taxon in self.taxlabels:
-                fh.write('%s %s\n' % (safename(taxon), str(self.matrix[taxon])))
+                fh.write('{0!s} {1!s}\n'.format(safename(taxon), str(self.matrix[taxon])))
         return filename
 
     def constant(self, matrix=None, delete=[], exclude=[]):
@@ -1686,8 +1674,7 @@ class Nexus(object):
         if not matrix:
             matrix = self.matrix
         if [t for t in delete if not self._check_taxlabels(t)]:
-            raise NexusError('Unknown taxa: %s'
-                             % ', '.join(set(delete).difference(self.taxlabels)))
+            raise NexusError('Unknown taxa: {0!s}'.format(', '.join(set(delete).difference(self.taxlabels))))
         if exclude != []:
             undelete = [t for t in self.taxlabels if t in matrix and t not in delete]
             if not undelete:
@@ -1777,7 +1764,7 @@ class Nexus(object):
             return set
 
         if pos < 0 or pos > self.nchar:
-            raise NexusError('Illegal gap position: %d' % pos)
+            raise NexusError('Illegal gap position: {0:d}'.format(pos))
         if n == 0:
             return
         sitesm = list(zip(*[str(self.matrix[t]) for t in self.taxlabels]))
@@ -1857,7 +1844,7 @@ class Nexus(object):
             else:
                 sequence = sequence[:end + 1] + missing * (length - end - 1)
                 sequence = start * missing + sequence[start:]
-            assert length == len(sequence), 'Illegal sequence manipulation in Nexus.terminal_gap_to_missing in taxon %s' % taxon
+            assert length == len(sequence), 'Illegal sequence manipulation in Nexus.terminal_gap_to_missing in taxon {0!s}'.format(taxon)
             self.matrix[taxon] = Seq(sequence, self.alphabet)
 
 
@@ -1873,7 +1860,7 @@ else:
         decommented = cnexus.scanfile(file_contents)
         # check for unmatched parentheses
         if decommented == '[' or decommented == ']':
-            raise NexusError('Unmatched %s' % decommented)
+            raise NexusError('Unmatched {0!s}'.format(decommented))
         # cnexus can't return lists, so in analogy we separate
         # commandlines with chr(7) (a character that shouldn't be part of a
         # nexus file under normal circumstances)

--- a/Bio/Nexus/Trees.py
+++ b/Bio/Nexus/Trees.py
@@ -159,8 +159,7 @@ class Tree(Nodes.Chain):
             nc_start = text.find(NODECOMMENT_START)
             nc_end = text.find(NODECOMMENT_END)
             if nc_end == -1:
-                raise TreeError('Error in tree description: Found %s without matching %s'
-                                % (NODECOMMENT_START, NODECOMMENT_END))
+                raise TreeError('Error in tree description: Found {0!s} without matching {1!s}'.format(NODECOMMENT_START, NODECOMMENT_END))
             nodecomment = text[nc_start:nc_end + 1]
             text = text[:nc_start] + text[nc_end + 1:]
 
@@ -196,7 +195,7 @@ class Tree(Nodes.Chain):
         node = node(self,node_id)
         """
         if node_id not in self.chain:
-            raise TreeError('Unknown node_id: %d' % node_id)
+            raise TreeError('Unknown node_id: {0:d}'.format(node_id))
         return self.chain[node_id]
 
     def split(self, parent_id=None, n=2, branchlength=1.0):
@@ -240,9 +239,9 @@ class Tree(Nodes.Chain):
 
         id = self.search_taxon(taxon)
         if id is None:
-            raise TreeError('Taxon not found: %s' % taxon)
+            raise TreeError('Taxon not found: {0!s}'.format(taxon))
         elif id not in self.get_terminals():
-            raise TreeError('Not a terminal taxon: %s' % taxon)
+            raise TreeError('Not a terminal taxon: {0!s}'.format(taxon))
         else:
             prev = self.unlink(id)
             self.kill(id)
@@ -267,7 +266,7 @@ class Tree(Nodes.Chain):
         if node_id is None:
             node_id = self.root
         if node_id not in self.chain:
-            raise TreeError('Unknown node_id: %d.' % node_id)
+            raise TreeError('Unknown node_id: {0:d}.'.format(node_id))
         if self.chain[node_id].succ == []:
             if self.chain[node_id].data:
                 return [self.chain[node_id].data.taxon]
@@ -364,7 +363,7 @@ class Tree(Nodes.Chain):
                 print(node)
                 print(self.node(node).succ)
                 for n in self.node(node).succ:
-                    print("%s %s" % (n, self.set_subtree(n)))
+                    print("{0!s} {1!s}".format(n, self.set_subtree(n)))
                 print([self.set_subtree(n) for n in self.node(node).succ])
                 raise
 
@@ -386,9 +385,9 @@ class Tree(Nodes.Chain):
         missing1 = set(tree2.get_taxa()) - set(self.get_taxa())
         if strict and (missing1 or missing2):
             if missing1:
-                print('Taxon/taxa %s is/are missing in tree %s' % (','.join(missing1), self.name))
+                print('Taxon/taxa {0!s} is/are missing in tree {1!s}'.format(','.join(missing1), self.name))
             if missing2:
-                print('Taxon/taxa %s is/are missing in tree %s' % (','.join(missing2), tree2.name))
+                print('Taxon/taxa {0!s} is/are missing in tree {1!s}'.format(','.join(missing2), tree2.name))
             raise TreeError('Can\'t compare trees with different taxon compositions.')
         t1 = [(set(self.get_taxa(n)), self.node(n).data.support) for n in self.all_ids() if
             self.node(n).succ and
@@ -538,24 +537,24 @@ class Tree(Nodes.Chain):
                 tx = n.data.taxon
                 if not tx:
                     tx = '-'
-                blength = "%0.2f" % n.data.branchlength
+                blength = "{0:0.2f}".format(n.data.branchlength)
                 if blength is None:
                     blength = '-'
                     sum_blength = '-'
                 else:
-                    sum_blength = "%0.2f" % self.sum_branchlength(node=i)
+                    sum_blength = "{0:0.2f}".format(self.sum_branchlength(node=i))
                 support = n.data.support
                 if support is None:
                     support = '-'
                 else:
-                    support = "%0.2f" % support
+                    support = "{0:0.2f}".format(support)
                 comment = n.data.comment
                 if comment is None:
                     comment = '-'
                 table.append((str(i), tx, str(n.prev), str(n.succ),
                              blength, sum_blength, support, comment))
-        print('\n'.join('%3s %32s %15s %15s %8s %10s %8s %20s' % l for l in table))
-        print('\nRoot:  %s' % self.root)
+        print('\n'.join('{0:3!s} {1:32!s} {2:15!s} {3:15!s} {4:8!s} {5:10!s} {6:8!s} {7:20!s}'.format(*l) for l in table))
+        print('\nRoot:  {0!s}'.format(self.root))
 
     def to_string(self, support_as_branchlengths=False, branchlengths_only=False, plain=True, plain_newick=False, ladderize=None, ignore_comments=True):
         """Return a paup compatible tree line."""
@@ -574,23 +573,23 @@ class Tree(Nodes.Chain):
                 info_string = ''
             elif self.support_as_branchlengths:  # support as branchlengths (eg. PAUP), ignore actual branchlengths
                 if terminal:    # terminal branches have 100% support
-                    info_string = ':%1.2f' % self.max_support
+                    info_string = ':{0:1.2f}'.format(self.max_support)
                 elif data.support:
-                    info_string = ':%1.2f' % (data.support)
+                    info_string = ':{0:1.2f}'.format((data.support))
                 else:
                     info_string = ':0.00'
             elif self.branchlengths_only:  # write only branchlengths, ignore support
-                info_string = ':%1.5f' % (data.branchlength)
+                info_string = ':{0:1.5f}'.format((data.branchlength))
             else:   # write suport and branchlengths (e.g. .con tree of mrbayes)
                 if terminal:
-                    info_string = ':%1.5f' % (data.branchlength)
+                    info_string = ':{0:1.5f}'.format((data.branchlength))
                 else:
                     if data.branchlength is not None and data.support is not None:  # we have blen and suppport
-                        info_string = '%1.2f:%1.5f' % (data.support, data.branchlength)
+                        info_string = '{0:1.2f}:{1:1.5f}'.format(data.support, data.branchlength)
                     elif data.branchlength is not None:                             # we have only blen
-                        info_string = '0.00000:%1.5f' % (data.branchlength)
+                        info_string = '0.00000:{0:1.5f}'.format((data.branchlength))
                     elif data.support is not None:                                  # we have only support
-                        info_string = '%1.2f:0.00000' % (data.support)
+                        info_string = '{0:1.2f}:0.00000'.format((data.support))
                     else:
                         info_string = '0.00:0.00000'
             if not ignore_comments and hasattr(data, 'nodecomment'):
@@ -619,7 +618,7 @@ class Tree(Nodes.Chain):
             else:
                 succnodes = ladderize_nodes(self.node(node).succ, ladderize=ladderize)
                 subtrees = [newickize(sn, ladderize=ladderize) for sn in succnodes]
-                return '(%s)%s' % (','.join(subtrees), make_info_string(self.node(node).data))
+                return '({0!s}){1!s}'.format(','.join(subtrees), make_info_string(self.node(node).data))
 
         treeline = ['tree']
         if self.name:
@@ -628,12 +627,12 @@ class Tree(Nodes.Chain):
             treeline.append('a_tree')
         treeline.append('=')
         if self.weight != 1:
-            treeline.append('[&W%s]' % str(round(float(self.weight), 3)))
+            treeline.append('[&W{0!s}]'.format(str(round(float(self.weight), 3))))
         if self.rooted:
             treeline.append('[&R]')
         succnodes = ladderize_nodes(self.node(self.root).succ)
         subtrees = [newickize(sn, ladderize=ladderize) for sn in succnodes]
-        treeline.append('(%s)' % ','.join(subtrees))
+        treeline.append('({0!s})'.format(','.join(subtrees)))
         if plain_newick:
             return treeline[-1]
         else:
@@ -674,8 +673,7 @@ class Tree(Nodes.Chain):
             elif b1[3] == 0 or b2[3] == 0:
                 newbranch.append(b1[3] + b2[3])  # one is 0, take the other
             else:
-                raise TreeError('Support mismatch in bifurcating root: %f, %f'
-                                % (float(b1[3]), float(b2[3])))
+                raise TreeError('Support mismatch in bifurcating root: {0:f}, {1:f}'.format(float(b1[3]), float(b2[3])))
             self.unrooted.append(newbranch)
 
     def root_with_outgroup(self, outgroup=None):
@@ -687,8 +685,7 @@ class Tree(Nodes.Chain):
                     branch = self.unrooted.pop(i)
                     break
             else:
-                raise TreeError('Unable to connect nodes for rooting: nodes %d and %d are not connected'
-                                % (parent, child))
+                raise TreeError('Unable to connect nodes for rooting: nodes {0:d} and {1:d} are not connected'.format(parent, child))
             self.link(parent, child)
             self.node(child).data.branchlength = branch[2]
             self.node(child).data.support = branch[3]
@@ -740,8 +737,7 @@ class Tree(Nodes.Chain):
         # if theres still a lonely node in self.chain, then it's the old root, and we delete it
         oldroot = [i for i in self.all_ids() if self.node(i).prev is None and i != self.root]
         if len(oldroot) > 1:
-            raise TreeError('Isolated nodes in tree description: %s'
-                            % ','.join(oldroot))
+            raise TreeError('Isolated nodes in tree description: {0!s}'.format(','.join(oldroot)))
         elif len(oldroot) == 1:
             self.kill(oldroot[0])
         return self.root
@@ -819,7 +815,7 @@ def consensus(trees, threshold=0.5, outgroup=None):
     for c in delclades:
         del clades[c]
     # create a tree with a root node
-    consensus = Tree(name='consensus_%2.1f' % float(threshold), data=dataclass)
+    consensus = Tree(name='consensus_{0:2.1f}'.format(float(threshold)), data=dataclass)
     # each clade needs a node in the new tree, add them as isolated nodes
     for c, s in clades.items():
         node = Nodes.Node(data=dataclass())

--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -88,12 +88,10 @@ class Atom(object):
                     putative_element = self.name[0]
 
             if putative_element.capitalize() in IUPACData.atom_weights:
-                msg = "Used element %r for Atom (name=%s) with given element %r" \
-                      % (putative_element, self.name, element)
+                msg = "Used element {0!r} for Atom (name={1!s}) with given element {2!r}".format(putative_element, self.name, element)
                 element = putative_element
             else:
-                msg = "Could not assign element %r for Atom (name=%s) with given element %r" \
-                      % (putative_element, self.name, element)
+                msg = "Could not assign element {0!r} for Atom (name={1!s}) with given element {2!r}".format(putative_element, self.name, element)
                 element = ""
             warnings.warn(msg, PDBConstructionWarning)
 
@@ -110,7 +108,7 @@ class Atom(object):
 
     def __repr__(self):
         """Print Atom object as <Atom atom_name>."""
-        return "<Atom %s>" % self.get_id()
+        return "<Atom {0!s}>".format(self.get_id())
 
     def __sub__(self, other):
         """Calculate distance between two atoms.
@@ -313,7 +311,7 @@ class DisorderedAtom(DisorderedEntityWrapper):
     # Special methods
 
     def __repr__(self):
-        return "<Disordered Atom %s>" % self.get_id()
+        return "<Disordered Atom {0!s}>".format(self.get_id())
 
     def disordered_add(self, atom):
         """Add a disordered atom."""

--- a/Bio/PDB/Chain.py
+++ b/Bio/PDB/Chain.py
@@ -87,7 +87,7 @@ class Chain(Entity):
         return Entity.__delitem__(self, id)
 
     def __repr__(self):
-        return "<Chain id=%s>" % self.get_id()
+        return "<Chain id={0!s}>".format(self.get_id())
 
     # Public methods
 

--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -257,7 +257,7 @@ class DSSP(AbstractResiduePropertyMap):
 
         def resid2code(res_id):
             """Serialize a residue's resseq and icode for easy comparison."""
-            return '%s%s' % (res_id[1], res_id[2])
+            return '{0!s}{1!s}'.format(res_id[1], res_id[2])
 
         # Now create a dictionary that maps Residue objects to
         # secondary structure and accessibility, and a list of
@@ -367,7 +367,7 @@ class DSSP(AbstractResiduePropertyMap):
                     aa = 'C'
             # Take care of HETATM again
             if (resname != aa) and (res.id[0] == ' ' or aa != 'X'):
-                raise PDBException("Structure/DSSP mismatch at %s" % res)
+                raise PDBException("Structure/DSSP mismatch at {0!s}".format(res))
 
             dssp_vals = (dssp_index, aa, ss, rel_acc, phi, psi,
                             NH_O_1_relidx, NH_O_1_energy,
@@ -392,7 +392,7 @@ if __name__ == "__main__":
 
     for r in d:
         print(r)
-    print("Handled %i residues" % len(d))
+    print("Handled {0:d} residues".format(len(d)))
     print(sorted(d))
     if ('A', 1) in d:
         print(d[('A', 1)])

--- a/Bio/PDB/Dice.py
+++ b/Bio/PDB/Dice.py
@@ -42,7 +42,7 @@ class ChainSelector(object):
             # skip HETATMS
             return 0
         if icode != " ":
-            warnings.warn("WARNING: Icode at %s" % residue.get_id(),
+            warnings.warn("WARNING: Icode at {0!s}".format(residue.get_id()),
                           RuntimeWarning)
         if self.start <= resseq <= self.end:
             return 1

--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -84,7 +84,7 @@ class Entity(object):
         entity_id = entity.get_id()
         if self.has_id(entity_id):
             raise PDBConstructionException(
-                "%s defined twice" % str(entity_id))
+                "{0!s} defined twice".format(str(entity_id)))
         entity.set_parent(self)
         self.child_list.append(entity)
         self.child_dict[entity_id] = entity
@@ -94,7 +94,7 @@ class Entity(object):
         entity_id = entity.get_id()
         if self.has_id(entity_id):
             raise PDBConstructionException(
-                "%s defined twice" % str(entity_id))
+                "{0!s} defined twice".format(str(entity_id)))
         entity.set_parent(self)
         self.child_list[pos:pos] = [entity]
         self.child_dict[entity_id] = entity

--- a/Bio/PDB/FragmentMapper.py
+++ b/Bio/PDB/FragmentMapper.py
@@ -171,7 +171,7 @@ class Fragment(object):
         Returns <Fragment length=L id=ID> where L=length of fragment
         and ID the identifier (rank in the library).
         """
-        return "<Fragment length=%i id=%i>" % (self.length, self.fid)
+        return "<Fragment length={0:d} id={1:d}>".format(self.length, self.fid)
 
 
 def _make_fragment_list(pp, length):
@@ -333,6 +333,6 @@ if __name__ == "__main__":
     fm = FragmentMapper(m, 10, 5, "levitt_data")
 
     for r in Selection.unfold_entities(m, "R"):
-        print("%s:" % r)
+        print("{0!s}:".format(r))
         if r in fm:
             print(fm[r])

--- a/Bio/PDB/HSExposure.py
+++ b/Bio/PDB/HSExposure.py
@@ -216,12 +216,12 @@ class HSExposureCA(_AbstractHSExposure):
             fp.write("from pymol import cmd\n")
             fp.write("obj=[\n")
             fp.write("BEGIN, LINES,\n")
-            fp.write("COLOR, %.2f, %.2f, %.2f,\n" % (1.0, 1.0, 1.0))
+            fp.write("COLOR, {0:.2f}, {1:.2f}, {2:.2f},\n".format(1.0, 1.0, 1.0))
             for (ca, cb) in self.ca_cb_list:
                 x, y, z = ca.get_array()
-                fp.write("VERTEX, %.2f, %.2f, %.2f,\n" % (x, y, z))
+                fp.write("VERTEX, {0:.2f}, {1:.2f}, {2:.2f},\n".format(x, y, z))
                 x, y, z = cb.get_array()
-                fp.write("VERTEX, %.2f, %.2f, %.2f,\n" % (x, y, z))
+                fp.write("VERTEX, {0:.2f}, {1:.2f}, {2:.2f},\n".format(x, y, z))
             fp.write("END]\n")
             fp.write("cmd.load_cgo(obj, 'HS')\n")
 

--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -217,4 +217,4 @@ if __name__ == "__main__":
         print(model)
         for chain in model.get_list():
             print(chain)
-            print("Found %d residues." % len(chain.get_list()))
+            print("Found {0:d} residues.".format(len(chain.get_list())))

--- a/Bio/PDB/Model.py
+++ b/Bio/PDB/Model.py
@@ -54,7 +54,7 @@ class Model(Entity):
     # Special methods
 
     def __repr__(self):
-        return "<Model id=%s>" % self.get_id()
+        return "<Model id={0!s}>".format(self.get_id())
 
     # Public
 

--- a/Bio/PDB/NeighborSearch.py
+++ b/Bio/PDB/NeighborSearch.py
@@ -85,7 +85,7 @@ class NeighborSearch(object):
          - level - char (A, R, C, M, S)
         """
         if level not in entity_levels:
-            raise PDBException("%s: Unknown level" % level)
+            raise PDBException("{0!s}: Unknown level".format(level))
         self.kdt.search(center, radius)
         indices = self.kdt.get_indices()
         n_atom_list = []
@@ -110,7 +110,7 @@ class NeighborSearch(object):
          - level - char (A, R, C, M, S)
         """
         if level not in entity_levels:
-            raise PDBException("%s: Unknown level" % level)
+            raise PDBException("{0!s}: Unknown level".format(level))
         self.kdt.all_search(radius)
         indices = self.kdt.all_get_indices()
         atom_list = self.atom_list
@@ -143,4 +143,4 @@ if __name__ == "__main__":
         # Make a list of 100 atoms
         al = [Atom() for j in range(100)]
         ns = NeighborSearch(al)
-        print("Found %i" % len(ns.search_all(5.0)))
+        print("Found {0:d}".format(len(ns.search_all(5.0))))

--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -73,7 +73,7 @@ class PDBIO(object):
         if atom.element:
             element = atom.element.strip().upper()
             if element.capitalize() not in atom_weights:
-                raise ValueError("Unrecognised element %r" % atom.element)
+                raise ValueError("Unrecognised element {0!r}".format(atom.element))
             element = element.rjust(2)
         else:
             element = "  "
@@ -83,17 +83,16 @@ class PDBIO(object):
         bfactor = atom.get_bfactor()
         occupancy = atom.get_occupancy()
         try:
-            occupancy_str = "%6.2f" % occupancy
+            occupancy_str = "{0:6.2f}".format(occupancy)
         except TypeError:
             if occupancy is None:
                 occupancy_str = " " * 6
                 import warnings
                 from Bio import BiopythonWarning
-                warnings.warn("Missing occupancy in atom %s written as blank" %
-                              repr(atom.get_full_id()), BiopythonWarning)
+                warnings.warn("Missing occupancy in atom {0!s} written as blank".format(
+                              repr(atom.get_full_id())), BiopythonWarning)
             else:
-                raise TypeError("Invalid occupancy %r in atom %r"
-                                % (occupancy, atom.get_full_id()))
+                raise TypeError("Invalid occupancy {0!r} in atom {1!r}".format(occupancy, atom.get_full_id()))
 
         args = (record_type, atom_number, name, altloc, resname, chain_id,
                 resseq, icode, x, y, z, occupancy_str, bfactor, segid,
@@ -184,7 +183,7 @@ class PDBIO(object):
             model_residues_written = 0
             atom_number = 1
             if model_flag:
-                fp.write("MODEL      %s\n" % model.serial_num)
+                fp.write("MODEL      {0!s}\n".format(model.serial_num))
             for chain in model.get_list():
                 if not select.accept_chain(chain):
                     continue

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -115,7 +115,7 @@ class PDBList(object):
                             (x.split()[-1] for x in handle.readlines())
                             )[-1]
 
-        path = self.pdb_server + '/pub/pdb/data/status/%s/' % (recent)
+        path = self.pdb_server + '/pub/pdb/data/status/{0!s}/'.format((recent))
 
         # Retrieve the lists
         added = self.get_status_list(path + 'added.pdb')
@@ -186,11 +186,10 @@ class PDBList(object):
         """
         # Get the compressed PDB structure
         code = pdb_code.lower()
-        archive_fn = "pdb%s.ent.gz" % code
+        archive_fn = "pdb{0!s}.ent.gz".format(code)
         pdb_dir = "divided" if not obsolete else "obsolete"
         url = (self.pdb_server +
-               '/pub/pdb/data/structures/%s/pdb/%s/%s' %
-               (pdb_dir, code[1:3], archive_fn))
+               '/pub/pdb/data/structures/{0!s}/pdb/{1!s}/{2!s}'.format(pdb_dir, code[1:3], archive_fn))
 
         # Where does the final PDB file get saved?
         if pdir is None:
@@ -203,16 +202,16 @@ class PDBList(object):
             os.makedirs(path)
 
         filename = os.path.join(path, archive_fn)
-        final_file = os.path.join(path, "pdb%s.ent" % code)  # (decompressed)
+        final_file = os.path.join(path, "pdb{0!s}.ent".format(code))  # (decompressed)
 
         # Skip download if the file already exists
         if not self.overwrite:
             if os.path.exists(final_file):
-                print("Structure exists: '%s' " % final_file)
+                print("Structure exists: '{0!s}' ".format(final_file))
                 return final_file
 
         # Retrieve the file
-        print("Downloading PDB structure '%s'..." % pdb_code)
+        print("Downloading PDB structure '{0!s}'...".format(pdb_code))
         _urlretrieve(url, filename)
 
         # Uncompress the archive, delete when done
@@ -241,7 +240,7 @@ class PDBList(object):
             try:
                 self.retrieve_pdb_file(pdb_code)
             except Exception:
-                print('error %s\n' % pdb_code)
+                print('error {0!s}\n'.format(pdb_code))
                 # you can insert here some more log notes that
                 # something has gone wrong.
 
@@ -249,24 +248,24 @@ class PDBList(object):
         for pdb_code in obsolete:
             if self.flat_tree:
                 old_file = os.path.join(self.local_pdb,
-                                        'pdb%s.ent' % pdb_code)
+                                        'pdb{0!s}.ent'.format(pdb_code))
                 new_dir = self.obsolete_pdb
             else:
                 old_file = os.path.join(self.local_pdb, pdb_code[1:3],
-                                        'pdb%s.ent' % pdb_code)
+                                        'pdb{0!s}.ent'.format(pdb_code))
                 new_dir = os.path.join(self.obsolete_pdb, pdb_code[1:3])
-            new_file = os.path.join(new_dir, 'pdb%s.ent' % pdb_code)
+            new_file = os.path.join(new_dir, 'pdb{0!s}.ent'.format(pdb_code))
             if os.path.isfile(old_file):
                 if not os.path.isdir(new_dir):
                     os.mkdir(new_dir)
                 try:
                     shutil.move(old_file, new_file)
                 except Exception:
-                    print("Could not move %s to obsolete folder" % old_file)
+                    print("Could not move {0!s} to obsolete folder".format(old_file))
             elif os.path.isfile(new_file):
-                print("Obsolete file %s already moved" % old_file)
+                print("Obsolete file {0!s} already moved".format(old_file))
             else:
-                print("Obsolete file %s is missing" % old_file)
+                print("Obsolete file {0!s} is missing".format(old_file))
 
     def download_entire_pdb(self, listfile=None):
         """Retrieve all PDB entries not present in the local PDB copy.

--- a/Bio/PDB/PDBParser.py
+++ b/Bio/PDB/PDBParser.py
@@ -178,8 +178,7 @@ class PDBParser(object):
                 except Exception:
                     # Should we allow parsing to continue in permissive mode?
                     # If so, what coordinates should we default to?  Easier to abort!
-                    raise PDBConstructionException("Invalid or missing coordinate(s) at line %i."
-                                                   % global_line_counter)
+                    raise PDBConstructionException("Invalid or missing coordinate(s) at line {0:d}.".format(global_line_counter))
                 coord = numpy.array((x, y, z), "f")
                 # occupancy & B factor
                 try:
@@ -278,7 +277,7 @@ class PDBParser(object):
         object (if PERMISSIVE), or raises it again, this time adding the
         PDB line number to the error message.
         """
-        message = "%s at line %i." % (message, line_counter)
+        message = "{0!s} at line {1:d}.".format(message, line_counter)
         if self.PERMISSIVE:
             # just print a warning - some residues/atoms may be missing
             warnings.warn("PDBConstructionException: %s\n"
@@ -312,4 +311,4 @@ if __name__ == "__main__":
                 for a in r:
                     p = a.get_parent()
                     if p is not r:
-                        print("%s %s" % (p, r))
+                        print("{0!s} {1!s}".format(p, r))

--- a/Bio/PDB/PSEA.py
+++ b/Bio/PDB/PSEA.py
@@ -79,7 +79,7 @@ def annotate(m, ss_seq):
             residues.append(res)
     L = len(residues)
     if not (L == len(ss_seq)):
-        raise ValueError("Length mismatch %i %i" % (L, len(ss_seq)))
+        raise ValueError("Length mismatch {0:d} {1:d}".format(L, len(ss_seq)))
     for i in range(0, L):
         residues[i].xtra["SS_PSEA"] = ss_seq[i]
     # os.system("rm "+fname)

--- a/Bio/PDB/Polypeptide.py
+++ b/Bio/PDB/Polypeptide.py
@@ -294,7 +294,7 @@ class Polypeptide(list):
         """
         start = self[0].get_id()[1]
         end = self[-1].get_id()[1]
-        s = "<Polypeptide start=%s end=%s>" % (start, end)
+        s = "<Polypeptide start={0!s} end={1!s}>".format(start, end)
         return s
 
 
@@ -473,7 +473,7 @@ if __name__ == "__main__":
 
     for pp in ppb.build_peptides(s):
         for phi, psi in pp.get_phi_psi_list():
-            print("%f %f" % (phi, psi))
+            print("{0:f} {1:f}".format(phi, psi))
 
     ppb = CaPPBuilder()
 

--- a/Bio/PDB/QCPSuperimposer/__init__.py
+++ b/Bio/PDB/QCPSuperimposer/__init__.py
@@ -189,10 +189,10 @@ if __name__ == "__main__":
         y_on_x2 = sup.get_transformed()
     t1 = datetime.now()
     dif = t1 - t0
-    print("process wall time (msec): %d" % (dif.total_seconds() * 1000))
+    print("process wall time (msec): {0:d}".format((dif.total_seconds() * 1000)))
 
     print(y_on_x1)
     print("")
     print(y_on_x2)
     print("")
-    print("%.2f" % rms)
+    print("{0:.2f}".format(rms))

--- a/Bio/PDB/Residue.py
+++ b/Bio/PDB/Residue.py
@@ -33,7 +33,7 @@ class Residue(Entity):
         resname = self.get_resname()
         hetflag, resseq, icode = self.get_id()
         full_id = (resname, hetflag, resseq, icode)
-        return "<Residue %s het=%s resseq=%s icode=%s>" % full_id
+        return "<Residue {0!s} het={1!s} resseq={2!s} icode={3!s}>".format(*full_id)
 
     # Private methods
 
@@ -77,7 +77,7 @@ class Residue(Entity):
         atom_id = atom.get_id()
         if self.has_id(atom_id):
             raise PDBConstructionException(
-                "Atom %s defined twice in residue %s" % (atom_id, self))
+                "Atom {0!s} defined twice in residue {1!s}".format(atom_id, self))
         Entity.add(self, atom)
 
     def sort(self):
@@ -128,7 +128,7 @@ class DisorderedResidue(DisorderedEntityWrapper):
         resname = self.get_resname()
         hetflag, resseq, icode = self.get_id()
         full_id = (resname, hetflag, resseq, icode)
-        return "<DisorderedResidue %s het=%s resseq=%i icode=%s>" % full_id
+        return "<DisorderedResidue {0!s} het={1!s} resseq={2:d} icode={3!s}>".format(*full_id)
 
     def add(self, atom):
         residue = self.disordered_get()
@@ -140,8 +140,7 @@ class DisorderedResidue(DisorderedEntityWrapper):
             # add atom anyway, if PDBParser ignores exception the atom will be part of the residue
             residue.add(atom)
             raise PDBConstructionException(
-                "Blank altlocs in duplicate residue %s (%s, %i, %s)"
-                % (resname, het, resseq, icode))
+                "Blank altlocs in duplicate residue {0!s} ({1!s}, {2:d}, {3!s})".format(resname, het, resseq, icode))
         residue.add(atom)
 
     def sort(self):

--- a/Bio/PDB/ResidueDepth.py
+++ b/Bio/PDB/ResidueDepth.py
@@ -79,7 +79,7 @@ def get_surface(pdb_file, PDB_TO_XYZR="pdb_to_xyzr", MSMS="msms"):
     make_xyz = PDB_TO_XYZR % (pdb_file, xyz_tmp)
     os.system(make_xyz)
     assert os.path.isfile(xyz_tmp), \
-        "Failed to generate XYZR file using command:\n%s" % make_xyz
+        "Failed to generate XYZR file using command:\n{0!s}".format(make_xyz)
     # make surface
     surface_tmp = tempfile.mktemp()
     MSMS = MSMS + " -probe_radius 1.5 -if %s -of %s > " + tempfile.mktemp()
@@ -87,7 +87,7 @@ def get_surface(pdb_file, PDB_TO_XYZR="pdb_to_xyzr", MSMS="msms"):
     os.system(make_surface)
     surface_file = surface_tmp + ".vert"
     assert os.path.isfile(surface_file), \
-        "Failed to generate surface file using command:\n%s" % make_surface
+        "Failed to generate surface file using command:\n{0!s}".format(make_surface)
     # read surface vertices from vertex file
     surface = _read_vertex_array(surface_file)
     # clean up tmp files

--- a/Bio/PDB/Selection.py
+++ b/Bio/PDB/Selection.py
@@ -51,7 +51,7 @@ def unfold_entities(entity_list, target_level):
 
     """
     if target_level not in entity_levels:
-        raise PDBException("%s: Not an entity level." % target_level)
+        raise PDBException("{0!s}: Not an entity level.".format(target_level))
     if entity_list == []:
         return []
     if isinstance(entity_list, (Entity, Atom)):

--- a/Bio/PDB/Structure.py
+++ b/Bio/PDB/Structure.py
@@ -19,7 +19,7 @@ class Structure(Entity):
     # Special methods
 
     def __repr__(self):
-        return "<Structure id=%s>" % self.get_id()
+        return "<Structure id={0!s}>".format(self.get_id())
 
     # Private methods
 

--- a/Bio/PDB/StructureAlignment.py
+++ b/Bio/PDB/StructureAlignment.py
@@ -135,4 +135,4 @@ if __name__ == "__main__":
 
     # Print aligned pairs (r is None if gap)
     for (r1, r2) in al.get_iterator():
-        print("%s %s" % (r1, r2))
+        print("{0!s} {1!s}".format(r1, r2))

--- a/Bio/PDB/StructureBuilder.py
+++ b/Bio/PDB/StructureBuilder.py
@@ -82,8 +82,7 @@ class StructureBuilder(object):
         """
         if self.model.has_id(chain_id):
             self.chain = self.model[chain_id]
-            warnings.warn("WARNING: Chain %s is discontinuous at line %i."
-                          % (chain_id, self.line_counter),
+            warnings.warn("WARNING: Chain {0!s} is discontinuous at line {1:d}.".format(chain_id, self.line_counter),
                           PDBConstructionWarning)
         else:
             self.chain = Chain(chain_id)
@@ -153,8 +152,7 @@ class StructureBuilder(object):
                         # if this exception is ignored, a residue will be missing
                         self.residue = None
                         raise PDBConstructionException(
-                            "Blank altlocs in duplicate residue %s ('%s', %i, '%s')"
-                            % (resname, field, resseq, icode))
+                            "Blank altlocs in duplicate residue {0!s} ('{1!s}', {2:d}, '{3!s}')".format(resname, field, resseq, icode))
                     self.chain.detach_child(res_id)
                     new_residue = Residue(res_id, resname, self.segid)
                     disordered_residue = DisorderedResidue(res_id)

--- a/Bio/PDB/Vector.py
+++ b/Bio/PDB/Vector.py
@@ -220,7 +220,7 @@ class Vector(object):
 
     def __repr__(self):
         x, y, z = self._ar
-        return "<Vector %.2f, %.2f, %.2f>" % (x, y, z)
+        return "<Vector {0:.2f}, {1:.2f}, {2:.2f}>".format(x, y, z)
 
     def __neg__(self):
         "Return Vector(-x, -y, -z)"
@@ -337,7 +337,7 @@ if __name__ == "__main__":
     dih = calc_dihedral(v1, v2, v3, v4)
     # Test dihedral sign
     assert(dih > 0)
-    print("DIHEDRAL %f" % dih)
+    print("DIHEDRAL {0:f}".format(dih))
 
     ref = refmat(v1, v3)
     rot = rotmat(v1, v3)

--- a/Bio/ParserSupport.py
+++ b/Bio/ParserSupport.py
@@ -118,7 +118,7 @@ class TaggingConsumer(AbstractConsumer):
     def _print_name(self, name, data=None):
         if data is None:
             # Write the name of a section.
-            self._handle.write("%s %s\n" % ("*" * self._colwidth, name))
+            self._handle.write("{0!s} {1!s}\n".format("*" * self._colwidth, name))
         else:
             # Write the tag and line.
             self._handle.write("%-*s: %s\n" % (
@@ -355,23 +355,23 @@ def _fails_conditions(line, start=None, end=None, contains=None, blank=None,
                       has_re=None):
     if start is not None:
         if line[:len(start)] != start:
-            return "Line does not start with '%s':\n%s" % (start, line)
+            return "Line does not start with '{0!s}':\n{1!s}".format(start, line)
     if end is not None:
         if line.rstrip()[-len(end):] != end:
-            return "Line does not end with '%s':\n%s" % (end, line)
+            return "Line does not end with '{0!s}':\n{1!s}".format(end, line)
     if contains is not None:
         if contains not in line:
-            return "Line does not contain '%s':\n%s" % (contains, line)
+            return "Line does not contain '{0!s}':\n{1!s}".format(contains, line)
     if blank is not None:
         if blank:
             if not is_blank_line(line):
-                return "Expected blank line, but got:\n%s" % line
+                return "Expected blank line, but got:\n{0!s}".format(line)
         else:
             if is_blank_line(line):
                 return "Expected non-blank line, but got a blank one"
     if has_re is not None:
         if has_re.search(line) is None:
-            return "Line does not match regex '%s':\n%s" % (
+            return "Line does not match regex '{0!s}':\n{1!s}".format(
                 has_re.pattern, line)
     return None
 

--- a/Bio/Pathway/Rep/Graph.py
+++ b/Bio/Pathway/Rep/Graph.py
@@ -36,7 +36,7 @@ class Graph(object):
         for key in sorted(self._adjacency_list):
             values = sorted([(x, self._edge_map[(key, x)])
                       for x in self._adjacency_list[key].list()])
-            s += "(%r: %s)" % (key, ",".join(repr(v) for v in values))
+            s += "({0!r}: {1!s})".format(key, ",".join(repr(v) for v in values))
         return s + ">"
 
     def __str__(self):

--- a/Bio/Pathway/Rep/MultiGraph.py
+++ b/Bio/Pathway/Rep/MultiGraph.py
@@ -34,7 +34,7 @@ class MultiGraph(object):
         s = "<MultiGraph: "
         for key in sorted(self._adjacency_list):
             values = sorted(self._adjacency_list[key])
-            s += "(%r: %s)" % (key, ",".join(repr(v) for v in values))
+            s += "({0!r}: {1!s})".format(key, ",".join(repr(v) for v in values))
         return s + ">"
 
     def __str__(self):

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -146,7 +146,7 @@ def _attribute_matcher(kwargs):
                 return (pattern == target)
             if pattern is None:
                 return (target is None)
-            raise TypeError('invalid query type: %s' % type(pattern))
+            raise TypeError('invalid query type: {0!s}'.format(type(pattern)))
         return True
     return match
 
@@ -184,8 +184,7 @@ def _object_matcher(obj):
         return _attribute_matcher(obj)
     if callable(obj):
         return _function_matcher(obj)
-    raise ValueError("%s (type %s) is not a valid type for comparison."
-                     % (obj, type(obj)))
+    raise ValueError("{0!s} (type {1!s}) is not a valid type for comparison.".format(obj, type(obj)))
 
 
 def _combine_matchers(target, kwargs, require_spec):
@@ -243,11 +242,9 @@ class TreeElement(object):
         """Show this object's constructor with its primitive arguments."""
         def pair_as_kwarg_string(key, val):
             if isinstance(val, basestring):
-                return ("%s='%s'"
-                        % (key, _utils.trim_str(as_string(val), 60, '...')))
-            return "%s=%s" % (key, val)
-        return ('%s(%s)'
-                % (self.__class__.__name__,
+                return ("{0!s}='{1!s}'".format(key, _utils.trim_str(as_string(val), 60, '...')))
+            return "{0!s}={1!s}".format(key, val)
+        return ('{0!s}({1!s})'.format(self.__class__.__name__,
                    ', '.join(pair_as_kwarg_string(key, val)
                              for key, val in sorted(self.__dict__.items())
                              if val is not None and
@@ -277,8 +274,7 @@ class TreeMixin(object):
         try:
             order_func = order_opts[order]
         except KeyError:
-            raise ValueError("Invalid order '%s'; must be one of: %s"
-                             % (order, tuple(order_opts)))
+            raise ValueError("Invalid order '{0!s}'; must be one of: {1!s}".format(order, tuple(order_opts)))
         if follow_attrs:
             get_children = _sorted_attrs
             root = self
@@ -429,7 +425,7 @@ class TreeMixin(object):
         # Validation -- otherwise izip throws a spooky error below
         for p, t in zip(paths, targets):
             if p is None:
-                raise ValueError("target %s is not in this tree" % repr(t))
+                raise ValueError("target {0!s} is not in this tree".format(repr(t)))
         mrca = self.root
         for level in zip(*paths):
             ref = level[0]
@@ -569,8 +565,7 @@ class TreeMixin(object):
         """
         path = self.get_path(target, **kwargs)
         if not path:
-            raise ValueError("couldn't collapse %s in this tree"
-                             % (target or kwargs))
+            raise ValueError("couldn't collapse {0!s} in this tree".format((target or kwargs)))
         if len(path) == 1:
             parent = self.root
         else:
@@ -750,7 +745,7 @@ class Tree(TreeElement, TreeMixin):
         :returns: a tree of the same type as this class.
         """
         if isinstance(taxa, int):
-            taxa = ['taxon%s' % (i + 1) for i in range(taxa)]
+            taxa = ['taxon{0!s}'.format((i + 1)) for i in range(taxa)]
         elif hasattr(taxa, '__iter__'):
             taxa = list(taxa)
         else:
@@ -1081,12 +1076,12 @@ class Clade(TreeElement, TreeMixin):
                 # HTML-style hex string
                 self._color = BranchColor.from_hex(arg)
             else:
-                raise ValueError("invalid color string %s" % arg)
+                raise ValueError("invalid color string {0!s}".format(arg))
         elif hasattr(arg, '__iter__') and len(arg) == 3:
             # RGB triplet
             self._color = BranchColor(*arg)
         else:
-            raise ValueError("invalid color value %s" % arg)
+            raise ValueError("invalid color value {0!s}".format(arg))
 
     color = property(_get_color, _set_color, doc="Branch color.")
 
@@ -1181,7 +1176,7 @@ class BranchColor(object):
             >>> bc.to_hex()
             '#0cc864'
         """
-        return "#%02x%02x%02x" % (self.red, self.green, self.blue)
+        return "#{0:02x}{1:02x}{2:02x}".format(self.red, self.green, self.blue)
 
     def to_rgb(self):
         """Return a tuple of RGB values (0 to 255) representing this color.
@@ -1196,9 +1191,8 @@ class BranchColor(object):
 
     def __repr__(self):
         """Preserve the standard RGB order when representing this object."""
-        return ('%s(red=%d, green=%d, blue=%d)'
-                % (self.__class__.__name__, self.red, self.green, self.blue))
+        return ('{0!s}(red={1:d}, green={2:d}, blue={3:d})'.format(self.__class__.__name__, self.red, self.green, self.blue))
 
     def __str__(self):
         """Show the color's RGB values."""
-        return "(%d, %d, %d)" % (self.red, self.green, self.blue)
+        return "({0:d}, {1:d}, {2:d})".format(self.red, self.green, self.blue)

--- a/Bio/Phylo/CDAOIO.py
+++ b/Bio/Phylo/CDAOIO.py
@@ -272,11 +272,11 @@ class Writer(object):
         trees = self.trees
 
         if tree_uri:
-            handle.write('@base <%s>\n' % tree_uri)
+            handle.write('@base <{0!s}>\n'.format(tree_uri))
         for k, v in self.prefixes.items():
-            handle.write('@prefix %s: <%s> .\n' % (k, v))
+            handle.write('@prefix {0!s}: <{1!s}> .\n'.format(k, v))
 
-        handle.write('<%s> a owl:Ontology .\n' % self.prefixes['cdao'])
+        handle.write('<{0!s}> a owl:Ontology .\n'.format(self.prefixes['cdao']))
 
         for tree in trees:
             self.tree_counter += 1
@@ -296,14 +296,14 @@ class Writer(object):
                 changed = False
                 for prefix, uri in self.prefixes.items():
                     if node_uri.startswith(uri):
-                        node_uri = node_uri.replace(uri, '%s:' % prefix, 1)
+                        node_uri = node_uri.replace(uri, '{0!s}:'.format(prefix), 1)
                         if node_uri == 'rdf:type':
                             node_uri = 'a'
                         changed = True
                 if changed or ':' in node_uri:
                     stmt_strings.append(node_uri)
                 else:
-                    stmt_strings.append('<%s>' % node_uri)
+                    stmt_strings.append('<{0!s}>'.format(node_uri))
 
             elif isinstance(part, rdflib.Literal):
                 stmt_strings.append(part.n3())
@@ -311,13 +311,13 @@ class Writer(object):
             else:
                 stmt_strings.append(str(part))
 
-        handle.write('%s .\n' % ' '.join(stmt_strings))
+        handle.write('{0!s} .\n'.format(' '.join(stmt_strings)))
 
     def process_clade(self, clade, parent=None, root=False):
         """recursively generate triples describing a tree of clades"""
 
         self.node_counter += 1
-        clade.uri = 'node%s' % str(self.node_counter).zfill(ZEROES)
+        clade.uri = 'node{0!s}'.format(str(self.node_counter).zfill(ZEROES))
         if parent:
             clade.ancestors = parent.ancestors + [parent.uri]
         else:
@@ -350,7 +350,7 @@ class Writer(object):
         if clade.name:
             # create TU
             self.tu_counter += 1
-            tu_uri = 'tu%s' % str(self.tu_counter).zfill(ZEROES)
+            tu_uri = 'tu{0!s}'.format(str(self.tu_counter).zfill(ZEROES))
 
             statements += [
                 (nUri(tu_uri), pUri('rdf:type'), pUri('cdao:TU')),
@@ -380,7 +380,7 @@ class Writer(object):
         if parent is not None:
             # create edge from the parent node to this node
             self.edge_counter += 1
-            edge_uri = 'edge%s' % str(self.edge_counter).zfill(ZEROES)
+            edge_uri = 'edge{0!s}'.format(str(self.edge_counter).zfill(ZEROES))
 
             statements += [
                 (nUri(edge_uri), pUri('rdf:type'), pUri('cdao:DirectedEdge')),
@@ -411,8 +411,8 @@ class Writer(object):
 
             if clade.branch_length is not None:
                 # add branch length
-                edge_ann_uri = 'edge_annotation%s' % str(
-                    self.edge_counter).zfill(ZEROES)
+                edge_ann_uri = 'edge_annotation{0!s}'.format(str(
+                    self.edge_counter).zfill(ZEROES))
 
                 branch_length = rdflib.Literal(clade.branch_length, datatype=rdflib.URIRef(
                     'http://www.w3.org/2001/XMLSchema#decimal'))

--- a/Bio/Phylo/NeXMLIO.py
+++ b/Bio/Phylo/NeXMLIO.py
@@ -66,7 +66,7 @@ def qUri(s):
 
 def cdao_to_obo(s):
     """Optionally converts a CDAO-prefixed URI into an OBO-prefixed URI."""
-    return 'obo:%s' % cdao_elements[s[len('cdao:'):]]
+    return 'obo:{0!s}'.format(cdao_elements[s[len('cdao:'):]])
 
 
 def matches(s):
@@ -226,9 +226,9 @@ class Writer(object):
         self.tree_counter = 0
 
     def new_label(self, obj_type):
-        counter = '%s_counter' % obj_type
+        counter = '{0!s}_counter'.format(obj_type)
         setattr(self, counter, getattr(self, counter) + 1)
-        return '%s%s' % (obj_type, getattr(self, counter))
+        return '{0!s}{1!s}'.format(obj_type, getattr(self, counter))
 
     def write(self, handle, cdao_to_obo=True, **kwargs):
         """Write this instance's trees to a file handle."""
@@ -242,7 +242,7 @@ class Writer(object):
         root_node.set('xsi:schemaLocation', SCHEMA)
 
         for prefix, uri in NAMESPACES.items():
-            root_node.set('xmlns:%s' % prefix, uri)
+            root_node.set('xmlns:{0!s}'.format(prefix), uri)
 
         otus = ElementTree.SubElement(root_node, 'otus',
                                       **{'id': 'tax', 'label': 'RootTaxaBlock'})
@@ -313,7 +313,7 @@ class Writer(object):
                 attrib.update({
                     'property': convert_uri('cdao:has_Support_Value'),
                     'datatype': 'xsd:float',
-                    'content': '%1.2f' % clade.confidence,
+                    'content': '{0:1.2f}'.format(clade.confidence),
                 })
             node = ElementTree.SubElement(tree, 'edge', **attrib)
 

--- a/Bio/Phylo/NewickIO.py
+++ b/Bio/Phylo/NewickIO.py
@@ -34,7 +34,7 @@ tokens = [
     (r"\;",                                       'semicolon'),
     (r"\n",                                       'newline'),
 ]
-tokenizer = re.compile('(%s)' % '|'.join(token[0] for token in tokens))
+tokenizer = re.compile('({0!s})'.format('|'.join(token[0] for token in tokens)))
 token_dict = dict((name, re.compile(token)) for (token, name) in tokens)
 
 
@@ -74,7 +74,7 @@ def _parse_confidence(text):
 
 
 def _format_comment(text):
-    return '[%s]' % (text.replace('[', '\\[').replace(']', '\\]'))
+    return '[{0!s}]'.format((text.replace('[', '\\[').replace(']', '\\]')))
 
 
 def _get_comment(clade):
@@ -199,8 +199,7 @@ class Parser(object):
         # if ; token broke out of for loop, there should be no remaining tokens
         try:
             next_token = next(tokens)
-            raise NewickError('Text after semicolon in Newick tree: %s'
-                              % next_token.group())
+            raise NewickError('Text after semicolon in Newick tree: {0!s}'.format(next_token.group()))
         except StopIteration:
             pass
 
@@ -269,15 +268,15 @@ class Writer(object):
             if label:
                 unquoted_label = re.match(token_dict['unquoted node label'], label)
                 if (not unquoted_label) or (unquoted_label.end() < len(label)):
-                    label = "'%s'" % label.replace(
-                        '\\', '\\\\').replace("'", "\\'")
+                    label = "'{0!s}'".format(label.replace(
+                        '\\', '\\\\').replace("'", "\\'"))
 
             if clade.is_terminal():    # terminal
                 return (label
                         + make_info_string(clade, terminal=True))
             else:
                 subtrees = (newickize(sub) for sub in clade)
-                return '(%s)%s' % (','.join(subtrees),
+                return '({0!s}){1!s}'.format(','.join(subtrees),
                                    label + make_info_string(clade))
 
         # Convert each tree to a string
@@ -292,7 +291,7 @@ class Writer(object):
             # Nexus-style (?) notation before the raw Newick tree
             treeline = ['tree', (tree.name or 'a_tree'), '=']
             if tree.weight != 1:
-                treeline.append('[&W%s]' % round(float(tree.weight), 3))
+                treeline.append('[&W{0!s}]'.format(round(float(tree.weight), 3)))
             if tree.rooted:
                 treeline.append('[&R]')
             treeline.append(rawtree)

--- a/Bio/Phylo/PAML/_paml.py
+++ b/Bio/Phylo/PAML/_paml.py
@@ -70,7 +70,7 @@ class Paml(object):
     def print_options(self):
         """Print out all of the options and their current settings."""
         for option in self._options.items():
-            print("%s = %s" % (option[0], option[1]))
+            print("{0!s} = {1!s}".format(option[0], option[1]))
 
     def set_options(self, **kwargs):
         """Set the value of an option.
@@ -155,9 +155,7 @@ class Paml(object):
         if result_code > 0:
             # If the program fails for any reason
             raise PamlError(
-            "%s has failed (return code %i). Run with verbose = True to view error message"
-            % (command, result_code))
+            "{0!s} has failed (return code {1:d}). Run with verbose = True to view error message".format(command, result_code))
         if result_code < 0:
             # If the paml process is killed by a signal somehow
-            raise EnvironmentError("The %s process was killed (return code %i)."
-                  % (command, result_code))
+            raise EnvironmentError("The {0!s} process was killed (return code {1:d}).".format(command, result_code))

--- a/Bio/Phylo/PAML/baseml.py
+++ b/Bio/Phylo/PAML/baseml.py
@@ -67,9 +67,9 @@ class Baseml(Paml):
         self._set_rel_paths()
         if True:  # Dummy statement to preserve indentation for diff
             with open(self.ctl_file, 'w') as ctl_handle:
-                ctl_handle.write("seqfile = %s\n" % self._rel_alignment)
-                ctl_handle.write("outfile = %s\n" % self._rel_out_file)
-                ctl_handle.write("treefile = %s\n" % self._rel_tree)
+                ctl_handle.write("seqfile = {0!s}\n".format(self._rel_alignment))
+                ctl_handle.write("outfile = {0!s}\n".format(self._rel_out_file))
+                ctl_handle.write("treefile = {0!s}\n".format(self._rel_tree))
                 for option in self._options.items():
                     if option[1] is None:
                         # If an option has a value of None, there's no need
@@ -86,17 +86,17 @@ class Baseml(Paml):
                     # which are to be stored in "model_options" as a string.
                     if option[0] == "model" and option[1] in [9, 10]:
                         if self._options["model_options"] is not None:
-                            ctl_handle.write("model = %s  %s" % (option[1],
+                            ctl_handle.write("model = {0!s}  {1!s}".format(option[1],
                                             self._options["model_options"]))
                             continue
-                    ctl_handle.write("%s = %s\n" % (option[0], option[1]))
+                    ctl_handle.write("{0!s} = {1!s}\n".format(option[0], option[1]))
 
     def read_ctl_file(self, ctl_file):
         """Parse a control file and load the options into the Baseml instance.
         """
         temp_options = {}
         if not os.path.isfile(ctl_file):
-            raise IOError("File not found: %r" % ctl_file)
+            raise IOError("File not found: {0!r}".format(ctl_file))
         else:
             with open(ctl_file) as ctl_handle:
                 for line in ctl_handle:
@@ -105,7 +105,7 @@ class Baseml(Paml):
                     if uncommented != "":
                         if "=" not in uncommented:
                             raise AttributeError(
-                                "Malformed line in control file:\n%r" % line)
+                                "Malformed line in control file:\n{0!r}".format(line))
                         (option, value) = uncommented.split("=")
                         option = option.strip()
                         value = value.strip()
@@ -116,7 +116,7 @@ class Baseml(Paml):
                         elif option == "outfile":
                             self.out_file = value
                         elif option not in self._options:
-                            raise KeyError("Invalid option: %s" % option)
+                            raise KeyError("Invalid option: {0!s}".format(option))
                         elif option == "model":
                             if len(value) <= 2 and value.isdigit():
                                 temp_options["model"] = int(value)

--- a/Bio/Phylo/PAML/codeml.py
+++ b/Bio/Phylo/PAML/codeml.py
@@ -75,9 +75,9 @@ class Codeml(Paml):
         self._set_rel_paths()
         if True:  # Dummy statement to preserve indentation for diff
             with open(self.ctl_file, 'w') as ctl_handle:
-                ctl_handle.write("seqfile = %s\n" % self._rel_alignment)
-                ctl_handle.write("outfile = %s\n" % self._rel_out_file)
-                ctl_handle.write("treefile = %s\n" % self._rel_tree)
+                ctl_handle.write("seqfile = {0!s}\n".format(self._rel_alignment))
+                ctl_handle.write("outfile = {0!s}\n".format(self._rel_out_file))
+                ctl_handle.write("treefile = {0!s}\n".format(self._rel_tree))
                 for option in self._options.items():
                     if option[1] is None:
                         # If an option has a value of None, there's no need
@@ -89,16 +89,16 @@ class Codeml(Paml):
                         # control file it is specified as a series of numbers
                         # separated by spaces.
                         NSsites = " ".join(str(site) for site in option[1])
-                        ctl_handle.write("%s = %s\n" % (option[0], NSsites))
+                        ctl_handle.write("{0!s} = {1!s}\n".format(option[0], NSsites))
                     else:
-                        ctl_handle.write("%s = %s\n" % (option[0], option[1]))
+                        ctl_handle.write("{0!s} = {1!s}\n".format(option[0], option[1]))
 
     def read_ctl_file(self, ctl_file):
         """Parse a control file and load the options into the Codeml instance.
         """
         temp_options = {}
         if not os.path.isfile(ctl_file):
-            raise IOError("File not found: %r" % ctl_file)
+            raise IOError("File not found: {0!r}".format(ctl_file))
         else:
             with open(ctl_file) as ctl_handle:
                 for line in ctl_handle:
@@ -107,7 +107,7 @@ class Codeml(Paml):
                     if uncommented != "":
                         if "=" not in uncommented:
                             raise AttributeError(
-                                "Malformed line in control file:\n%r" % line)
+                                "Malformed line in control file:\n{0!r}".format(line))
                         (option, value) = uncommented.split("=", 1)
                         option = option.strip()
                         value = value.strip()
@@ -124,10 +124,10 @@ class Codeml(Paml):
                                     site_classes[n] = int(site_classes[n])
                                 except:
                                     raise TypeError(
-                                        "Invalid site class: %s" % site_classes[n])
+                                        "Invalid site class: {0!s}".format(site_classes[n]))
                             temp_options["NSsites"] = site_classes
                         elif option not in self._options:
-                            raise KeyError("Invalid option: %s" % option)
+                            raise KeyError("Invalid option: {0!s}".format(option))
                         else:
                             if "." in value:
                                 try:
@@ -154,9 +154,9 @@ class Codeml(Paml):
                 # control file it is specified as a series of numbers
                 # separated by spaces.
                 NSsites = " ".join(str(site) for site in option[1])
-                print("%s = %s" % (option[0], NSsites))
+                print("{0!s} = {1!s}".format(option[0], NSsites))
             else:
-                print("%s = %s" % (option[0], option[1]))
+                print("{0!s} = {1!s}".format(option[0], option[1]))
 
     def _set_rel_paths(self):
         """Convert all file/directory locations to paths relative to the current working directory.

--- a/Bio/Phylo/PAML/yn00.py
+++ b/Bio/Phylo/PAML/yn00.py
@@ -44,22 +44,22 @@ class Yn00(Paml):
         # Make sure all paths are relative to the working directory
         self._set_rel_paths()
         with open(self.ctl_file, 'w') as ctl_handle:
-            ctl_handle.write("seqfile = %s\n" % self._rel_alignment)
-            ctl_handle.write("outfile = %s\n" % self._rel_out_file)
+            ctl_handle.write("seqfile = {0!s}\n".format(self._rel_alignment))
+            ctl_handle.write("outfile = {0!s}\n".format(self._rel_out_file))
             for option in self._options.items():
                 if option[1] is None:
                     # If an option has a value of None, there's no need
                     # to write it in the control file; it's normally just
                     # commented out.
                     continue
-                ctl_handle.write("%s = %s\n" % (option[0], option[1]))
+                ctl_handle.write("{0!s} = {1!s}\n".format(option[0], option[1]))
 
     def read_ctl_file(self, ctl_file):
         """Parse a control file and load the options into the yn00 instance.
         """
         temp_options = {}
         if not os.path.isfile(ctl_file):
-            raise IOError("File not found: %r" % ctl_file)
+            raise IOError("File not found: {0!r}".format(ctl_file))
         else:
             with open(ctl_file) as ctl_handle:
                 for line in ctl_handle:
@@ -68,7 +68,7 @@ class Yn00(Paml):
                     if uncommented != "":
                         if "=" not in uncommented:
                             raise AttributeError(
-                                "Malformed line in control file:\n%r" % line)
+                                "Malformed line in control file:\n{0!r}".format(line))
                         (option, value) = uncommented.split("=")
                         option = option.strip()
                         value = value.strip()
@@ -77,7 +77,7 @@ class Yn00(Paml):
                         elif option == "outfile":
                             self.out_file = value
                         elif option not in self._options:
-                            raise KeyError("Invalid option: %s" % option)
+                            raise KeyError("Invalid option: {0!s}".format(option))
                         else:
                             if "." in value or "e-" in value:
                                 try:

--- a/Bio/Phylo/PhyloXML.py
+++ b/Bio/Phylo/PhyloXML.py
@@ -38,7 +38,7 @@ class PhyloXMLWarning(BiopythonWarning):
 def _check_str(text, testfunc):
     """Check a string using testfunc, and warn if there's no match."""
     if text is not None and not testfunc(text):
-        warnings.warn("String %s doesn't match the given regexp" % text,
+        warnings.warn("String {0!s} doesn't match the given regexp".format(text),
                       PhyloXMLWarning, stacklevel=2)
 
 
@@ -80,7 +80,7 @@ class Phyloxml(PhyloElement):
         if isinstance(index, (int, slice)):
             return self.phylogenies[index]
         if not isinstance(index, basestring):
-            raise KeyError("can't use %s as an index" % type(index))
+            raise KeyError("can't use {0!s} as an index".format(type(index)))
         for tree in self.phylogenies:
             if tree.name == index:
                 return tree
@@ -96,7 +96,7 @@ class Phyloxml(PhyloElement):
         return len(self.phylogenies)
 
     def __str__(self):
-        return '%s([%s])' % (self.__class__.__name__,
+        return '{0!s}([{1!s}])'.format(self.__class__.__name__,
                              ',\n'.join(map(str, self.phylogenies)))
 
 
@@ -452,7 +452,7 @@ class Accession(PhyloElement):
 
     def __str__(self):
         """Show the class name and an identifying attribute."""
-        return '%s:%s' % (self.source, self.value)
+        return '{0!s}:{1!s}'.format(self.source, self.value)
 
 
 class Annotation(PhyloElement):
@@ -718,7 +718,7 @@ class Date(PhyloElement):
     def __str__(self):
         """Show the class name and the human-readable date."""
         if self.unit and self.value is not None:
-            return '%s %s' % (self.value, self.unit)
+            return '{0!s} {1!s}'.format(self.value, self.unit)
         if self.desc is not None:
             return self.desc
         return self.__class__.__name__
@@ -796,7 +796,7 @@ class Events(PhyloElement):
             raise KeyError(key)
         val = getattr(self, key)
         if val is None:
-            raise KeyError("%s has not been set in this object" % repr(key))
+            raise KeyError("{0!s} has not been set in this object".format(repr(key)))
         return val
 
     def __setitem__(self, key, val):
@@ -825,7 +825,7 @@ class Id(PhyloElement):
 
     def __str__(self):
         if self.provider is not None:
-            return '%s:%s' % (self.provider, self.value)
+            return '{0!s}:{1!s}'.format(self.provider, self.value)
         return self.value
 
 
@@ -887,7 +887,7 @@ class Polygon(PhyloElement):
         self.points = points or []
 
     def __str__(self):
-        return '%s([%s])' % (self.__class__.__name__,
+        return '{0!s}([{1!s}])'.format(self.__class__.__name__,
                              ',\n'.join(map(str, self.points)))
 
 

--- a/Bio/Phylo/PhyloXMLIO.py
+++ b/Bio/Phylo/PhyloXMLIO.py
@@ -150,7 +150,7 @@ def _split_namespace(tag):
 
 def _ns(tag, namespace=NAMESPACES['phy']):
     """Format an XML tag with the given namespace."""
-    return '{%s}%s' % (namespace, tag)
+    return '{{{0!s}}}{1!s}'.format(namespace, tag)
 
 
 def _get_child_as(parent, tag, construct):
@@ -652,7 +652,7 @@ def _handle_complex(tag, attribs, subnodes, has_text=False):
         if has_text:
             elem.text = _serialize(obj.value)
         return elem
-    wrapped.__doc__ = "Serialize a %s and its subnodes, in order." % tag
+    wrapped.__doc__ = "Serialize a {0!s} and its subnodes, in order.".format(tag)
     return wrapped
 
 
@@ -661,7 +661,7 @@ def _handle_simple(tag):
         elem = ElementTree.Element(tag)
         elem.text = _serialize(obj)
         return elem
-    wrapped.__doc__ = "Serialize a simple %s node." % tag
+    wrapped.__doc__ = "Serialize a simple {0!s} node.".format(tag)
     return wrapped
 
 

--- a/Bio/Phylo/TreeConstruction.py
+++ b/Bio/Phylo/TreeConstruction.py
@@ -285,8 +285,7 @@ class _Matrix(object):
 
     def __repr__(self):
         return self.__class__.__name__ \
-            + "(names=%s, matrix=%s)" \
-            % tuple(map(repr, (self.names, self.matrix)))
+            + "(names={0!s}, matrix={1!s})".format(*tuple(map(repr, (self.names, self.matrix))))
 
     def __str__(self):
         """Get a lower triangular matrix string"""
@@ -432,11 +431,9 @@ class DistanceCalculator(object):
                 if l1 in skip_letters or l2 in skip_letters:
                     continue
                 if l1 not in self.scoring_matrix.names:
-                    raise ValueError("Bad alphabet '%s' in sequence '%s' at position '%s'"
-                                     % (l1, seq1.id, i))
+                    raise ValueError("Bad alphabet '{0!s}' in sequence '{1!s}' at position '{2!s}'".format(l1, seq1.id, i))
                 if l2 not in self.scoring_matrix.names:
-                    raise ValueError("Bad alphabet '%s' in sequence '%s' at position '%s'"
-                                     % (l2, seq2.id, i))
+                    raise ValueError("Bad alphabet '{0!s}' in sequence '{1!s}' at position '{2!s}'".format(l2, seq2.id, i))
                 max_score1 += self.scoring_matrix[l1, l1]
                 max_score2 += self.scoring_matrix[l2, l2]
                 score += self.scoring_matrix[l1, l2]

--- a/Bio/Phylo/_cdao_owl.py
+++ b/Bio/Phylo/_cdao_owl.py
@@ -18,11 +18,11 @@ def resolve_uri(s, namespaces=cdao_namespaces, cdao_to_obo=True, xml_style=False
     """
 
     if cdao_to_obo and s.startswith('cdao:'):
-        return resolve_uri('obo:%s' % cdao_elements[s[5:]], namespaces, cdao_to_obo)
+        return resolve_uri('obo:{0!s}'.format(cdao_elements[s[5:]]), namespaces, cdao_to_obo)
 
     for prefix in namespaces:
         if xml_style:
-            s = s.replace(prefix + ':', '{%s}' % namespaces[prefix])
+            s = s.replace(prefix + ':', '{{{0!s}}}'.format(namespaces[prefix]))
         else:
             s = s.replace(prefix + ':', namespaces[prefix])
 
@@ -2875,7 +2875,7 @@ cdao_elements = {}
 
 root = ET.fromstring(cdao_owl)
 for node_type in 'ObjectProperty', 'Class', 'DatatypeProperty':
-    for element in root.findall('{http://www.w3.org/2002/07/owl#}%s' % node_type):
+    for element in root.findall('{{http://www.w3.org/2002/07/owl#}}{0!s}'.format(node_type)):
         obo = element.attrib[
             '{http://www.w3.org/1999/02/22-rdf-syntax-ns#}about'].split('/')[-1]
         cdao = element.find(

--- a/Bio/Phylo/_utils.py
+++ b/Bio/Phylo/_utils.py
@@ -427,7 +427,7 @@ def draw(tree, label_func=str, do_show=True, show_confidence=True,
         fig = plt.figure()
         axes = fig.add_subplot(1, 1, 1)
     elif not isinstance(axes, plt.matplotlib.axes.Axes):
-        raise ValueError("Invalid argument for axes: %s" % axes)
+        raise ValueError("Invalid argument for axes: {0!s}".format(axes))
 
     def draw_clade_lines(use_linecollection=False, orientation='horizontal',
                          y_here=0, x_start=0, x_here=0, y_bot=0, y_top=0,
@@ -463,8 +463,8 @@ def draw(tree, label_func=str, do_show=True, show_confidence=True,
         # Add node/taxon labels
         label = label_func(clade)
         if label not in (None, clade.__class__.__name__):
-            axes.text(x_here, y_here, ' %s' %
-                      label, verticalalignment='center',
+            axes.text(x_here, y_here, ' {0!s}'.format(
+                      label), verticalalignment='center',
                       color=get_label_color(label))
         # Add label above the branch (optional)
         conf_label = format_branch_label(clade)

--- a/Bio/PopGen/FDist/Controller.py
+++ b/Bio/PopGen/FDist/Controller.py
@@ -92,7 +92,7 @@ class FDistController(object):
             sample_line = lines[1].rstrip().split(' ')
             sample = int(sample_line[9])
         else:
-            out, err = proc.communicate('%f\n%f\n%f %f\na\n' % (
+            out, err = proc.communicate('{0:f}\n{1:f}\n{2:f} {3:f}\na\n'.format(
                 crit_freq, p, beta[0], beta[1]))
             lines = out.split("\n")
             l = lines[0].rstrip().split(" ")
@@ -169,8 +169,8 @@ class FDistController(object):
             f.write(str(mut) + '\n')
         f.write(str(num_sims) + '\n')
         if is_dominant:
-            f.write("%f %f\n" % beta)
-            f.write("%f\n" % max_freq)
+            f.write("{0:f} {1:f}\n".format(*beta))
+            f.write("{0:f}\n".format(max_freq))
         f.close()
 
         self._generate_intfile(data_dir)

--- a/Bio/Restriction/PrintFormat.py
+++ b/Bio/Restriction/PrintFormat.py
@@ -274,12 +274,12 @@ class PrintFormat(object):
         for name, sites in iterator:
             l = len(sites)
             if l > cur_len:
-                title += "\n\nenzymes which cut %i times :\n\n" % cur_len
+                title += "\n\nenzymes which cut {0:d} times :\n\n".format(cur_len)
                 title = self.__next_section(new_sect, title)
                 new_sect, cur_len = [(name, sites)], l
                 continue
             new_sect.append((name, sites))
-        title += "\n\nenzymes which cut %i times :\n\n" % cur_len
+        title += "\n\nenzymes which cut {0:d} times :\n\n".format(cur_len)
         return self.__next_section(new_sect, title)
 
     def _make_map_only(self, ls, title, nc=[], s1=''):
@@ -411,7 +411,7 @@ class PrintFormat(object):
         ls.sort()
         indentation = '\n' + (self.NameWidth + self.Indent) * ' '
         linesize = self.linesize - self.MaxSize
-        pat = re.compile("([\w,\s()]){1,%i}[,\.]" % linesize)
+        pat = re.compile("([\w,\s()]){{1,{0:d}}}[,\.]".format(linesize))
         several, Join = '', ''.join
         for name, sites in ls:
             stringsite = ''

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -123,7 +123,7 @@ def _check_bases(seq_string):
         seq_string = seq_string.replace(c, "")
     # Check only allowed IUPAC letters
     if not set(seq_string).issubset(set("ABCDGHKMNRSTVWY")):
-        raise TypeError("Invalid character found in %s" % repr(seq_string))
+        raise TypeError("Invalid character found in {0!s}".format(repr(seq_string)))
     return " " + seq_string
 
 
@@ -172,13 +172,13 @@ class FormattedSeq(object):
             self.alphabet = seq.alphabet
             self.klass = seq.klass
         else:
-            raise TypeError('expected Seq or MutableSeq, got %s' % type(seq))
+            raise TypeError('expected Seq or MutableSeq, got {0!s}'.format(type(seq)))
 
     def __len__(self):
         return len(self.data) - 1
 
     def __repr__(self):
-        return 'FormattedSeq(%s, linear=%s)' % (repr(self[1:]), repr(self.linear))
+        return 'FormattedSeq({0!s}, linear={1!s})'.format(repr(self[1:]), repr(self.linear))
 
     def __eq__(self, other):
         if isinstance(other, FormattedSeq):
@@ -250,16 +250,14 @@ class RestrictionType(type):
 
         see below."""
         if "-" in name:
-            raise ValueError("Problem with hyphen in %s as enzyme name"
-                             % repr(name))
+            raise ValueError("Problem with hyphen in {0!s} as enzyme name".format(repr(name)))
         # 2011/11/26 - Nobody knows what this call was supposed to accomplish,
         # but all unit tests seem to pass without it.
         # super(RestrictionType, cls).__init__(cls, name, bases, dct)
         try:
             cls.compsite = re.compile(cls.compsite)
         except Exception as err:
-            raise ValueError("Problem with regular expression, re.compiled(%s)"
-                             % repr(cls.compsite))
+            raise ValueError("Problem with regular expression, re.compiled({0!s})".format(repr(cls.compsite)))
 
     def __add__(cls, other):
         """RE.__add__(other) -> RestrictionBatch().
@@ -325,7 +323,7 @@ class RestrictionType(type):
         """RE.__repr__() -> str.
 
         used with eval or exec will instantiate the enzyme."""
-        return "%s" % cls.__name__
+        return "{0!s}".format(cls.__name__)
 
     def __len__(cls):
         """RE.__len__() -> int.
@@ -381,7 +379,7 @@ class RestrictionType(type):
         True if a and b have compatible overhang."""
         if not isinstance(other, RestrictionType):
             raise TypeError(
-                  'expected RestrictionType, got %s instead' % type(other))
+                  'expected RestrictionType, got {0!s} instead'.format(type(other)))
         return cls._mod1(other)
 
     def __ge__(cls, other):
@@ -919,8 +917,7 @@ class Unknown(AbstractCut):
 
         if linear is False, the sequence is considered to be circular and the
         output will be modified accordingly."""
-        raise NotImplementedError('%s restriction is unknown.'
-                                  % self.__name__)
+        raise NotImplementedError('{0!s} restriction is unknown.'.format(self.__name__))
     catalyze = catalyse
 
     @classmethod
@@ -1642,8 +1639,7 @@ class Ambiguous(AbstractCut):
             elif f5 > length:
                 re = site + (f5 - length) * 'N' + '^_N'
             else:
-                raise ValueError('%s.easyrepr() : error f5=%i'
-                                 % (self.name, f5))
+                raise ValueError('{0!s}.easyrepr() : error f5={1:d}'.format(self.name, f5))
         else:
             if f3 == 0:
                 if f5 == 0:
@@ -1748,8 +1744,7 @@ class NotDefined(AbstractCut):
         #   could raise an Error may be rather than return quietly.
         #
         # return False
-        raise ValueError("%s.mod2(%s), %s : NotDefined. pas glop pas glop!"
-                         % (str(self), str(other), str(self)))
+        raise ValueError("{0!s}.mod2({1!s}), {2!s} : NotDefined. pas glop pas glop!".format(str(self), str(other), str(self)))
 
     @classmethod
     def elucidate(self):
@@ -1768,7 +1763,7 @@ class NotDefined(AbstractCut):
         '? GTATAC ?'
         >>>
         """
-        return '? %s ?' % self.site
+        return '? {0!s} ?'.format(self.site)
 
 
 class Commercially_available(AbstractCut):
@@ -1868,7 +1863,7 @@ class RestrictionBatch(set):
                                '+'.join(self.elements()[-2:])))
 
     def __repr__(self):
-        return 'RestrictionBatch(%s)' % self.elements()
+        return 'RestrictionBatch({0!s})'.format(self.elements())
 
     def __contains__(self, other):
         try:
@@ -1897,8 +1892,7 @@ class RestrictionBatch(set):
             self.add(e)
             return e
         else:
-            raise ValueError('enzyme %s is not in RestrictionBatch'
-                             % e.__name__)
+            raise ValueError('enzyme {0!s} is not in RestrictionBatch'.format(e.__name__))
 
     def lambdasplit(self, func):
         """B.lambdasplit(func) -> RestrictionBatch .
@@ -1980,7 +1974,7 @@ class RestrictionBatch(set):
                 pass
         except (NameError, SyntaxError):
             pass
-        raise ValueError('%s is not a RestrictionType' % y.__class__)
+        raise ValueError('{0!s} is not a RestrictionType'.format(y.__class__))
 
     def is_restriction(self, y):
         """B.is_restriction(y) -> bool.
@@ -2069,8 +2063,7 @@ class RestrictionBatch(set):
                 self.already_mapped = str(dna), dna.linear
                 self.mapping = dict((x, x.search(dna)) for x in self)
                 return self.mapping
-        raise TypeError("Expected Seq or MutableSeq instance, got %s instead"
-                        % type(dna))
+        raise TypeError("Expected Seq or MutableSeq instance, got {0!s} instead".format(type(dna)))
 
 ###############################################################################
 #                                                                             #
@@ -2097,8 +2090,7 @@ class Analysis(RestrictionBatch, PrintFormat):
             self.search(self.sequence, self.linear)
 
     def __repr__(self):
-        return 'Analysis(%s,%s,%s)' %\
-               (repr(self.rb), repr(self.sequence), self.linear)
+        return 'Analysis({0!s},{1!s},{2!s})'.format(repr(self.rb), repr(self.sequence), self.linear)
 
     def _sub_set(self, wanted):
         """A._sub_set(other_set) -> dict.
@@ -2117,9 +2109,9 @@ class Analysis(RestrictionBatch, PrintFormat):
         search to only part of the sequence given to analyse.
         """
         if not isinstance(start, int):
-            raise TypeError('expected int, got %s instead' % type(start))
+            raise TypeError('expected int, got {0!s} instead'.format(type(start)))
         if not isinstance(end, int):
-            raise TypeError('expected int, got %s instead' % type(end))
+            raise TypeError('expected int, got {0!s} instead'.format(type(end)))
         if start < 1:
             start += len(self.sequence)
         if end < 1:
@@ -2189,11 +2181,10 @@ class Analysis(RestrictionBatch, PrintFormat):
                 setattr(self, k, v)
             elif k in ('Cmodulo', 'PrefWidth'):
                 raise AttributeError(
-                    'To change %s, change NameWidth and/or ConsoleWidth'
-                    % name)
+                    'To change {0!s}, change NameWidth and/or ConsoleWidth'.format(name))
             else:
                 raise AttributeError(
-                    'Analysis has no attribute %s' % name)
+                    'Analysis has no attribute {0!s}'.format(name))
         return
 
     def full(self, linear=True):
@@ -2269,7 +2260,7 @@ class Analysis(RestrictionBatch, PrintFormat):
          Limit the search to the enzymes named in list_of_names."""
         for i, enzyme in enumerate(names):
             if enzyme not in AllEnzymes:
-                print("no data for the enzyme: %s" % name)
+                print("no data for the enzyme: {0!s}".format(name))
                 del names[i]
         if not dct:
             return RestrictionBatch(names).search(self.sequence)

--- a/Bio/SCOP/Cla.py
+++ b/Bio/SCOP/Cla.py
@@ -48,7 +48,7 @@ class Record(object):
         line = line.rstrip()         # no trailing whitespace
         columns = line.split('\t')   # separate the tab-delineated cols
         if len(columns) != 6:
-            raise ValueError("I don't understand the format of %s" % line)
+            raise ValueError("I don't understand the format of {0!s}".format(line))
 
         self.sid, pdbid, residues, self.sccs, self.sunid, hierarchy = columns
         self.residues = Residues.Residues(residues)

--- a/Bio/SCOP/Des.py
+++ b/Bio/SCOP/Des.py
@@ -55,7 +55,7 @@ class Record(object):
         line = line.rstrip()  # no trailing whitespace
         columns = line.split("\t")  # separate the tab-delineated cols
         if len(columns) != 5:
-            raise ValueError("I don't understand the format of %s" % line)
+            raise ValueError("I don't understand the format of {0!s}".format(line))
 
         sunid, self.nodetype, self.sccs, self.name, self.description = columns
         if self.name == '-':

--- a/Bio/SCOP/Dom.py
+++ b/Bio/SCOP/Dom.py
@@ -50,7 +50,7 @@ class Record(object):
         line = line.rstrip()  # no trailing whitespace
         columns = line.split("\t")  # separate the tab-delineated cols
         if len(columns) != 4:
-            raise ValueError("I don't understand the format of %s" % line)
+            raise ValueError("I don't understand the format of {0!s}".format(line))
         self.sid, pdbid, res, self.hierarchy = columns
         self.residues = Residues(res)
         self.residues.pdbid = pdbid

--- a/Bio/SCOP/Hie.py
+++ b/Bio/SCOP/Hie.py
@@ -46,7 +46,7 @@ class Record(object):
         line = line.rstrip()        # no trailing whitespace
         columns = line.split('\t')   # separate the tab-delineated cols
         if len(columns) != 3:
-            raise ValueError("I don't understand the format of %s" % line)
+            raise ValueError("I don't understand the format of {0!s}".format(line))
 
         sunid, parent, children = columns
 

--- a/Bio/SCOP/Residues.py
+++ b/Bio/SCOP/Residues.py
@@ -56,15 +56,15 @@ class Residues(object):
         for l in str.split(","):
             m = _fragment_re.match(l)
             if m is None:
-                raise ValueError("I don't understand the format of %s" % l)
+                raise ValueError("I don't understand the format of {0!s}".format(l))
             chain, start, end, postfix = m.groups()
 
             if postfix != "":
-                raise ValueError("I don't understand the format of %s" % l)
+                raise ValueError("I don't understand the format of {0!s}".format(l))
 
             if chain:
                 if chain[-1] != ':':
-                    raise ValueError("I don't understand the chain in %s" % l)
+                    raise ValueError("I don't understand the chain in {0!s}".format(l))
                 chain = chain[:-1]   # chop off the ':'
             else:
                 chain = ""
@@ -83,8 +83,8 @@ class Residues(object):
         for chain, start, end in self.fragments:
             s = []
             if chain:
-                s.append("%s:" % chain)
+                s.append("{0!s}:".format(chain))
             if start:
-                s.append("%s-%s" % (start, end))
+                s.append("{0!s}-{1!s}".format(start, end))
             strs.append("".join(s))
         return prefix + ",".join(strs)

--- a/Bio/SCOP/__init__.py
+++ b/Bio/SCOP/__init__.py
@@ -156,7 +156,7 @@ def parse_domain(str):
 
 
 def _open_scop_file(scop_dir_path, version, filetype):
-    filename = "dir.%s.scop.txt_%s" % (filetype, version)
+    filename = "dir.{0!s}.scop.txt_{1!s}".format(filetype, version)
     handle = open(os.path.join(scop_dir_path, filename))
     return handle
 
@@ -466,7 +466,7 @@ class Scop(object):
 
         for p in self._sunidDict.values():
             for c in p.children:
-                cur.execute("INSERT INTO hie VALUES (%s,%s)" % (p.sunid, c.sunid))
+                cur.execute("INSERT INTO hie VALUES ({0!s},{1!s})".format(p.sunid, c.sunid))
 
     def write_cla_sql(self, handle):
         """Write CLA data to SQL database"""
@@ -711,8 +711,8 @@ class Astral(object):
                 raise RuntimeError("must provide dir_path and version")
 
             self.version = version
-            self.path = os.path.join(dir_path, "scopseq-%s" % version)
-            astral_file = "astral-scopdom-seqres-all-%s.fa" % self.version
+            self.path = os.path.join(dir_path, "scopseq-{0!s}".format(version))
+            astral_file = "astral-scopdom-seqres-all-{0!s}.fa".format(self.version)
             astral_file = os.path.join(self.path, astral_file)
 
         if astral_file:
@@ -736,7 +736,7 @@ class Astral(object):
                     raise RuntimeError("No scopseq directory specified")
 
                 file_prefix = "astral-scopdom-seqres-sel-gs"
-                filename = "%s-e100m-%s-%s.id" % (file_prefix, astralEv_to_file[id],
+                filename = "{0!s}-e100m-{1!s}-{2!s}.id".format(file_prefix, astralEv_to_file[id],
                                                   self.version)
                 filename = os.path.join(self.path, filename)
                 self.EvDatasets[id] = self.getAstralDomainsFromFile(filename)
@@ -752,7 +752,7 @@ class Astral(object):
                     raise RuntimeError("No scopseq directory specified")
 
                 file_prefix = "astral-scopdom-seqres-sel-gs"
-                filename = "%s-bib-%s-%s.id" % (file_prefix, id, self.version)
+                filename = "{0!s}-bib-{1!s}-{2!s}.id".format(file_prefix, id, self.version)
                 filename = os.path.join(self.path, filename)
                 self.IdDatasets[id] = self.getAstralDomainsFromFile(filename)
         return self.IdDatasets[id]

--- a/Bio/SVDSuperimposer/__init__.py
+++ b/Bio/SVDSuperimposer/__init__.py
@@ -166,4 +166,4 @@ if __name__ == "__main__":
     print("")
     print(y_on_x2)
     print("")
-    print("%.2f" % rms)
+    print("{0:.2f}".format(rms))

--- a/Bio/SearchIO/BlastIO/blast_tab.py
+++ b/Bio/SearchIO/BlastIO/blast_tab.py
@@ -435,11 +435,11 @@ class BlastTabParser(object):
                     # try to set hit and query frame
                     frame = self._get_frag_frame(frag, seq_type,
                             prev['frag'])
-                    setattr(frag, '%s_frame' % seq_type, frame)
+                    setattr(frag, '{0!s}_frame'.format(seq_type), frame)
                     # try to set hit and query strand
                     strand = self._get_frag_strand(frag, seq_type,
                             prev['frag'])
-                    setattr(frag, '%s_strand' % seq_type, strand)
+                    setattr(frag, '{0!s}_strand'.format(seq_type), strand)
 
                 hsp = HSP([frag])
                 for attr, value in prev['hsp'].items():
@@ -476,7 +476,7 @@ class BlastTabParser(object):
         """Returns `HSPFragment` frame given the object, its sequence type,
         and its parsed dictionary values."""
         assert seq_type in ('query', 'hit')
-        frame = getattr(frag, '%s_frame' % seq_type, None)
+        frame = getattr(frag, '{0!s}_frame'.format(seq_type), None)
         if frame is not None:
             return frame
         else:
@@ -493,14 +493,14 @@ class BlastTabParser(object):
         # queries / hits, since we can't detect the blast flavors
         # from the columns alone.
         assert seq_type in ('query', 'hit')
-        strand = getattr(frag, '%s_strand' % seq_type, None)
+        strand = getattr(frag, '{0!s}_strand'.format(seq_type), None)
         if strand is not None:
             return strand
         else:
             # using parsedict instead of the fragment object since
             # we need the unadjusted coordinated values
-            start = parsedict.get('%s_start' % seq_type)
-            end = parsedict.get('%s_end' % seq_type)
+            start = parsedict.get('{0!s}_start'.format(seq_type))
+            end = parsedict.get('{0!s}_end'.format(seq_type))
             if start is not None and end is not None:
                 return 1 if start <= end else -1
             # else implicit None return
@@ -694,7 +694,7 @@ class BlastTabWriter(object):
 
         # commented files have a line saying how many queries were processed
         if self.has_comments:
-            handle.write('# BLAST processed %i queries' % qresult_counter)
+            handle.write('# BLAST processed {0:d} queries'.format(qresult_counter))
 
         return qresult_counter, hit_counter, hsp_counter, frag_counter
 
@@ -718,7 +718,7 @@ class BlastTabWriter(object):
                     # special case, since 'frames' can be determined from
                     # query frame and hit frame
                     elif field == 'frames':
-                        value = '%i/%i' % (hsp.query_frame, hsp.hit_frame)
+                        value = '{0:d}/{1:d}'.format(hsp.query_frame, hsp.hit_frame)
                     elif field in _COLUMN_HSP:
                         try:
                             value = getattr(hsp, _COLUMN_HSP[field][0])
@@ -752,16 +752,16 @@ class BlastTabWriter(object):
         # determine sequence type to operate on based on field's first letter
         seq_type = 'query' if field.startswith('q') else 'hit'
 
-        strand = getattr(hsp, '%s_strand' % seq_type, None)
+        strand = getattr(hsp, '{0!s}_strand'.format(seq_type), None)
         if strand is None:
-            raise ValueError("Required attribute %r not found." %
-                    ('%s_strand' % (seq_type)))
+            raise ValueError("Required attribute {0!r} not found.".format(
+                    ('{0!s}_strand'.format((seq_type)))))
         # switch start <--> end coordinates if strand is -1
         if strand < 0:
             if field.endswith('start'):
-                value = getattr(hsp, '%s_end' % seq_type)
+                value = getattr(hsp, '{0!s}_end'.format(seq_type))
             elif field.endswith('end'):
-                value = getattr(hsp, '%s_start' % seq_type) + 1
+                value = getattr(hsp, '{0!s}_start'.format(seq_type)) + 1
         elif field.endswith('start'):
             # adjust start coordinate for positive strand
             value += 1
@@ -780,36 +780,36 @@ class BlastTabWriter(object):
             if value < 1.0e-180:
                 value = '0.0'
             elif value < 1.0e-99:
-                value = '%2.0e' % value
+                value = '{0:2.0e}'.format(value)
             elif value < 0.0009:
-                value = '%3.0e' % value
+                value = '{0:3.0e}'.format(value)
             elif value < 0.1:
-                value = '%4.3f' % value
+                value = '{0:4.3f}'.format(value)
             elif value < 1.0:
-                value = '%3.2f' % value
+                value = '{0:3.2f}'.format(value)
             elif value < 10.0:
-                value = '%2.1f' % value
+                value = '{0:2.1f}'.format(value)
             else:
-                value = '%5.0f' % value
+                value = '{0:5.0f}'.format(value)
 
         # pident and ppos formatting
         elif field in ('pident', 'ppos'):
-            value = '%.2f' % value
+            value = '{0:.2f}'.format(value)
 
         # evalue formatting, adapted from BLAST+ source:
         # src/objtools/align_format/align_format_util.cpp#L723
         elif field == 'bitscore':
             if value > 9999:
-                value = '%4.3e' % value
+                value = '{0:4.3e}'.format(value)
             elif value > 99.9:
-                value = '%4.0d' % value
+                value = '{0:4.0d}'.format(value)
             else:
-                value = '%4.1f' % value
+                value = '{0:4.1f}'.format(value)
 
         # coverages have no comma (using floats still ~ a more proper
         # representation)
         elif field in ('qcovhsp', 'qcovs'):
-            value = '%.0f' % value
+            value = '{0:.0f}'.format(value)
 
         # list into '<>'-delimited string
         elif field == 'salltitles':
@@ -835,26 +835,26 @@ class BlastTabWriter(object):
 
         # try to anticipate qress without version
         if not hasattr(qres, 'version'):
-            program_line = '# %s' % qres.program.upper()
+            program_line = '# {0!s}'.format(qres.program.upper())
         else:
-            program_line = '# %s %s' % (qres.program.upper(), qres.version)
+            program_line = '# {0!s} {1!s}'.format(qres.program.upper(), qres.version)
         comments.append(program_line)
         # description may or may not be None
         if qres.description is None:
-            comments.append('# Query: %s' % qres.id)
+            comments.append('# Query: {0!s}'.format(qres.id))
         else:
-            comments.append('# Query: %s %s' % (qres.id, qres.description))
+            comments.append('# Query: {0!s} {1!s}'.format(qres.id, qres.description))
         # try appending RID line, if present
         try:
-            comments.append('# RID: %s' % qres.rid)
+            comments.append('# RID: {0!s}'.format(qres.rid))
         except AttributeError:
             pass
-        comments.append('# Database: %s' % qres.target)
+        comments.append('# Database: {0!s}'.format(qres.target))
         # qresults without hits don't show the Fields comment
         if qres:
-            comments.append('# Fields: %s' %
-                            ', '.join(inv_field_map[field] for field in self.fields))
-        comments.append('# %i hits found' % len(qres))
+            comments.append('# Fields: {0!s}'.format(
+                            ', '.join(inv_field_map[field] for field in self.fields)))
+        comments.append('# {0:d} hits found'.format(len(qres)))
 
         return '\n'.join(comments) + '\n'
 

--- a/Bio/SearchIO/BlastIO/blast_xml.py
+++ b/Bio/SearchIO/BlastIO/blast_xml.py
@@ -322,7 +322,7 @@ class BlastXmlParser(object):
                                     (hit._blast_id, hit.id, query_id), BiopythonParserWarning)
                             # fallback to Blast-generated IDs, if the ID is already present
                             # and restore the desc, too
-                            hit.description = '%s %s' % (hit.id, hit.description)
+                            hit.description = '{0!s} {1!s}'.format(hit.id, hit.description)
                             hit.id = hit._blast_id
                             # and change the hit_id of the HSPs contained
                             for hsp in hit:
@@ -586,8 +586,8 @@ class BlastXmlIndexer(SearchIndexer):
                     block.append(line)
                 assert line.rstrip().endswith(qend_mark), line
                 block = _empty_bytes_string.join(block)
-            assert block.count(qstart_mark) == 1, "XML without line breaks? %r" % block
-            assert block.count(qend_mark) == 1, "XML without line breaks? %r" % block
+            assert block.count(qstart_mark) == 1, "XML without line breaks? {0!r}".format(block)
+            assert block.count(qend_mark) == 1, "XML without line breaks? {0!r}".format(block)
             # Now we have a full <Iteration>...</Iteration> block, find the ID
             regx = re.search(re_desc, block)
             try:
@@ -792,7 +792,7 @@ class BlastXmlWriter(object):
                     "found" % (elem, attr)
             else:
                 if elem == 'BlastOutput_version':
-                    content = '%s %s' % (qresult.program.upper(),
+                    content = '{0!s} {1!s}'.format(qresult.program.upper(),
                             qresult.version)
                 elif qresult._blast_id:
                     if elem == 'BlastOutput_query-ID':
@@ -878,8 +878,7 @@ class BlastXmlWriter(object):
                 # make sure any elements that is not present is optional
                 # in the DTD
                 except AttributeError:
-                    assert elem in _DTD_OPT, "Element %s (attribute %s) not found" \
-                            % (elem, attr)
+                    assert elem in _DTD_OPT, "Element {0!s} (attribute {1!s}) not found".format(elem, attr)
                 else:
                     xml.simpleElement(elem, str(content))
             self.hsp_counter += 1

--- a/Bio/SearchIO/BlatIO.py
+++ b/Bio/SearchIO/BlatIO.py
@@ -231,8 +231,7 @@ def _reorient_starts(starts, blksizes, seqlen, strand):
 
     """
     assert len(starts) == len(blksizes), \
-            "Unequal start coordinates and block sizes list (%r vs %r)" \
-            % (len(starts), len(blksizes))
+            "Unequal start coordinates and block sizes list ({0!r} vs {1!r})".format(len(starts), len(blksizes))
     # see: http://genome.ucsc.edu/goldenPath/help/blatSpec.html
     # no need to reorient if it's already the positive strand
     if strand >= 0:
@@ -628,7 +627,7 @@ class BlatPslWriter(object):
         "\tT  \tblock\tblockSizes \tqStarts\t tStarts\n     " \
         "\tmatch\tmatch\t   \tcount\tbases\tcount\tbases\t      \tname     "
         "\tsize\tstart\tend\tname     \tsize\tstart\tend\tcount"
-        "\n%s\n" % ('-' * 159)
+        "\n{0!s}\n".format(('-' * 159))
 
         return header
 

--- a/Bio/SearchIO/ExonerateIO/exonerate_text.py
+++ b/Bio/SearchIO/ExonerateIO/exonerate_text.py
@@ -263,8 +263,8 @@ def _comp_coords(hsp, seq_type, inter_lens):
     """Fill the block coordinates of the given hsp dictionary."""
     assert seq_type in ('hit', 'query')
     # manually fill the first coord
-    seq_step = 1 if hsp['%s_strand' % seq_type] >= 0 else -1
-    fstart = hsp['%s_start' % seq_type]
+    seq_step = 1 if hsp['{0!s}_strand'.format(seq_type)] >= 0 else -1
+    fstart = hsp['{0!s}_start'.format(seq_type)]
     # fend is fstart + number of residues in the sequence, minus gaps
     fend = fstart + len(
             hsp[seq_type][0].replace('-', '').replace('>',
@@ -298,8 +298,8 @@ def _comp_split_codons(hsp, seq_type, scodon_moves):
         else:
             assert not all(pair)
         a, b = pair
-        anchor_pair = hsp['%s_ranges' % seq_type][idx // 2]
-        strand = 1 if hsp['%s_strand' % seq_type] >= 0 else -1
+        anchor_pair = hsp['{0!s}_ranges'.format(seq_type)][idx // 2]
+        strand = 1 if hsp['{0!s}_strand'.format(seq_type)] >= 0 else -1
 
         if a:
             func = max if strand == 1 else min
@@ -409,23 +409,23 @@ class ExonerateTextParser(_BaseExonerateParser):
 
             # check that inter_lens's length is len opp_type block - 1
             assert len(inter_lens) == len(hsp[opp_type]) - 1, \
-                    "%r vs %r" % (len(inter_lens), len(hsp[opp_type]) - 1)
+                    "{0!r} vs {1!r}".format(len(inter_lens), len(hsp[opp_type]) - 1)
             # fill the hsp query and hit coordinates
-            hsp['%s_ranges' % opp_type] = \
+            hsp['{0!s}_ranges'.format(opp_type)] = \
                     _comp_coords(hsp, opp_type, inter_lens)
             # and fill the split codon coordinates, if model != ner
             # can't do this in the if-else clause above since we need to
             # compute the ranges first
             if not has_ner:
-                hsp['%s_split_codons' % opp_type] = \
+                hsp['{0!s}_split_codons'.format(opp_type)] = \
                         _comp_split_codons(hsp, opp_type, scodon_moves)
 
         # now that we've finished parsing coords, we can set the hit and start
         # coord according to Biopython's convention (start <= end)
         for seq_type in ('query', 'hit'):
-            if hsp['%s_strand' % seq_type] == -1:
-                n_start = '%s_start' % seq_type
-                n_end = '%s_end' % seq_type
+            if hsp['{0!s}_strand'.format(seq_type)] == -1:
+                n_start = '{0!s}_start'.format(seq_type)
+                n_end = '{0!s}_end'.format(seq_type)
                 hsp[n_start], hsp[n_end] = hsp[n_end], hsp[n_start]
 
         return {'qresult': qresult, 'hit': hit, 'hsp': hsp}

--- a/Bio/SearchIO/ExonerateIO/exonerate_vulgar.py
+++ b/Bio/SearchIO/ExonerateIO/exonerate_vulgar.py
@@ -50,7 +50,7 @@ def parse_vulgar_comp(hsp, vulgar_comp):
     for idx, match in enumerate(vcomps):
         label, qstep, hstep = match[0], int(match[1]), int(match[2])
         # check for label, must be recognized
-        assert label in 'MCGF53INS', "Unexpected vulgar label: %r" % label
+        assert label in 'MCGF53INS', "Unexpected vulgar label: {0!r}".format(label)
         # match, codon, or gaps
         if label in 'MCGS':
             # if the previous comp is not an MCGS block, it's the

--- a/Bio/SearchIO/FastaIO.py
+++ b/Bio/SearchIO/FastaIO.py
@@ -196,8 +196,7 @@ def _set_hsp_seqs(hsp, parsed, program):
             start = start + start_adj
             stop = stop + start_adj - stop_adj
             parsed[seq_type]['seq'] = pseq['seq'][start:stop]
-    assert len(parsed['query']['seq']) == len(parsed['hit']['seq']), "%r %r" \
-            % (len(parsed['query']['seq']), len(parsed['hit']['seq']))
+    assert len(parsed['query']['seq']) == len(parsed['hit']['seq']), "{0!r} {1!r}".format(len(parsed['query']['seq']), len(parsed['hit']['seq']))
     if 'similarity' in hsp.aln_annotation:
         # only using 'start' since FASTA seems to have trimmed the 'excess'
         # end part
@@ -259,8 +258,7 @@ def _get_aln_slice_coords(parsed_hsp):
         stop = disp_start - stop + 1
     stop += seq_stripped.count('-')
     assert 0 <= start and start < stop and stop <= len(seq_stripped), \
-           "Problem with sequence start/stop,\n%s[%i:%i]\n%s" \
-           % (seq, start, stop, parsed_hsp)
+           "Problem with sequence start/stop,\n{0!s}[{1:d}:{2:d}]\n{3!s}".format(seq, start, stop, parsed_hsp)
     return start, stop
 
 
@@ -451,7 +449,7 @@ class FastaM10Parser(object):
                 if state == _STATE_NONE:
                     # make sure it's the correct query
                     assert query_id.startswith(self.line[1:].split(' ')[0]), \
-                            "%r vs %r" % (query_id, self.line)
+                            "{0!r} vs {1!r}".format(query_id, self.line)
                     state = _STATE_QUERY_BLOCK
                     parsed_hsp['query']['seq'] = ''
                 elif state == _STATE_QUERY_BLOCK:
@@ -490,7 +488,7 @@ class FastaM10Parser(object):
                         parsed_hsp['hit'][name] = value
                 # for values in the hit block
                 else:
-                    raise ValueError("Unexpected line: %r" % self.line)
+                    raise ValueError("Unexpected line: {0!r}".format(self.line))
             # otherwise, it must be lines containing the sequences
             else:
                 assert '>' not in self.line
@@ -504,7 +502,7 @@ class FastaM10Parser(object):
                             self.line.strip('\r\n')
                 # we should not get here!
                 else:
-                    raise ValueError("Unexpected line: %r" % self.line)
+                    raise ValueError("Unexpected line: {0!r}".format(self.line))
 
             self.line = self.handle.readline()
 

--- a/Bio/SearchIO/HmmerIO/hmmer3_text.py
+++ b/Bio/SearchIO/HmmerIO/hmmer3_text.py
@@ -331,7 +331,7 @@ class Hmmer3TextParser(object):
             if self.line.startswith('>>') or \
                     self.line.startswith('Internal pipeline'):
                 return hsp_list
-            assert self.line.startswith('  == domain %i' % (dom_counter + 1))
+            assert self.line.startswith('  == domain {0:d}'.format((dom_counter + 1)))
             # alias hsp to local var
             # but note that we're still changing the attrs of the actual
             # hsp inside the qresult as we're not creating a copy

--- a/Bio/SearchIO/__init__.py
+++ b/Bio/SearchIO/__init__.py
@@ -416,7 +416,7 @@ def to_dict(qresults, key_function=lambda rec: rec.id):
     for qresult in qresults:
         key = key_function(qresult)
         if key in qdict:
-            raise ValueError("Duplicate key %r" % key)
+            raise ValueError("Duplicate key {0!r}".format(key))
         qdict[key] = qresult
     return qdict
 
@@ -485,8 +485,7 @@ def index(filename, format=None, key_function=None, **kwargs):
 
     from Bio.File import _IndexedSeqFileDict
     proxy_class = get_processor(format, _INDEXER_MAP)
-    repr = "SearchIO.index(%r, %r, key_function=%r)" \
-        % (filename, format, key_function)
+    repr = "SearchIO.index({0!r}, {1!r}, key_function={2!r})".format(filename, format, key_function)
     return _IndexedSeqFileDict(proxy_class(filename, **kwargs),
                                key_function, repr, "QueryResult")
 
@@ -558,8 +557,7 @@ def index_db(index_filename, filenames=None, format=None,
         filenames = [filenames]
 
     from Bio.File import _SQLiteManySeqFilesDict
-    repr = "SearchIO.index_db(%r, filenames=%r, format=%r, key_function=%r, ...)" \
-               % (index_filename, filenames, format, key_function)
+    repr = "SearchIO.index_db({0!r}, filenames={1!r}, format={2!r}, key_function={3!r}, ...)".format(index_filename, filenames, format, key_function)
 
     def proxy_factory(format, filename=None):
         """Given a filename returns proxy object, else boolean if format OK."""

--- a/Bio/SearchIO/_model/_base.py
+++ b/Bio/SearchIO/_model/_base.py
@@ -46,11 +46,9 @@ class _BaseHSP(_BaseSearchObject):
         """Prints the alignment header info."""
         lines = []
         # set query id line
-        qid_line = trim_str('      Query: %s %s' %
-                (self.query_id, self.query_description), 80, '...')
+        qid_line = trim_str('      Query: {0!s} {1!s}'.format(self.query_id, self.query_description), 80, '...')
         # set hit id line
-        hid_line = trim_str('        Hit: %s %s' %
-                (self.hit_id, self.hit_description), 80, '...')
+        hid_line = trim_str('        Hit: {0!s} {1!s}'.format(self.hit_id, self.hit_description), 80, '...')
         lines.append(qid_line)
         lines.append(hid_line)
 
@@ -67,9 +65,9 @@ class _BaseHSP(_BaseSearchObject):
         except ValueError:
             qstrand = self.query_strand_all[0]
             hstrand = self.hit_strand_all[0]
-        lines.append('Query range: [%s:%s] (%r)' % (query_start, query_end,
+        lines.append('Query range: [{0!s}:{1!s}] ({2!r})'.format(query_start, query_end,
                 qstrand))
-        lines.append('  Hit range: [%s:%s] (%r)' % (hit_start, hit_end,
+        lines.append('  Hit range: [{0!s}:{1!s}] ({2!r})'.format(hit_start, hit_end,
                 hstrand))
 
         return '\n'.join(lines)

--- a/Bio/SearchIO/_model/hit.py
+++ b/Bio/SearchIO/_model/hit.py
@@ -147,7 +147,7 @@ class Hit(_BaseSearchObject):
             self.append(hsp)
 
     def __repr__(self):
-        return "Hit(id=%r, query_id=%r, %r hsps)" % (self.id, self.query_id,
+        return "Hit(id={0!r}, query_id={1!r}, {2!r} hsps)".format(self.id, self.query_id,
                 len(self))
 
     def __iter__(self):
@@ -170,18 +170,18 @@ class Hit(_BaseSearchObject):
         lines = []
 
         # set query id line
-        qid_line = 'Query: %s' % self.query_id
+        qid_line = 'Query: {0!s}'.format(self.query_id)
         if self.query_description:
-            qid_line += trim_str('\n       %s' %
-                    self.query_description, 80, '...')
+            qid_line += trim_str('\n       {0!s}'.format(
+                    self.query_description), 80, '...')
         lines.append(qid_line)
 
         # set hit id line
-        hid_line = '  Hit: %s' % self.id
+        hid_line = '  Hit: {0!s}'.format(self.id)
         if hasattr(self, 'seq_len'):
-            hid_line += ' (%i)' % self.seq_len
+            hid_line += ' ({0:d})'.format(self.seq_len)
         if self.description:
-            hid_line += trim_str('\n       %s' % self.description,
+            hid_line += trim_str('\n       {0!s}'.format(self.description),
                     80, '...')
         lines.append(hid_line)
 
@@ -189,8 +189,7 @@ class Hit(_BaseSearchObject):
         if not self.hsps:
             lines.append(' HSPs: ?')
         else:
-            lines.append(' HSPs: %s  %s  %s  %s  %s  %s' %
-                    ('-' * 4, '-' * 8, '-' * 9, '-' * 6, '-' * 15, '-' * 21))
+            lines.append(' HSPs: {0!s}  {1!s}  {2!s}  {3!s}  {4!s}  {5!s}'.format('-' * 4, '-' * 8, '-' * 9, '-' * 6, '-' * 15, '-' * 21))
             pattern = '%11s  %8s  %9s  %6s  %15s  %21s'
             lines.append(pattern % ('#', 'E-value', 'Bit score', 'Span',
                     'Query range', 'Hit range'))
@@ -205,13 +204,13 @@ class Hit(_BaseSearchObject):
                 # query region
                 query_start = getattr_str(hsp, 'query_start')
                 query_end = getattr_str(hsp, 'query_end')
-                query_range = '[%s:%s]' % (query_start, query_end)
+                query_range = '[{0!s}:{1!s}]'.format(query_start, query_end)
                 # max column length is 18
                 query_range = trim_str(query_range, 15, '~]')
                 # hit region
                 hit_start = getattr_str(hsp, 'hit_start')
                 hit_end = getattr_str(hsp, 'hit_end')
-                hit_range = '[%s:%s]' % (hit_start, hit_end)
+                hit_range = '[{0!s}:{1!s}]'.format(hit_start, hit_end)
                 hit_range = trim_str(hit_range, 21, '~]')
                 # append the hsp row
                 lines.append(pattern % (str(idx), evalue, bitscore, aln_span,

--- a/Bio/SearchIO/_model/hsp.py
+++ b/Bio/SearchIO/_model/hsp.py
@@ -282,8 +282,7 @@ class HSP(_BaseHSP):
             self._items.append(fragment)
 
     def __repr__(self):
-        return "%s(hit_id=%r, query_id=%r, %r fragments)" % \
-                (self.__class__.__name__, self.hit_id, self.query_id, len(self))
+        return "{0!s}(hit_id={1!r}, query_id={2!r}, {3!r} fragments)".format(self.__class__.__name__, self.hit_id, self.query_id, len(self))
 
     def __iter__(self):
         return iter(self._items)
@@ -318,8 +317,7 @@ class HSP(_BaseHSP):
             return '\n'.join([self._str_hsp_header(), '\n'.join(lines),
                     self.fragments[0]._str_aln()])
         else:
-            lines.append('  Fragments: %s  %s  %s  %s' %
-                    ('-' * 3, '-' * 14, '-' * 22, '-' * 22))
+            lines.append('  Fragments: {0!s}  {1!s}  {2!s}  {3!s}'.format('-' * 3, '-' * 14, '-' * 22, '-' * 22))
             pattern = '%16s  %14s  %22s  %22s'
             lines.append(pattern % ('#', 'Span', 'Query range', 'Hit range'))
             lines.append(pattern % ('-' * 3, '-' * 14, '-' * 22, '-' * 22))
@@ -330,13 +328,13 @@ class HSP(_BaseHSP):
                 # query region
                 query_start = getattr_str(block, 'query_start')
                 query_end = getattr_str(block, 'query_end')
-                query_range = '[%s:%s]' % (query_start, query_end)
+                query_range = '[{0!s}:{1!s}]'.format(query_start, query_end)
                 # max column length is 20
                 query_range = trim_str(query_range, 22, '~]')
                 # hit region
                 hit_start = getattr_str(block, 'hit_start')
                 hit_end = getattr_str(block, 'hit_end')
-                hit_range = '[%s:%s]' % (hit_start, hit_end)
+                hit_range = '[{0!s}:{1!s}]'.format(hit_start, hit_end)
                 hit_range = trim_str(hit_range, 22, '~]')
                 # append the hsp row
                 lines.append(pattern % (str(idx), aln_span, query_range, hit_range))
@@ -404,11 +402,11 @@ class HSP(_BaseHSP):
     def _get_coords(self, seq_type, coord_type):
         assert seq_type in ('hit', 'query')
         assert coord_type in ('start', 'end')
-        coord_name = '%s_%s' % (seq_type, coord_type)
+        coord_name = '{0!s}_{1!s}'.format(seq_type, coord_type)
         coords = [getattr(frag, coord_name) for frag in self.fragments]
         if None in coords:
-            warnings.warn("'None' exist in %s coordinates; ignored" %
-                    (coord_name), BiopythonWarning)
+            warnings.warn("'None' exist in {0!s} coordinates; ignored".format(
+                    (coord_name)), BiopythonWarning)
         return coords
 
     def _hit_start_get(self):
@@ -469,8 +467,8 @@ class HSP(_BaseHSP):
     def _inter_ranges_get(self, seq_type):
         # this property assumes that there are no mixed strands in a hit/query
         assert seq_type in ('query', 'hit')
-        strand = getattr(self, '%s_strand_all' % seq_type)[0]
-        coords = getattr(self, '%s_range_all' % seq_type)
+        strand = getattr(self, '{0!s}_strand_all'.format(seq_type))[0]
+        coords = getattr(self, '{0!s}_range_all'.format(seq_type))
         # determine function used to set inter range
         # start and end coordinates, given two pairs
         # of fragment start and end coordinates
@@ -500,7 +498,7 @@ class HSP(_BaseHSP):
 
     def _inter_spans_get(self, seq_type):
         assert seq_type in ('query', 'hit')
-        attr_name = '%s_inter_ranges' % seq_type
+        attr_name = '{0!s}_inter_ranges'.format(seq_type)
         return [coord[1] - coord[0] for coord in getattr(self, attr_name)]
 
     def _hit_inter_spans_get(self):
@@ -692,11 +690,11 @@ class HSPFragment(_BaseHSP):
 
         for seq_type in ('query', 'hit'):
             # query or hit attributes default attributes
-            setattr(self, '_%s_description' % seq_type, '<unknown description>')
-            setattr(self, '_%s_features' % seq_type, [])
+            setattr(self, '_{0!s}_description'.format(seq_type), '<unknown description>')
+            setattr(self, '_{0!s}_features'.format(seq_type), [])
             # query or hit attributes whose default attribute is None
             for attr in ('strand', 'frame', 'start', 'end'):
-                setattr(self, '%s_%s' % (seq_type, attr), None)
+                setattr(self, '{0!s}_{1!s}'.format(seq_type, attr), None)
             # self.query or self.hit
             if eval(seq_type):
                 setattr(self, seq_type, eval(seq_type))
@@ -704,12 +702,12 @@ class HSPFragment(_BaseHSP):
                 setattr(self, seq_type, None)
 
     def __repr__(self):
-        info = "hit_id=%r, query_id=%r" % (self.hit_id, self.query_id)
+        info = "hit_id={0!r}, query_id={1!r}".format(self.hit_id, self.query_id)
         try:
-            info += ", %i columns" % len(self)
+            info += ", {0:d} columns".format(len(self))
         except AttributeError:
             pass
-        return "%s(%s)" % (self.__class__.__name__, info)
+        return "{0!s}({1!s})".format(self.__class__.__name__, info)
 
     def __len__(self):
         return self.aln_span
@@ -734,7 +732,7 @@ class HSPFragment(_BaseHSP):
             # description, strand, frame
             for attr in ('description', 'strand', 'frame'):
                 for seq_type in ('hit', 'query'):
-                    attr_name = '%s_%s' % (seq_type, attr)
+                    attr_name = '{0!s}_{1!s}'.format(seq_type, attr)
                     self_val = getattr(self, attr_name)
                     setattr(obj, attr_name, self_val)
             # alignment annotation should be transferred, since we can compute
@@ -752,7 +750,7 @@ class HSPFragment(_BaseHSP):
         lines = []
         # alignment length
         aln_span = getattr_str(self, 'aln_span')
-        lines.append('  Fragments: 1 (%s columns)' % aln_span)
+        lines.append('  Fragments: 1 ({0!s} columns)'.format(aln_span))
         # sequences
         if self.query is not None and self.hit is not None:
             try:
@@ -771,10 +769,10 @@ class HSPFragment(_BaseHSP):
                 simil = self.aln_annotation['similarity']
 
             if self.aln_span <= 67:
-                lines.append("%10s - %s" % ('Query', qseq))
+                lines.append("{0:10!s} - {1!s}".format('Query', qseq))
                 if simil:
-                    lines.append("             %s" % simil)
-                lines.append("%10s - %s" % ('Hit', hseq))
+                    lines.append("             {0!s}".format(simil))
+                lines.append("{0:10!s} - {1!s}".format('Hit', hseq))
             else:
                 # adjust continuation character length, so we don't display
                 # the same residues twice
@@ -782,12 +780,11 @@ class HSPFragment(_BaseHSP):
                     cont = '~' * 3
                 else:
                     cont = '~' * (self.aln_span - 66)
-                lines.append("%10s - %s%s%s" % ('Query',
+                lines.append("{0:10!s} - {1!s}{2!s}{3!s}".format('Query',
                                 qseq[:59], cont, qseq[-5:]))
                 if simil:
-                    lines.append("             %s%s%s" %
-                            (simil[:59], cont, simil[-5:]))
-                lines.append("%10s - %s%s%s" % ('Hit',
+                    lines.append("             {0!s}{1!s}{2!s}".format(simil[:59], cont, simil[-5:]))
+                lines.append("{0:10!s} - {1!s}{2!s}{3!s}".format('Hit',
                                 hseq[:59], cont, hseq[-5:]))
 
         return '\n'.join(lines)
@@ -811,17 +808,17 @@ class HSPFragment(_BaseHSP):
                         " object." % seq_type)
         # check length if the opposite sequence is not None
         opp_type = 'hit' if seq_type == 'query' else 'query'
-        opp_seq = getattr(self, '_%s' % opp_type, None)
+        opp_seq = getattr(self, '_{0!s}'.format(opp_type), None)
         if opp_seq is not None:
             if len(seq) != len(opp_seq):
                 raise ValueError("Sequence lengths do not match. Expected: "
                         "%r (%s); found: %r (%s)." % (len(opp_seq), opp_type,
                         len(seq), seq_type))
 
-        seq_id = getattr(self, '%s_id' % seq_type)
-        seq_desc = getattr(self, '%s_description' % seq_type)
-        seq_feats = getattr(self, '%s_features' % seq_type)
-        seq_name = 'aligned %s sequence' % seq_type
+        seq_id = getattr(self, '{0!s}_id'.format(seq_type))
+        seq_desc = getattr(self, '{0!s}_description'.format(seq_type))
+        seq_feats = getattr(self, '{0!s}_features'.format(seq_type))
+        seq_name = 'aligned {0!s} sequence'.format(seq_type)
 
         if isinstance(seq, SeqRecord):
             seq.id = seq_id
@@ -926,23 +923,23 @@ class HSPFragment(_BaseHSP):
     def _prep_strand(self, strand):
         # follow SeqFeature's convention
         if strand not in (-1, 0, 1, None):
-            raise ValueError("Strand should be -1, 0, 1, or None; not %r" %
-                    strand)
+            raise ValueError("Strand should be -1, 0, 1, or None; not {0!r}".format(
+                    strand))
         return strand
 
     def _get_strand(self, seq_type):
         assert seq_type in ('hit', 'query')
-        strand = getattr(self, '_%s_strand' % seq_type)
+        strand = getattr(self, '_{0!s}_strand'.format(seq_type))
 
         if strand is None:
             # try to compute strand from frame
-            frame = getattr(self, '%s_frame' % seq_type)
+            frame = getattr(self, '{0!s}_frame'.format(seq_type))
             if frame is not None:
                 try:
                     strand = frame // abs(frame)
                 except ZeroDivisionError:
                     strand = 0
-                setattr(self, '%s_strand' % seq_type, strand)
+                setattr(self, '{0!s}_strand'.format(seq_type), strand)
 
         return strand
 

--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -302,46 +302,46 @@ class QueryResult(_BaseSearchObject):
     __nonzero__ = __bool__
 
     def __repr__(self):
-        return "QueryResult(id=%r, %r hits)" % (self.id, len(self))
+        return "QueryResult(id={0!r}, {1!r} hits)".format(self.id, len(self))
 
     def __str__(self):
         lines = []
 
         # set program and version line
-        lines.append('Program: %s (%s)' % (self.program, self.version))
+        lines.append('Program: {0!s} ({1!s})'.format(self.program, self.version))
 
         # set query id line
-        qid_line = '  Query: %s' % self.id
+        qid_line = '  Query: {0!s}'.format(self.id)
         if hasattr(self, 'seq_len'):
-            qid_line += ' (%i)' % self.seq_len
+            qid_line += ' ({0:d})'.format(self.seq_len)
         if self.description:
-            qid_line += trim_str('\n         %s' % self.description, 80, '...')
+            qid_line += trim_str('\n         {0!s}'.format(self.description), 80, '...')
         lines.append(qid_line)
 
         # set target line
-        lines.append(' Target: %s' % self.target)
+        lines.append(' Target: {0!s}'.format(self.target))
 
         # set hit lines
         if not self.hits:
             lines.append('   Hits: 0')
         else:
-            lines.append('   Hits: %s  %s  %s' % ('-' * 4, '-' * 5, '-' * 58))
+            lines.append('   Hits: {0!s}  {1!s}  {2!s}'.format('-' * 4, '-' * 5, '-' * 58))
             pattern = '%13s  %5s  %s'
             lines.append(pattern % ('#', '# HSP', 'ID + description'))
             lines.append(pattern % ('-' * 4, '-' * 5, '-' * 58))
             for idx, hit in enumerate(self.hits):
                 if idx < 30:
-                    hid_line = '%s  %s' % (hit.id, hit.description)
+                    hid_line = '{0!s}  {1!s}'.format(hit.id, hit.description)
                     if len(hid_line) > 58:
                         hid_line = hid_line[:55] + '...'
                     lines.append(pattern % (idx, str(len(hit)), hid_line))
                 elif idx > len(self.hits) - 4:
-                    hid_line = '%s  %s' % (hit.id, hit.description)
+                    hid_line = '{0!s}  {1!s}'.format(hit.id, hit.description)
                     if len(hid_line) > 58:
                         hid_line = hid_line[:55] + '...'
                     lines.append(pattern % (idx, str(len(hit)), hid_line))
                 elif idx == 30:
-                    lines.append('%14s' % '~~~')
+                    lines.append('{0:14!s}'.format('~~~'))
 
         return '\n'.join(lines)
 

--- a/Bio/SearchIO/_utils.py
+++ b/Bio/SearchIO/_utils.py
@@ -26,14 +26,14 @@ def get_processor(format, mapping):
         elif not isinstance(format, basestring):
             raise TypeError("Need a string for the file format (lower case)")
         elif format != format.lower():
-            raise ValueError("Format string %r should be lower case" %
-                    format)
+            raise ValueError("Format string {0!r} should be lower case".format(
+                    format))
         else:
             raise ValueError("Unknown format %r. Supported formats are "
                     "%r" % (format, "', '".join(mapping)))
 
     mod_name, obj_name = obj_info
-    mod = __import__('Bio.SearchIO.%s' % mod_name, fromlist=[''])
+    mod = __import__('Bio.SearchIO.{0!s}'.format(mod_name), fromlist=[''])
 
     return getattr(mod, obj_name)
 
@@ -118,7 +118,7 @@ def fragcascade(attr, seq_type, doc=''):
 
     """
     assert seq_type in ('hit', 'query')
-    attr_name = '_%s_%s' % (seq_type, attr)
+    attr_name = '_{0!s}_{1!s}'.format(seq_type, attr)
 
     def getter(self):
         return getattr(self, attr_name)

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -257,45 +257,45 @@ class SeqFeature(object):
                 self.location.operator = value
             elif self.location is None:
                 raise ValueError(
-                    "Location is None so can't set its operator (to %r)" % value)
+                    "Location is None so can't set its operator (to {0!r})".format(value))
             else:
                 raise ValueError(
-                    "Only CompoundLocation gets an operator (%r)" % value)
+                    "Only CompoundLocation gets an operator ({0!r})".format(value))
     location_operator = property(fget=_get_location_operator, fset=_set_location_operator,
                                  doc="Location operator for compound locations (e.g. join).")
 
     def __repr__(self):
         """A string representation of the record for debugging."""
-        answer = "%s(%s" % (self.__class__.__name__, repr(self.location))
+        answer = "{0!s}({1!s}".format(self.__class__.__name__, repr(self.location))
         if self.type:
-            answer += ", type=%s" % repr(self.type)
+            answer += ", type={0!s}".format(repr(self.type))
         if self.location_operator:
-            answer += ", location_operator=%s" % repr(self.location_operator)
+            answer += ", location_operator={0!s}".format(repr(self.location_operator))
         if self.id and self.id != "<unknown id>":
-            answer += ", id=%s" % repr(self.id)
+            answer += ", id={0!s}".format(repr(self.id))
         if self.ref:
-            answer += ", ref=%s" % repr(self.ref)
+            answer += ", ref={0!s}".format(repr(self.ref))
         if self.ref_db:
-            answer += ", ref_db=%s" % repr(self.ref_db)
+            answer += ", ref_db={0!s}".format(repr(self.ref_db))
         answer += ")"
         return answer
 
     def __str__(self):
         """A readable summary of the feature intended to be printed to screen.
         """
-        out = "type: %s\n" % self.type
-        out += "location: %s\n" % self.location
+        out = "type: {0!s}\n".format(self.type)
+        out += "location: {0!s}\n".format(self.location)
         if self.id and self.id != "<unknown id>":
-            out += "id: %s\n" % self.id
+            out += "id: {0!s}\n".format(self.id)
         out += "qualifiers:\n"
         for qual_key in sorted(self.qualifiers):
-            out += "    Key: %s, Value: %s\n" % (qual_key,
+            out += "    Key: {0!s}, Value: {1!s}\n".format(qual_key,
                                                  self.qualifiers[qual_key])
         # TODO - Remove this from __str__ since deprecated
         if len(self._sub_features) != 0:
             out += "Sub-Features\n"
             for sub_feature in self._sub_features:
-                out += "%s\n" % sub_feature
+                out += "{0!s}\n".format(sub_feature)
         return out
 
     def _shift(self, offset):
@@ -531,20 +531,20 @@ class Reference(object):
         """
         out = ""
         for single_location in self.location:
-            out += "location: %s\n" % single_location
-        out += "authors: %s\n" % self.authors
+            out += "location: {0!s}\n".format(single_location)
+        out += "authors: {0!s}\n".format(self.authors)
         if self.consrtm:
-            out += "consrtm: %s\n" % self.consrtm
-        out += "title: %s\n" % self.title
-        out += "journal: %s\n" % self.journal
-        out += "medline id: %s\n" % self.medline_id
-        out += "pubmed id: %s\n" % self.pubmed_id
-        out += "comment: %s\n" % self.comment
+            out += "consrtm: {0!s}\n".format(self.consrtm)
+        out += "title: {0!s}\n".format(self.title)
+        out += "journal: {0!s}\n".format(self.journal)
+        out += "medline id: {0!s}\n".format(self.medline_id)
+        out += "pubmed id: {0!s}\n".format(self.pubmed_id)
+        out += "comment: {0!s}\n".format(self.comment)
         return out
 
     def __repr__(self):
         # TODO - Update this is __init__ later accpets values
-        return "%s(title=%s, ...)" % (self.__class__.__name__,
+        return "{0!s}(title={1!s}, ...)".format(self.__class__.__name__,
                                       repr(self.title))
 
 
@@ -675,13 +675,13 @@ class FeatureLocation(object):
         elif _is_int_or_long(start):
             self._start = ExactPosition(start)
         else:
-            raise TypeError("start=%r %s" % (start, type(start)))
+            raise TypeError("start={0!r} {1!s}".format(start, type(start)))
         if isinstance(end, AbstractPosition):
             self._end = end
         elif _is_int_or_long(end):
             self._end = ExactPosition(end)
         else:
-            raise TypeError("end=%r %s" % (end, type(end)))
+            raise TypeError("end={0!r} {1!s}".format(end, type(end)))
         self.strand = strand
         self.ref = ref
         self.ref_db = ref_db
@@ -691,8 +691,7 @@ class FeatureLocation(object):
 
     def _set_strand(self, value):
         if value not in [+1, -1, 0, None]:
-            raise ValueError("Strand should be +1, -1, 0 or None, not %r"
-                             % value)
+            raise ValueError("Strand should be +1, -1, 0 or None, not {0!r}".format(value))
         self._strand = value
 
     strand = property(fget=_get_strand, fset=_set_strand,
@@ -705,9 +704,9 @@ class FeatureLocation(object):
         (zero based counting) which GenBank would call 123..150 (one based
         counting).
         """
-        answer = "[%s:%s]" % (self._start, self._end)
+        answer = "[{0!s}:{1!s}]".format(self._start, self._end)
         if self.ref and self.ref_db:
-            answer = "%s:%s%s" % (self.ref_db, self.ref, answer)
+            answer = "{0!s}:{1!s}{2!s}".format(self.ref_db, self.ref, answer)
         elif self.ref:
             answer = self.ref + answer
         # Is ref_db without ref meaningful?
@@ -725,13 +724,12 @@ class FeatureLocation(object):
         """A string representation of the location for debugging."""
         optional = ""
         if self.strand is not None:
-            optional += ", strand=%r" % self.strand
+            optional += ", strand={0!r}".format(self.strand)
         if self.ref is not None:
-            optional += ", ref=%r" % self.ref
+            optional += ", ref={0!r}".format(self.ref)
         if self.ref_db is not None:
-            optional += ", ref_db=%r" % self.ref_db
-        return "%s(%r, %r%s)" \
-            % (self.__class__.__name__, self.start, self.end, optional)
+            optional += ", ref_db={0!r}".format(self.ref_db)
+        return "{0!s}({1!r}, {2!r}{3!s})".format(self.__class__.__name__, self.start, self.end, optional)
 
     def __add__(self, other):
         """Combine location with another feature location, or shift it.
@@ -1036,15 +1034,15 @@ class CompoundLocation(object):
                                  "FeatureLocation objects, not %s" % loc.__class__)
         if len(parts) < 2:
             raise ValueError(
-                "CompoundLocation should have at least 2 parts, not %r" % parts)
+                "CompoundLocation should have at least 2 parts, not {0!r}".format(parts))
 
     def __str__(self):
         """Returns a representation of the location (with python counting)."""
-        return "%s{%s}" % (self.operator, ", ".join(str(loc) for loc in self.parts))
+        return "{0!s}{{{1!s}}}".format(self.operator, ", ".join(str(loc) for loc in self.parts))
 
     def __repr__(self):
         """String representation of the location for debugging."""
-        return "%s(%r, %r)" % (self.__class__.__name__,
+        return "{0!s}({1!r}, {2!r})".format(self.__class__.__name__,
                                self.parts, self.operator)
 
     def _get_strand(self):
@@ -1132,8 +1130,7 @@ class CompoundLocation(object):
         elif isinstance(other, CompoundLocation):
             if self.operator != other.operator:
                 # Handle join+order -> order as a special case?
-                raise ValueError("Mixed operators %s and %s"
-                                 % (self.operator, other.operator))
+                raise ValueError("Mixed operators {0!s} and {1!s}".format(self.operator, other.operator))
             return CompoundLocation(self.parts + other.parts, self.operator)
         elif isinstance(other, int):
             return self._shift(other)
@@ -1324,7 +1321,7 @@ class AbstractPosition(object):
 
     def __repr__(self):
         """String representation of the location for debugging."""
-        return "%s(...)" % (self.__class__.__name__)
+        return "{0!s}(...)".format((self.__class__.__name__))
 
 
 class ExactPosition(int, AbstractPosition):
@@ -1362,13 +1359,12 @@ class ExactPosition(int, AbstractPosition):
     """
     def __new__(cls, position, extension=0):
         if extension != 0:
-            raise AttributeError("Non-zero extension %s for exact position."
-                                 % extension)
+            raise AttributeError("Non-zero extension {0!s} for exact position.".format(extension))
         return int.__new__(cls, position)
 
     def __repr__(self):
         """String representation of the ExactPosition location for debugging."""
-        return "%s(%i)" % (self.__class__.__name__, int(self))
+        return "{0!s}({1:d})".format(self.__class__.__name__, int(self))
 
     @property
     def position(self):
@@ -1406,7 +1402,7 @@ class UnknownPosition(AbstractPosition):
 
     def __repr__(self):
         """String representation of the UnknownPosition location for debugging."""
-        return "%s()" % self.__class__.__name__
+        return "{0!s}()".format(self.__class__.__name__)
 
     def __hash__(self):
         return hash(None)
@@ -1514,8 +1510,7 @@ class WithinPosition(int, AbstractPosition):
     """
     def __new__(cls, position, left, right):
         assert position == left or position == right, \
-            "WithinPosition: %r should match left %r or right %r" \
-            % (position, left, right)
+            "WithinPosition: {0!r} should match left {1!r} or right {2!r}".format(position, left, right)
         obj = int.__new__(cls, position)
         obj._left = left
         obj._right = right
@@ -1523,12 +1518,11 @@ class WithinPosition(int, AbstractPosition):
 
     def __repr__(self):
         """String representation of the WithinPosition location for debugging."""
-        return "%s(%i, left=%i, right=%i)" \
-               % (self.__class__.__name__, int(self),
+        return "{0!s}({1:d}, left={2:d}, right={3:d})".format(self.__class__.__name__, int(self),
                   self._left, self._right)
 
     def __str__(self):
-        return "(%s.%s)" % (self._left, self._right)
+        return "({0!s}.{1!s})".format(self._left, self._right)
 
     @property
     def position(self):
@@ -1625,12 +1619,11 @@ class BetweenPosition(int, AbstractPosition):
 
     def __repr__(self):
         """String representation of the WithinPosition location for debugging."""
-        return "%s(%i, left=%i, right=%i)" \
-               % (self.__class__.__name__, int(self),
+        return "{0!s}({1:d}, left={2:d}, right={3:d})".format(self.__class__.__name__, int(self),
                   self._left, self._right)
 
     def __str__(self):
-        return "(%s^%s)" % (self._left, self._right)
+        return "({0!s}^{1!s})".format(self._left, self._right)
 
     @property
     def position(self):
@@ -1688,8 +1681,7 @@ class BeforePosition(int, AbstractPosition):
     # Subclasses int so can't use __init__
     def __new__(cls, position, extension=0):
         if extension != 0:
-            raise AttributeError("Non-zero extension %s for exact position."
-                                 % extension)
+            raise AttributeError("Non-zero extension {0!s} for exact position.".format(extension))
         return int.__new__(cls, position)
 
     @property
@@ -1704,10 +1696,10 @@ class BeforePosition(int, AbstractPosition):
 
     def __repr__(self):
         """A string representation of the location for debugging."""
-        return "%s(%i)" % (self.__class__.__name__, int(self))
+        return "{0!s}({1:d})".format(self.__class__.__name__, int(self))
 
     def __str__(self):
-        return "<%s" % self.position
+        return "<{0!s}".format(self.position)
 
     def _shift(self, offset):
         return self.__class__(int(self) + offset)
@@ -1758,8 +1750,7 @@ class AfterPosition(int, AbstractPosition):
     # Subclasses int so can't use __init__
     def __new__(cls, position, extension=0):
         if extension != 0:
-            raise AttributeError("Non-zero extension %s for exact position."
-                                 % extension)
+            raise AttributeError("Non-zero extension {0!s} for exact position.".format(extension))
         return int.__new__(cls, position)
 
     @property
@@ -1774,10 +1765,10 @@ class AfterPosition(int, AbstractPosition):
 
     def __repr__(self):
         """A string representation of the location for debugging."""
-        return "%s(%i)" % (self.__class__.__name__, int(self))
+        return "{0!s}({1:d})".format(self.__class__.__name__, int(self))
 
     def __str__(self):
-        return ">%s" % self.position
+        return ">{0!s}".format(self.position)
 
     def _shift(self, offset):
         return self.__class__(int(self) + offset)
@@ -1845,7 +1836,7 @@ class OneOfPosition(int, AbstractPosition):
         position is an integer specifying the default behaviour.
         """
         assert position in choices, \
-            "OneOfPosition: %r should match one of %r" % (position, choices)
+            "OneOfPosition: {0!r} should match one of {1!r}".format(position, choices)
         obj = int.__new__(cls, position)
         obj.position_choices = choices
         return obj
@@ -1863,13 +1854,13 @@ class OneOfPosition(int, AbstractPosition):
 
     def __repr__(self):
         """String representation of the OneOfPosition location for debugging."""
-        return "%s(%i, choices=%r)" % (self.__class__.__name__,
+        return "{0!s}({1:d}, choices={2!r})".format(self.__class__.__name__,
                                        int(self), self.position_choices)
 
     def __str__(self):
         out = "one-of("
         for position in self.position_choices:
-            out += "%s," % position
+            out += "{0!s},".format(position)
         # replace the last comma with the closing parenthesis
         out = out[:-1] + ")"
         return out
@@ -1893,10 +1884,10 @@ class PositionGap(object):
 
     def __repr__(self):
         """A string representation of the position gap for debugging."""
-        return "%s(%s)" % (self.__class__.__name__, repr(self.gap_size))
+        return "{0!s}({1!s})".format(self.__class__.__name__, repr(self.gap_size))
 
     def __str__(self):
-        out = "gap(%s)" % self.gap_size
+        out = "gap({0!s})".format(self.gap_size)
         return out
 
 

--- a/Bio/SeqIO/AbiIO.py
+++ b/Bio/SeqIO/AbiIO.py
@@ -356,7 +356,7 @@ def AbiIterator(handle, alphabet=None, trim=False):
         # handle empty file gracefully
         raise StopIteration
     if marker != _as_bytes('ABIF'):
-        raise IOError('File should start ABIF, not %r' % marker)
+        raise IOError('File should start ABIF, not {0!r}'.format(marker))
 
     # dirty hack for handling time information
     times = {'RUND1': '', 'RUND2': '', 'RUNT1': '', 'RUNT2': '', }
@@ -396,8 +396,8 @@ def AbiIterator(handle, alphabet=None, trim=False):
                 annot[_EXTRACT[key]] = tag_data
 
     # set time annotations
-    annot['run_start'] = '%s %s' % (times['RUND1'], times['RUNT1'])
-    annot['run_finish'] = '%s %s' % (times['RUND2'], times['RUNT2'])
+    annot['run_start'] = '{0!s} {1!s}'.format(times['RUND1'], times['RUNT1'])
+    annot['run_finish'] = '{0!s} {1!s}'.format(times['RUND2'], times['RUNT2'])
 
     # raw data (for advanced end users benefit)
     annot['abif_raw'] = raw

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -193,13 +193,13 @@ class FastaWriter(SequentialSequenceWriter):
                 # The description includes the id at the start
                 title = description
             elif description:
-                title = "%s %s" % (id, description)
+                title = "{0!s} {1!s}".format(id, description)
             else:
                 title = id
 
         assert "\n" not in title
         assert "\r" not in title
-        self.handle.write(">%s\n" % title)
+        self.handle.write(">{0!s}\n".format(title))
 
         data = self._get_seq_string(record)  # Catches sequence being None
 
@@ -237,11 +237,11 @@ if __name__ == "__main__":
         print("Descr:" + record.description)
         print(record.seq)
         for feature in record.annotations:
-            print('/%s=%s' % (feature, record.annotations[feature]))
+            print('/{0!s}={1!s}'.format(feature, record.annotations[feature]))
         if record.dbxrefs:
             print("Database cross references:")
             for x in record.dbxrefs:
-                print(" - %s" % x)
+                print(" - {0!s}".format(x))
 
     if os.path.isfile(fna_filename):
         print("--------")

--- a/Bio/SeqIO/IgIO.py
+++ b/Bio/SeqIO/IgIO.py
@@ -47,7 +47,7 @@ def IgIterator(handle, alphabet=single_letter_alphabet):
         # Now iterate over the records
         if line[0] != ";":
             raise ValueError(
-                "Records should start with ';' and not:\n%s" % repr(line))
+                "Records should start with ';' and not:\n{0!s}".format(repr(line)))
 
         # Try and agree with SeqRecord convention from the GenBank parser,
         # (and followed in the SwissProt parser) which stores the comments
@@ -100,7 +100,7 @@ if __name__ == "__main__":
                 print("-" * len(filename))
                 with open(os.path.join(path, filename)) as handle:
                     for record in IgIterator(handle):
-                        print("%s %i" % (record.id, len(record)))
+                        print("{0!s} {1:d}".format(record.id, len(record)))
         print("Done")
     else:
         print("Could not find input files")

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -95,11 +95,9 @@ class SequenceWriter(object):
         if not isinstance(record, SeqRecord):
             raise TypeError("Expected a SeqRecord object")
         if record.seq is None:
-            raise TypeError("SeqRecord (id=%s) has None for its sequence."
-                            % record.id)
+            raise TypeError("SeqRecord (id={0!s}) has None for its sequence.".format(record.id))
         elif not isinstance(record.seq, (Seq, MutableSeq)):
-            raise TypeError("SeqRecord (id=%s) has an invalid sequence."
-                            % record.id)
+            raise TypeError("SeqRecord (id={0!s}) has an invalid sequence.".format(record.id))
         return str(record.seq)
 
     def clean(self, text):

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -82,14 +82,14 @@ def PdbSeqresIterator(handle):
         record.annotations = {"chain": chn_id}
         if chn_id in metadata:
             m = metadata[chn_id][0]
-            record.id = record.name = "%s:%s" % (m['pdb_id'], chn_id)
-            record.description = ("%s:%s %s" % (m['database'],
+            record.id = record.name = "{0!s}:{1!s}".format(m['pdb_id'], chn_id)
+            record.description = ("{0!s}:{1!s} {2!s}".format(m['database'],
                                                 m['db_acc'],
                                                 m['db_id_code']))
             for melem in metadata[chn_id]:
                 record.dbxrefs.extend([
-                    "%s:%s" % (melem['database'], melem['db_acc']),
-                    "%s:%s" % (melem['database'], melem['db_id_code'])])
+                    "{0!s}:{1!s}".format(melem['database'], melem['db_acc']),
+                    "{0!s}:{1!s}".format(melem['database'], melem['db_id_code'])])
         else:
             record.id = chn_id
         yield record
@@ -182,7 +182,7 @@ def PdbAtomIterator(handle):
         else:
             # No gaps
             res_out = [restype(x) for x in residues]
-        record_id = "%s:%s" % (pdb_id, chn_id)
+        record_id = "{0!s}:{1!s}".format(pdb_id, chn_id)
         # ENH - model number in SeqRecord id if multiple models?
         # id = "Chain%s" % str(chain.id)
         # if len(structure) > 1 :

--- a/Bio/SeqIO/PhdIO.py
+++ b/Bio/SeqIO/PhdIO.py
@@ -114,36 +114,35 @@ class PhdWriter(SequentialSequenceWriter):
                 "of peak location scores does not match length of sequence"
         if None in phred_qualities:
             raise ValueError("A quality value of None was found")
-        if record.description.startswith("%s " % record.id):
+        if record.description.startswith("{0!s} ".format(record.id)):
             title = record.description
         else:
-            title = "%s %s" % (record.id, record.description)
-        self.handle.write("BEGIN_SEQUENCE %s\nBEGIN_COMMENT\n"
-                          % self.clean(title))
+            title = "{0!s} {1!s}".format(record.id, record.description)
+        self.handle.write("BEGIN_SEQUENCE {0!s}\nBEGIN_COMMENT\n".format(self.clean(title)))
         for annot in [k.lower() for k in Phd.CKEYWORDS]:
             value = None
             if annot == "trim":
                 if record.annotations.get("trim", None):
-                    value = "%s %s %.4f" % record.annotations["trim"]
+                    value = "{0!s} {1!s} {2:.4f}".format(*record.annotations["trim"])
             elif annot == "trace_peak_area_ratio":
                 if record.annotations.get("trace_peak_area_ratio", None):
-                    value = "%.4f" % record.annotations[
-                        "trace_peak_area_ratio"]
+                    value = "{0:.4f}".format(record.annotations[
+                        "trace_peak_area_ratio"])
             else:
                 value = record.annotations.get(annot, None)
             if value or value == 0:
-                self.handle.write("%s: %s\n" % (annot.upper(), value))
+                self.handle.write("{0!s}: {1!s}\n".format(annot.upper(), value))
 
         self.handle.write("END_COMMENT\nBEGIN_DNA\n")
         for i, site in enumerate(record.seq):
             if peak_locations:
-                self.handle.write("%s %i %i\n" % (
+                self.handle.write("{0!s} {1:d} {2:d}\n".format(
                     site,
                     round(phred_qualities[i]),
                     peak_locations[i])
                 )
             else:
-                self.handle.write("%s %i\n" % (
+                self.handle.write("{0!s} {1:d}\n".format(
                     site,
                     round(phred_qualities[i]))
                 )

--- a/Bio/SeqIO/PirIO.py
+++ b/Bio/SeqIO/PirIO.py
@@ -177,9 +177,9 @@ if __name__ == "__main__":
 
     for name in ["clustalw", "DMA_nuc", "DMB_prot", "B_nuc", "Cw_prot"]:
         print(name)
-        filename = "../../Tests/NBRF/%s.pir" % name
+        filename = "../../Tests/NBRF/{0!s}.pir".format(name)
         if not os.path.isfile(filename):
-            print("Missing %s" % filename)
+            print("Missing {0!s}".format(filename))
             continue
 
         records = list(PirIterator(open(filename)))
@@ -189,4 +189,4 @@ if __name__ == "__main__":
             parts = record.description.split()
             if "bases," in parts:
                 assert len(record) == int(parts[parts.index("bases,") - 1])
-        print("Could read %s (%i records)" % (name, count))
+        print("Could read {0!s} ({1:d} records)".format(name, count))

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -469,8 +469,7 @@ def solexa_quality_from_phred(phred_quality):
         # Special case, map to -5 as discussed in the docstring
         return -5.0
     else:
-        raise ValueError("PHRED qualities must be positive (or zero), not %s"
-                         % repr(phred_quality))
+        raise ValueError("PHRED qualities must be positive (or zero), not {0!s}".format(repr(phred_quality)))
 
 
 def phred_quality_from_solexa(solexa_quality):
@@ -515,8 +514,7 @@ def phred_quality_from_solexa(solexa_quality):
         # Assume None is used as some kind of NULL or NA value; return None
         return None
     if solexa_quality < -5:
-        warnings.warn("Solexa quality less than -5 passed, %s"
-                      % repr(solexa_quality), BiopythonWarning)
+        warnings.warn("Solexa quality less than -5 passed, {0!s}".format(repr(solexa_quality)), BiopythonWarning)
     return 10 * log(10 ** (solexa_quality / 10.0) + 1, 10)
 
 
@@ -1429,12 +1427,11 @@ class FastqPhredWriter(SequentialSequenceWriter):
         self._record_written = True
         # TODO - Is an empty sequence allowed in FASTQ format?
         if record.seq is None:
-            raise ValueError("No sequence for record %s" % record.id)
+            raise ValueError("No sequence for record {0!s}".format(record.id))
         seq_str = str(record.seq)
         qualities_str = _get_sanger_quality_str(record)
         if len(qualities_str) != len(seq_str):
-            raise ValueError("Record %s has sequence length %i but %i quality scores"
-                             % (record.id, len(seq_str), len(qualities_str)))
+            raise ValueError("Record {0!s} has sequence length {1:d} but {2:d} quality scores".format(record.id, len(seq_str), len(qualities_str)))
 
         # FASTQ files can include a description, just like FASTA files
         # (at least, this is what the NCBI Short Read Archive does)
@@ -1444,11 +1441,11 @@ class FastqPhredWriter(SequentialSequenceWriter):
             # The description includes the id at the start
             title = description
         elif description:
-            title = "%s %s" % (id, description)
+            title = "{0!s} {1!s}".format(id, description)
         else:
             title = id
 
-        self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str))
+        self.handle.write("@{0!s}\n{1!s}\n+\n{2!s}\n".format(title, seq_str, qualities_str))
 
 
 class QualPhredWriter(SequentialSequenceWriter):
@@ -1518,16 +1515,16 @@ class QualPhredWriter(SequentialSequenceWriter):
                 # The description includes the id at the start
                 title = description
             elif description:
-                title = "%s %s" % (id, description)
+                title = "{0!s} {1!s}".format(id, description)
             else:
                 title = id
-        handle.write(">%s\n" % title)
+        handle.write(">{0!s}\n".format(title))
 
         qualities = _get_phred_quality(record)
         try:
             # This rounds to the nearest integer.
             # TODO - can we record a float in a qual file?
-            qualities_strs = [("%i" % round(q, 0)) for q in qualities]
+            qualities_strs = [("{0:d}".format(round(q, 0))) for q in qualities]
         except TypeError as e:
             if None in qualities:
                 raise TypeError("A quality value of None was found")
@@ -1617,12 +1614,11 @@ class FastqSolexaWriter(SequentialSequenceWriter):
 
         # TODO - Is an empty sequence allowed in FASTQ format?
         if record.seq is None:
-            raise ValueError("No sequence for record %s" % record.id)
+            raise ValueError("No sequence for record {0!s}".format(record.id))
         seq_str = str(record.seq)
         qualities_str = _get_solexa_quality_str(record)
         if len(qualities_str) != len(seq_str):
-            raise ValueError("Record %s has sequence length %i but %i quality scores"
-                             % (record.id, len(seq_str), len(qualities_str)))
+            raise ValueError("Record {0!s} has sequence length {1:d} but {2:d} quality scores".format(record.id, len(seq_str), len(qualities_str)))
 
         # FASTQ files can include a description, just like FASTA files
         # (at least, this is what the NCBI Short Read Archive does)
@@ -1632,11 +1628,11 @@ class FastqSolexaWriter(SequentialSequenceWriter):
             # The description includes the id at the start
             title = description
         elif description:
-            title = "%s %s" % (id, description)
+            title = "{0!s} {1!s}".format(id, description)
         else:
             title = id
 
-        self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str))
+        self.handle.write("@{0!s}\n{1!s}\n+\n{2!s}\n".format(title, seq_str, qualities_str))
 
 
 class FastqIlluminaWriter(SequentialSequenceWriter):
@@ -1673,12 +1669,11 @@ class FastqIlluminaWriter(SequentialSequenceWriter):
 
         # TODO - Is an empty sequence allowed in FASTQ format?
         if record.seq is None:
-            raise ValueError("No sequence for record %s" % record.id)
+            raise ValueError("No sequence for record {0!s}".format(record.id))
         seq_str = str(record.seq)
         qualities_str = _get_illumina_quality_str(record)
         if len(qualities_str) != len(seq_str):
-            raise ValueError("Record %s has sequence length %i but %i quality scores"
-                             % (record.id, len(seq_str), len(qualities_str)))
+            raise ValueError("Record {0!s} has sequence length {1:d} but {2:d} quality scores".format(record.id, len(seq_str), len(qualities_str)))
 
         # FASTQ files can include a description, just like FASTA files
         # (at least, this is what the NCBI Short Read Archive does)
@@ -1688,11 +1683,11 @@ class FastqIlluminaWriter(SequentialSequenceWriter):
             # The description includes the id at the start
             title = description
         elif description:
-            title = "%s %s" % (id, description)
+            title = "{0!s} {1!s}".format(id, description)
         else:
             title = id
 
-        self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str))
+        self.handle.write("@{0!s}\n{1!s}\n+\n{2!s}\n".format(title, seq_str, qualities_str))
 
 
 def PairedFastaQualIterator(fasta_handle, qual_handle, alphabet=single_letter_alphabet, title2ids=None):
@@ -1783,11 +1778,9 @@ def PairedFastaQualIterator(fasta_handle, qual_handle, alphabet=single_letter_al
         if q_rec is None:
             raise ValueError("QUAL file has more entries than the FASTA file.")
         if f_rec.id != q_rec.id:
-            raise ValueError("FASTA and QUAL entries do not match (%s vs %s)."
-                             % (f_rec.id, q_rec.id))
+            raise ValueError("FASTA and QUAL entries do not match ({0!s} vs {1!s}).".format(f_rec.id, q_rec.id))
         if len(f_rec) != len(q_rec.letter_annotations["phred_quality"]):
-            raise ValueError("Sequence length and number of quality scores disagree for %s"
-                             % f_rec.id)
+            raise ValueError("Sequence length and number of quality scores disagree for {0!s}".format(f_rec.id))
         # Merge the data....
         f_rec.letter_annotations[
             "phred_quality"] = q_rec.letter_annotations["phred_quality"]

--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -210,9 +210,9 @@ class SeqXmlIterator(XMLRecordIterator):
         if "source" not in attr_dict or "id" not in attr_dict:
             raise ValueError("Invalid DB cross reference.")
 
-        if "%s:%s" % (attr_dict["source"], attr_dict["id"]) not in record.dbxrefs:
+        if "{0!s}:{1!s}".format(attr_dict["source"], attr_dict["id"]) not in record.dbxrefs:
             record.dbxrefs.append(
-                "%s:%s" % (attr_dict["source"], attr_dict["id"]))
+                "{0!s}:{1!s}".format(attr_dict["source"], attr_dict["id"]))
 
 
 class SeqXmlWriter(SequentialSequenceWriter):
@@ -304,8 +304,7 @@ class SeqXmlWriter(SequentialSequenceWriter):
                 elif len(local_ncbi_taxid) == 0:
                     local_ncbi_taxid = None
                 else:
-                    ValueError('Multiple entries for record.annotations["ncbi_taxid"], %r'
-                                     % local_ncbi_taxid)
+                    ValueError('Multiple entries for record.annotations["ncbi_taxid"], {0!r}'.format(local_ncbi_taxid))
         if "organism" in record.annotations and local_ncbi_taxid:
             local_org = record.annotations["organism"]
 

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -330,17 +330,13 @@ def _sff_file_header(handle):
         # Probably user error, calling Bio.SeqIO.parse() twice!
         raise ValueError("Handle seems to be at SFF index block, not start")
     if magic_number != _sff:  # 779314790
-        raise ValueError("SFF file did not start '.sff', but %s"
-                         % repr(magic_number))
+        raise ValueError("SFF file did not start '.sff', but {0!s}".format(repr(magic_number)))
     if (ver0, ver1, ver2, ver3) != (0, 0, 0, 1):
-        raise ValueError("Unsupported SFF version in header, %i.%i.%i.%i"
-                         % (ver0, ver1, ver2, ver3))
+        raise ValueError("Unsupported SFF version in header, {0:d}.{1:d}.{2:d}.{3:d}".format(ver0, ver1, ver2, ver3))
     if flowgram_format != 1:
-        raise ValueError("Flowgram format code %i not supported"
-                         % flowgram_format)
+        raise ValueError("Flowgram format code {0:d} not supported".format(flowgram_format))
     if (index_offset != 0) ^ (index_length != 0):
-        raise ValueError("Index offset %i but index length %i"
-                         % (index_offset, index_length))
+        raise ValueError("Index offset {0:d} but index length {1:d}".format(index_offset, index_length))
     flow_chars = _bytes_to_string(handle.read(number_of_flows_per_read))
     key_sequence = _bytes_to_string(handle.read(key_length))
     # According to the spec, the header_length field should be the total number
@@ -377,7 +373,7 @@ def _sff_do_slow_index(handle):
     read_header_fmt = '>2HI4H'
     read_header_size = struct.calcsize(read_header_fmt)
     # NOTE - assuming flowgram_format==1, which means struct type H
-    read_flow_fmt = ">%iH" % number_of_flows_per_read
+    read_flow_fmt = ">{0:d}H".format(number_of_flows_per_read)
     read_flow_size = struct.calcsize(read_flow_fmt)
     assert 1 == struct.calcsize(">B")
     assert 1 == struct.calcsize(">s")
@@ -400,8 +396,7 @@ def _sff_do_slow_index(handle):
             clip_qual_right, clip_adapter_left, clip_adapter_right \
             = struct.unpack(read_header_fmt, data)
         if read_header_length < 10 or read_header_length % 8 != 0:
-            raise ValueError("Malformed read header, says length is %i:\n%s"
-                             % (read_header_length, repr(data)))
+            raise ValueError("Malformed read header, says length is {0:d}:\n{1!s}".format(read_header_length, repr(data)))
         # now the name and any padding (remainder of header)
         name = _bytes_to_string(handle.read(name_length))
         padding = read_header_length - read_header_size - name_length
@@ -456,11 +451,9 @@ def _sff_find_roche_index(handle):
     fmt_size = struct.calcsize(fmt)
     data = handle.read(fmt_size)
     if not data:
-        raise ValueError("Premature end of file? Expected index of size %i at offest %i, found nothing"
-                         % (index_length, index_offset))
+        raise ValueError("Premature end of file? Expected index of size {0:d} at offest {1:d}, found nothing".format(index_length, index_offset))
     if len(data) < fmt_size:
-        raise ValueError("Premature end of file? Expected index of size %i at offest %i, found %s"
-                         % (index_length, index_offset, repr(data)))
+        raise ValueError("Premature end of file? Expected index of size {0:d} at offest {1:d}, found {2!s}".format(index_length, index_offset, repr(data)))
     magic_number, ver0, ver1, ver2, ver3 = struct.unpack(fmt, data)
     if magic_number == _mft:  # 778921588
         # Roche 454 manifest index
@@ -468,14 +461,12 @@ def _sff_find_roche_index(handle):
         # both an XML manifest and the sorted index.
         if (ver0, ver1, ver2, ver3) != (49, 46, 48, 48):
             # This is "1.00" as a string
-            raise ValueError("Unsupported version in .mft index header, %i.%i.%i.%i"
-                             % (ver0, ver1, ver2, ver3))
+            raise ValueError("Unsupported version in .mft index header, {0:d}.{1:d}.{2:d}.{3:d}".format(ver0, ver1, ver2, ver3))
         fmt2 = ">LL"
         fmt2_size = struct.calcsize(fmt2)
         xml_size, data_size = struct.unpack(fmt2, handle.read(fmt2_size))
         if index_length != fmt_size + fmt2_size + xml_size + data_size:
-            raise ValueError("Problem understanding .mft index header, %i != %i + %i + %i + %i"
-                             % (index_length, fmt_size, fmt2_size, xml_size, data_size))
+            raise ValueError("Problem understanding .mft index header, {0:d} != {1:d} + {2:d} + {3:d} + {4:d}".format(index_length, fmt_size, fmt2_size, xml_size, data_size))
         return number_of_reads, header_length, \
             index_offset, index_length, \
             index_offset + fmt_size + fmt2_size, xml_size, \
@@ -486,8 +477,7 @@ def _sff_find_roche_index(handle):
         # had nonstandard lengths and there was no XML manifest.
         if (ver0, ver1, ver2, ver3) != (49, 46, 48, 48):
             # This is "1.00" as a string
-            raise ValueError("Unsupported version in .srt index header, %i.%i.%i.%i"
-                             % (ver0, ver1, ver2, ver3))
+            raise ValueError("Unsupported version in .srt index header, {0:d}.{1:d}.{2:d}.{3:d}".format(ver0, ver1, ver2, ver3))
         data = handle.read(4)
         if data != _null * 4:
             raise ValueError(
@@ -500,8 +490,7 @@ def _sff_find_roche_index(handle):
         raise ValueError("Hash table style indexes (.hsh) in SFF files are "
                          "not (yet) supported")
     else:
-        raise ValueError("Unknown magic number %s in SFF index header:\n%s"
-                         % (repr(magic_number), repr(data)))
+        raise ValueError("Unknown magic number {0!s} in SFF index header:\n{1!s}".format(repr(magic_number), repr(data)))
 
 
 def ReadRocheXmlManifest(handle):
@@ -577,8 +566,7 @@ def _sff_read_roche_index(handle):
             raise ValueError("Expected a null terminator to the read name.")
         yield name, offset
     if handle.tell() != read_index_offset + read_index_size:
-        raise ValueError("Problem with index length? %i vs %i"
-                         % (handle.tell(), read_index_offset + read_index_size))
+        raise ValueError("Problem with index length? {0:d} vs {1:d}".format(handle.tell(), read_index_offset + read_index_size))
 
 _valid_UAN_read_name = re.compile(r'^[a-zA-Z0-9]{14}$')
 
@@ -598,7 +586,7 @@ def _sff_read_seq_record(handle, number_of_flows_per_read, flow_chars,
     # [rest of read header depends on the name length etc]
     read_header_fmt = '>2HI4H'
     read_header_size = struct.calcsize(read_header_fmt)
-    read_flow_fmt = ">%iH" % number_of_flows_per_read
+    read_flow_fmt = ">{0:d}H".format(number_of_flows_per_read)
     read_flow_size = struct.calcsize(read_flow_fmt)
 
     read_header_length, name_length, seq_len, clip_qual_left, \
@@ -609,8 +597,7 @@ def _sff_read_seq_record(handle, number_of_flows_per_read, flow_chars,
     if clip_adapter_left:
         clip_adapter_left -= 1  # python counting
     if read_header_length < 10 or read_header_length % 8 != 0:
-        raise ValueError("Malformed read header, says length is %i"
-                         % read_header_length)
+        raise ValueError("Malformed read header, says length is {0:d}".format(read_header_length))
     # now the name and any padding (remainder of header)
     name = _bytes_to_string(handle.read(name_length))
     padding = read_header_length - read_header_size - name_length
@@ -623,7 +610,7 @@ def _sff_read_seq_record(handle, number_of_flows_per_read, flow_chars,
     # now the flowgram values, flowgram index, bases and qualities
     # NOTE - assuming flowgram_format==1, which means struct type H
     flow_values = handle.read(read_flow_size)  # unpack later if needed
-    temp_fmt = ">%iB" % seq_len  # used for flow index and quals
+    temp_fmt = ">{0:d}B".format(seq_len)  # used for flow index and quals
     flow_index = handle.read(seq_len)  # unpack later if needed
     seq = _bytes_to_string(handle.read(seq_len))  # TODO - Use bytes in Seq?
     quals = list(struct.unpack(temp_fmt, handle.read(seq_len)))
@@ -758,15 +745,14 @@ def _sff_read_raw_record(handle, number_of_flows_per_read):
     """Extract the next read in the file as a raw (bytes) string (PRIVATE)."""
     read_header_fmt = '>2HI'
     read_header_size = struct.calcsize(read_header_fmt)
-    read_flow_fmt = ">%iH" % number_of_flows_per_read
+    read_flow_fmt = ">{0:d}H".format(number_of_flows_per_read)
     read_flow_size = struct.calcsize(read_flow_fmt)
 
     raw = handle.read(read_header_size)
     read_header_length, name_length, seq_len \
         = struct.unpack(read_header_fmt, raw)
     if read_header_length < 10 or read_header_length % 8 != 0:
-        raise ValueError("Malformed read header, says length is %i"
-                         % read_header_length)
+        raise ValueError("Malformed read header, says length is {0:d}".format(read_header_length))
     # now the four clip values (4H = 8 bytes), and read name
     raw += handle.read(8 + name_length)
     # and any padding (remainder of header)
@@ -898,7 +884,7 @@ def SffIterator(handle, alphabet=Alphabet.generic_dna, trim=False):
                   Alphabet.RNAAlphabet):
         raise ValueError("Invalid alphabet, SFF files do not hold RNA.")
     try:
-        assert 0 == handle.tell(), "Not at start of file, offset %i" % handle.tell()
+        assert 0 == handle.tell(), "Not at start of file, offset {0:d}".format(handle.tell())
     except AttributeError:
         # Probably a network handle or something like that
         handle = _AddTellHandle(handle)
@@ -917,7 +903,7 @@ def SffIterator(handle, alphabet=Alphabet.generic_dna, trim=False):
     # [rest of read header depends on the name length etc]
     read_header_fmt = '>2HI4H'
     read_header_size = struct.calcsize(read_header_fmt)
-    read_flow_fmt = ">%iH" % number_of_flows_per_read
+    read_flow_fmt = ">{0:d}H".format(number_of_flows_per_read)
     read_flow_size = struct.calcsize(read_flow_fmt)
     assert 1 == struct.calcsize(">B")
     assert 1 == struct.calcsize(">s")
@@ -967,8 +953,7 @@ def _check_eof(handle, index_offset, index_length):
         handle.read(index_offset + index_length - offset)
         offset = index_offset + index_length
         assert offset == handle.tell(), \
-            "Wanted %i, got %i, index is %i to %i" \
-            % (offset, handle.tell(), index_offset, index_offset + index_length)
+            "Wanted {0:d}, got {1:d}, index is {2:d} to {3:d}".format(offset, handle.tell(), index_offset, index_offset + index_length)
 
     if offset % 8:
         padding = 8 - (offset % 8)
@@ -999,7 +984,7 @@ def _check_eof(handle, index_offset, index_length):
 
     offset = handle.tell()
     assert offset % 8 == 0, \
-        "Wanted offset %i %% 8 = %i to be zero" % (offset, offset % 8)
+        "Wanted offset {0:d} % 8 = {1:d} to be zero".format(offset, offset % 8)
     # Should now be at the end of the file...
     extra = handle.read(4)
     if extra == _sff:
@@ -1104,7 +1089,7 @@ class SffWriter(SequenceWriter):
             xml = _as_bytes(self._xml)
         else:
             from Bio import __version__
-            xml = "<!-- This file was output with Biopython %s -->\n" % __version__
+            xml = "<!-- This file was output with Biopython {0!s} -->\n".format(__version__)
             xml += "<!-- This XML and index block attempts to mimic Roche SFF files -->\n"
             xml += "<!-- This file may be a combination of multiple SFF files etc -->\n"
             xml = _as_bytes(xml)
@@ -1129,11 +1114,11 @@ class SffWriter(SequenceWriter):
             off2 = off3 % 16581375
             off3 -= off2
             assert offset == off0 + off1 + off2 + off3, \
-                "%i -> %i %i %i %i" % (offset, off0, off1, off2, off3)
+                "{0:d} -> {1:d} {2:d} {3:d} {4:d}".format(offset, off0, off1, off2, off3)
             off3, off2, off1, off0 = off3 // 16581375, off2 // 65025, \
                 off1 // 255, off0
             assert off0 < 255 and off1 < 255 and off2 < 255 and off3 < 255, \
-                "%i -> %i %i %i %i" % (offset, off0, off1, off2, off3)
+                "{0:d} -> {1:d} {2:d} {3:d} {4:d}".format(offset, off0, off1, off2, off3)
             handle.write(name + struct.pack(fmt2, 0,
                                             off3, off2, off1, off0, 255))
             index_len += len(name) + 6
@@ -1149,7 +1134,7 @@ class SffWriter(SequenceWriter):
             padding = 0
         offset = handle.tell()
         assert offset == self._index_start + self._index_length + padding, \
-            "%i vs %i + %i + %i" % (offset, self._index_start,
+            "{0:d} vs {1:d} + {2:d} + {3:d}".format(offset, self._index_start,
                                     self._index_length, padding)
         # Must now go back and update the index header with index size...
         handle.seek(self._index_start)
@@ -1176,7 +1161,7 @@ class SffWriter(SequenceWriter):
         # number_of_flows_per_read   H
         # flowgram_format_code       B
         # [rest of file header depends on the number of flows and how many keys]
-        fmt = '>I4BQIIHHHB%is%is' % (
+        fmt = '>I4BQIIHHHB{0:d}s{1:d}s'.format(
             self._number_of_flows_per_read, key_length)
         # According to the spec, the header_length field should be the total
         # number of bytes required by this set of header fields, and should be
@@ -1212,7 +1197,7 @@ class SffWriter(SequenceWriter):
         try:
             quals = record.letter_annotations["phred_quality"]
         except KeyError:
-            raise ValueError("Missing PHRED qualities information for %s" % record.id)
+            raise ValueError("Missing PHRED qualities information for {0!s}".format(record.id))
         # Flow
         try:
             flow_values = record.annotations["flow_values"]
@@ -1221,29 +1206,29 @@ class SffWriter(SequenceWriter):
                     or self._flow_chars != _as_bytes(record.annotations["flow_chars"]):
                 raise ValueError("Records have inconsistent SFF flow data")
         except KeyError:
-            raise ValueError("Missing SFF flow information for %s" % record.id)
+            raise ValueError("Missing SFF flow information for {0!s}".format(record.id))
         except AttributeError:
             raise ValueError("Header not written yet?")
         # Clipping
         try:
             clip_qual_left = record.annotations["clip_qual_left"]
             if clip_qual_left < 0:
-                raise ValueError("Negative SFF clip_qual_left value for %s" % record.id)
+                raise ValueError("Negative SFF clip_qual_left value for {0!s}".format(record.id))
             if clip_qual_left:
                 clip_qual_left += 1
             clip_qual_right = record.annotations["clip_qual_right"]
             if clip_qual_right < 0:
-                raise ValueError("Negative SFF clip_qual_right value for %s" % record.id)
+                raise ValueError("Negative SFF clip_qual_right value for {0!s}".format(record.id))
             clip_adapter_left = record.annotations["clip_adapter_left"]
             if clip_adapter_left < 0:
-                raise ValueError("Negative SFF clip_adapter_left value for %s" % record.id)
+                raise ValueError("Negative SFF clip_adapter_left value for {0!s}".format(record.id))
             if clip_adapter_left:
                 clip_adapter_left += 1
             clip_adapter_right = record.annotations["clip_adapter_right"]
             if clip_adapter_right < 0:
-                raise ValueError("Negative SFF clip_adapter_right value for %s" % record.id)
+                raise ValueError("Negative SFF clip_adapter_right value for {0!s}".format(record.id))
         except KeyError:
-            raise ValueError("Missing SFF clipping information for %s" % record.id)
+            raise ValueError("Missing SFF clipping information for {0!s}".format(record.id))
 
         # Capture information for index
         if self._index is not None:
@@ -1276,7 +1261,7 @@ class SffWriter(SequenceWriter):
         # flow index
         # sequence
         # padding
-        read_header_fmt = '>2HI4H%is' % name_len
+        read_header_fmt = '>2HI4H{0:d}s'.format(name_len)
         if struct.calcsize(read_header_fmt) % 8 == 0:
             padding = 0
         else:
@@ -1292,9 +1277,9 @@ class SffWriter(SequenceWriter):
         assert len(data) == read_header_length
         # now the flowgram values, flowgram index, bases and qualities
         # NOTE - assuming flowgram_format==1, which means struct type H
-        read_flow_fmt = ">%iH" % self._number_of_flows_per_read
+        read_flow_fmt = ">{0:d}H".format(self._number_of_flows_per_read)
         read_flow_size = struct.calcsize(read_flow_fmt)
-        temp_fmt = ">%iB" % seq_len  # used for flow index and quals
+        temp_fmt = ">{0:d}B".format(seq_len)  # used for flow index and quals
         data += struct.pack(read_flow_fmt, *flow_values) \
             + struct.pack(temp_fmt, *flow_index) \
             + seq \

--- a/Bio/SeqIO/SwissIO.py
+++ b/Bio/SeqIO/SwissIO.py
@@ -53,7 +53,7 @@ def _make_position(location_string, offset=0):
             return SeqFeature.UncertainPosition(max(0, offset + int(location_string[1:])))
         except ValueError:
             pass
-    raise NotImplementedError("Cannot parse location '%s'" % location_string)
+    raise NotImplementedError("Cannot parse location '{0!s}'".format(location_string))
 
 
 def _make_seqfeature(name, from_res, to_res, description, ft_id):
@@ -96,7 +96,7 @@ def SwissIterator(handle):
             if len(cross_reference) < 2:
                 continue
             database, accession = cross_reference[:2]
-            dbxref = "%s:%s" % (database, accession)
+            dbxref = "{0!s}:{1!s}".format(database, accession)
             if dbxref not in record.dbxrefs:
                 record.dbxrefs.append(dbxref)
         annotations = record.annotations
@@ -123,7 +123,7 @@ def SwissIterator(handle):
             annotations['references'] = []
             for reference in swiss_record.references:
                 feature = SeqFeature.Reference()
-                feature.comment = " ".join("%s=%s;" % k_v for k_v in reference.comments)
+                feature.comment = " ".join("{0!s}={1!s};".format(*k_v) for k_v in reference.comments)
                 for key, value in reference.references:
                     if key == 'PubMed':
                         feature.pubmed_id = value
@@ -135,7 +135,7 @@ def SwissIterator(handle):
                         pass
                     else:
                         raise ValueError(
-                            "Unknown key %s found in references" % key)
+                            "Unknown key {0!s} found in references".format(key))
                 feature.authors = reference.authors
                 feature.title = reference.title
                 feature.journal = reference.location
@@ -151,7 +151,7 @@ if __name__ == "__main__":
 
     import os
     if not os.path.isfile(example_filename):
-        print("Missing test file %s" % example_filename)
+        print("Missing test file {0!s}".format(example_filename))
     else:
         # Try parsing it!
         with open(example_filename) as handle:

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -64,8 +64,7 @@ def TabIterator(handle, alphabet=single_letter_alphabet):
                 # It's a blank line, ignore it
                 continue
             raise ValueError("Each line should have one tab separating the" +
-                             " title and sequence, this line has %i tabs: %s"
-                             % (line.count("\t"), repr(line)))
+                             " title and sequence, this line has {0:d} tabs: {1!s}".format(line.count("\t"), repr(line)))
         title = title.strip()
         seq = seq.strip()  # removes the trailing new line
         yield SeqRecord(Seq(seq, alphabet),
@@ -94,7 +93,7 @@ class TabWriter(SequentialSequenceWriter):
         assert "\t" not in seq
         assert "\n" not in seq
         assert "\r" not in seq
-        self.handle.write("%s\t%s\n" % (title, seq))
+        self.handle.write("{0!s}\t{1!s}\n".format(title, seq))
 
 
 if __name__ == "__main__":

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -53,10 +53,10 @@ def UniprotIterator(handle, alphabet=Alphabet.ProteinAlphabet(), return_raw_comm
     skip_parsing_errors = True --> if parsing errors are found, skip to next entry
     """
     if isinstance(alphabet, Alphabet.NucleotideAlphabet):
-        raise ValueError("Wrong alphabet %r" % alphabet)
+        raise ValueError("Wrong alphabet {0!r}".format(alphabet))
     if isinstance(alphabet, Alphabet.Gapped):
         if isinstance(alphabet.alphabet, Alphabet.NucleotideAlphabet):
-            raise ValueError("Wrong alphabet %r" % alphabet)
+            raise ValueError("Wrong alphabet {0!r}".format(alphabet))
 
     if not hasattr(handle, "read"):
         if isinstance(handle, str):
@@ -113,7 +113,7 @@ class Parser(object):
                 if protein_element.tag in [NS + 'recommendedName', NS + 'alternativeName']:  # recommendedName tag are parsed before
                     # use protein fields for name and description
                     for rec_name in protein_element:
-                        ann_key = '%s_%s' % (protein_element.tag.replace(NS, ''),
+                        ann_key = '{0!s}_{1!s}'.format(protein_element.tag.replace(NS, ''),
                                              rec_name.tag.replace(NS, ''))
                         append_to_annotations(ann_key, rec_name.text)
                         if (rec_name.tag == NS + 'fullName') and not descr_set:
@@ -127,7 +127,7 @@ class Parser(object):
         def _parse_gene(element):
             for genename_element in element:
                 if 'type' in genename_element.attrib:
-                    ann_key = 'gene_%s_%s' % (genename_element.tag.replace(NS, ''),
+                    ann_key = 'gene_{0!s}_{1!s}'.format(genename_element.tag.replace(NS, ''),
                                               genename_element.attrib['type'])
                     if genename_element.attrib['type'] == 'primary':
                         self.ParsedSeqRecord.annotations[ann_key] = genename_element.text
@@ -156,7 +156,7 @@ class Parser(object):
                         if taxon_element.tag == NS + 'taxon':
                             append_to_annotations('taxonomy', taxon_element.text)
             if sci_name and com_name:
-                organism_name = '%s (%s)' % (sci_name, com_name)
+                organism_name = '{0!s} ({1!s})'.format(sci_name, com_name)
             elif sci_name:
                 organism_name = sci_name
             elif com_name:
@@ -240,7 +240,7 @@ class Parser(object):
                                ]
 
             if element.attrib['type'] in simple_comments:
-                ann_key = 'comment_%s' % element.attrib['type'].replace(' ', '')
+                ann_key = 'comment_{0!s}'.format(element.attrib['type'].replace(' ', ''))
                 for text_element in element.getiterator(NS + 'text'):
                     if text_element.text:
                         append_to_annotations(ann_key, text_element.text)
@@ -248,19 +248,19 @@ class Parser(object):
                 for subloc_element in element.getiterator(NS + 'subcellularLocation'):
                     for el in subloc_element:
                         if el.text:
-                            ann_key = 'comment_%s_%s' % (element.attrib['type'].replace(' ', ''), el.tag.replace(NS, ''))
+                            ann_key = 'comment_{0!s}_{1!s}'.format(element.attrib['type'].replace(' ', ''), el.tag.replace(NS, ''))
                             append_to_annotations(ann_key, el.text)
             elif element.attrib['type'] == 'interaction':
                 for interact_element in element.getiterator(NS + 'interactant'):
-                    ann_key = 'comment_%s_intactId' % element.attrib['type']
+                    ann_key = 'comment_{0!s}_intactId'.format(element.attrib['type'])
                     append_to_annotations(ann_key, interact_element.attrib['intactId'])
             elif element.attrib['type'] == 'alternative products':
                 for alt_element in element.getiterator(NS + 'isoform'):
-                    ann_key = 'comment_%s_isoform' % element.attrib['type'].replace(' ', '')
+                    ann_key = 'comment_{0!s}_isoform'.format(element.attrib['type'].replace(' ', ''))
                     for id_element in alt_element.getiterator(NS + 'id'):
                         append_to_annotations(ann_key, id_element.text)
             elif element.attrib['type'] == 'mass spectrometry':
-                ann_key = 'comment_%s' % element.attrib['type'].replace(' ', '')
+                ann_key = 'comment_{0!s}'.format(element.attrib['type'].replace(' ', ''))
                 start = end = 0
                 for loc_element in element.getiterator(NS + 'location'):
                     pos_els = loc_element.getiterator(NS + 'position')
@@ -278,21 +278,21 @@ class Parser(object):
                 mass = element.attrib['mass']
                 method = element.attrib['method']
                 if start == end == 0:
-                    append_to_annotations(ann_key, 'undefined:%s|%s' % (mass, method))
+                    append_to_annotations(ann_key, 'undefined:{0!s}|{1!s}'.format(mass, method))
                 else:
-                    append_to_annotations(ann_key, '%s..%s:%s|%s' % (start, end, mass, method))
+                    append_to_annotations(ann_key, '{0!s}..{1!s}:{2!s}|{3!s}'.format(start, end, mass, method))
             elif element.attrib['type'] == 'sequence caution':
                 pass  # not parsed: few information, complex structure
             elif element.attrib['type'] == 'online information':
                 for link_element in element.getiterator(NS + 'link'):
-                    ann_key = 'comment_%s' % element.attrib['type'].replace(' ', '')
+                    ann_key = 'comment_{0!s}'.format(element.attrib['type'].replace(' ', ''))
                     for id_element in link_element.getiterator(NS + 'link'):
                         append_to_annotations(ann_key,
-                                              '%s@%s' % (element.attrib['name'], link_element.attrib['uri']))
+                                              '{0!s}@{1!s}'.format(element.attrib['name'], link_element.attrib['uri']))
 
             # return raw XML comments if needed
             if self.return_raw_comments:
-                ann_key = 'comment_%s_xml' % element.attrib['type'].replace(' ', '')
+                ann_key = 'comment_{0!s}_xml'.format(element.attrib['type'].replace(' ', ''))
                 append_to_annotations(ann_key, ElementTree.tostring(element))
 
         def _parse_dbReference(element):
@@ -414,7 +414,7 @@ class Parser(object):
             elif status == 'uncertain':
                 return SeqFeature.UncertainPosition(position)
             else:
-                raise NotImplementedError("Position status %r" % status)
+                raise NotImplementedError("Position status {0!r}".format(status))
 
         def _parse_feature(element):
             feature = SeqFeature.SeqFeature()
@@ -454,9 +454,9 @@ class Parser(object):
         def _parse_sequence(element):
             for k, v in element.attrib.items():
                 if k in ("length", "mass", "version"):
-                    self.ParsedSeqRecord.annotations['sequence_%s' % k] = int(v)
+                    self.ParsedSeqRecord.annotations['sequence_{0!s}'.format(k)] = int(v)
                 else:
-                    self.ParsedSeqRecord.annotations['sequence_%s' % k] = v
+                    self.ParsedSeqRecord.annotations['sequence_{0!s}'.format(k)] = v
             seq = ''.join((element.text.split()))
             self.ParsedSeqRecord.seq = Seq.Seq(seq, self.alphabet)
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -459,7 +459,7 @@ def write(sequences, handle, format):
     if not format:
         raise ValueError("Format required (lower case string)")
     if format != format.lower():
-        raise ValueError("Format string '%s' should be lower case" % format)
+        raise ValueError("Format string '{0!s}' should be lower case".format(format))
 
     if isinstance(handle, SeqRecord):
         raise TypeError("Check arguments, handle should NOT be a SeqRecord")
@@ -492,10 +492,9 @@ def write(sequences, handle, format):
             count = len(alignment)
             del alignment_count, alignment
         elif format in _FormatToIterator or format in AlignIO._FormatToIterator:
-            raise ValueError("Reading format '%s' is supported, but not writing"
-                             % format)
+            raise ValueError("Reading format '{0!s}' is supported, but not writing".format(format))
         else:
-            raise ValueError("Unknown format '%s'" % format)
+            raise ValueError("Unknown format '{0!s}'".format(format))
 
         assert isinstance(count, int), "Internal error - the underlying %s " \
             "writer should have returned the record count, not %s" \
@@ -575,10 +574,10 @@ def parse(handle, format, alphabet=None):
     if not format:
         raise ValueError("Format required (lower case string)")
     if format != format.lower():
-        raise ValueError("Format string '%s' should be lower case" % format)
+        raise ValueError("Format string '{0!s}' should be lower case".format(format))
     if alphabet is not None and not (isinstance(alphabet, Alphabet) or
                                      isinstance(alphabet, AlphabetEncoder)):
-        raise ValueError("Invalid alphabet, %s" % repr(alphabet))
+        raise ValueError("Invalid alphabet, {0!s}".format(repr(alphabet)))
 
     with as_handle(handle, mode) as fp:
         # Map the file format to a sequence iterator:
@@ -597,7 +596,7 @@ def parse(handle, format, alphabet=None):
                                                   alphabet=alphabet)
                  for r in alignment)
         else:
-            raise ValueError("Unknown format '%s'" % format)
+            raise ValueError("Unknown format '{0!s}'".format(format))
         # This imposes some overhead... wait until we drop Python 2.4 to fix it
         for r in i:
             yield r
@@ -733,7 +732,7 @@ def to_dict(sequences, key_function=None):
     for record in sequences:
         key = key_function(record)
         if key in d:
-            raise ValueError("Duplicate key '%s'" % key)
+            raise ValueError("Duplicate key '{0!s}'".format(key))
         d[key] = record
     return d
 
@@ -854,10 +853,10 @@ def index(filename, format, alphabet=None, key_function=None):
     if not format:
         raise ValueError("Format required (lower case string)")
     if format != format.lower():
-        raise ValueError("Format string '%s' should be lower case" % format)
+        raise ValueError("Format string '{0!s}' should be lower case".format(format))
     if alphabet is not None and not (isinstance(alphabet, Alphabet) or
                                      isinstance(alphabet, AlphabetEncoder)):
-        raise ValueError("Invalid alphabet, %s" % repr(alphabet))
+        raise ValueError("Invalid alphabet, {0!s}".format(repr(alphabet)))
 
     # Map the file format to a sequence iterator:
     from ._index import _FormatToRandomAccess  # Lazy import
@@ -865,9 +864,8 @@ def index(filename, format, alphabet=None, key_function=None):
     try:
         proxy_class = _FormatToRandomAccess[format]
     except KeyError:
-        raise ValueError("Unsupported format %r" % format)
-    repr = "SeqIO.index(%r, %r, alphabet=%r, key_function=%r)" \
-        % (filename, format, alphabet, key_function)
+        raise ValueError("Unsupported format {0!r}".format(format))
+    repr = "SeqIO.index({0!r}, {1!r}, alphabet={2!r}, key_function={3!r})".format(filename, format, alphabet, key_function)
     return _IndexedSeqFileDict(proxy_class(filename, format, alphabet),
                                key_function, repr, "SeqRecord")
 
@@ -934,16 +932,15 @@ def index_db(index_filename, filenames=None, format=None, alphabet=None,
     if format is not None and not isinstance(format, basestring):
         raise TypeError("Need a string for the file format (lower case)")
     if format and format != format.lower():
-        raise ValueError("Format string '%s' should be lower case" % format)
+        raise ValueError("Format string '{0!s}' should be lower case".format(format))
     if alphabet is not None and not (isinstance(alphabet, Alphabet) or
                                      isinstance(alphabet, AlphabetEncoder)):
-        raise ValueError("Invalid alphabet, %s" % repr(alphabet))
+        raise ValueError("Invalid alphabet, {0!s}".format(repr(alphabet)))
 
     # Map the file format to a sequence iterator:
     from ._index import _FormatToRandomAccess  # Lazy import
     from Bio.File import _SQLiteManySeqFilesDict
-    repr = "SeqIO.index_db(%r, filenames=%r, format=%r, alphabet=%r, key_function=%r)" \
-               % (index_filename, filenames, format, alphabet, key_function)
+    repr = "SeqIO.index_db({0!r}, filenames={1!r}, format={2!r}, alphabet={3!r}, key_function={4!r})".format(index_filename, filenames, format, alphabet, key_function)
 
     def proxy_factory(format, filename=None):
         """Given a filename returns proxy object, else boolean if format OK."""

--- a/Bio/SeqIO/_convert.py
+++ b/Bio/SeqIO/_convert.py
@@ -60,7 +60,7 @@ def _fastq_generic(in_handle, out_handle, mapping):
         qual = old_qual.translate(mapping)
         if null in qual:
             raise ValueError("Invalid character in quality string")
-        out_handle.write("@%s\n%s\n+\n%s\n" % (title, seq, qual))
+        out_handle.write("@{0!s}\n{1!s}\n+\n{2!s}\n".format(title, seq, qual))
     return count
 
 
@@ -80,7 +80,7 @@ def _fastq_generic2(in_handle, out_handle, mapping, truncate_char, truncate_msg)
             qual = qual.replace(truncate_char, chr(126))
             import warnings
             warnings.warn(truncate_msg)
-        out_handle.write("@%s\n%s\n+\n%s\n" % (title, seq, qual))
+        out_handle.write("@{0!s}\n{1!s}\n+\n{2!s}\n".format(title, seq, qual))
     return count
 
 
@@ -248,7 +248,7 @@ def _fastq_convert_fasta(in_handle, out_handle, alphabet=None):
     count = 0
     for title, seq, qual in FastqGeneralIterator(in_handle):
         count += 1
-        out_handle.write(">%s\n" % title)
+        out_handle.write(">{0!s}\n".format(title))
         # Do line wrapping
         for i in range(0, len(seq), 60):
             out_handle.write(seq[i:i + 60] + "\n")
@@ -269,7 +269,7 @@ def _fastq_convert_tab(in_handle, out_handle, alphabet=None):
     count = 0
     for title, seq, qual in FastqGeneralIterator(in_handle):
         count += 1
-        out_handle.write("%s\t%s\n" % (title.split(None, 1)[0], seq))
+        out_handle.write("{0!s}\t{1!s}\n".format(title.split(None, 1)[0], seq))
     return count
 
 
@@ -284,7 +284,7 @@ def _fastq_convert_qual(in_handle, out_handle, mapping):
     count = 0
     for title, seq, qual in FastqGeneralIterator(in_handle):
         count += 1
-        out_handle.write(">%s\n" % title)
+        out_handle.write(">{0!s}\n".format(title))
         # map the qual... note even with Sanger encoding max 2 digits
         try:
             qualities_strs = [mapping[ascii] for ascii in qual]

--- a/Bio/SeqIO/_index.py
+++ b/Bio/SeqIO/_index.py
@@ -101,13 +101,12 @@ class SffRandomAccess(SeqFileRandomAccess):
                     yield name, offset, 0
                     count += 1
                 assert count == number_of_reads, \
-                    "Indexed %i records, expected %i" \
-                    % (count, number_of_reads)
+                    "Indexed {0:d} records, expected {1:d}".format(count, number_of_reads)
                 # If that worked, call _check_eof ...
             except ValueError as err:
                 import warnings
                 from Bio import BiopythonParserWarning
-                warnings.warn("Could not parse the SFF index: %s" % err,
+                warnings.warn("Could not parse the SFF index: {0!s}".format(err),
                               BiopythonParserWarning)
                 assert count == 0, "Partially populated index"
                 handle.seek(0)
@@ -130,7 +129,7 @@ class SffRandomAccess(SeqFileRandomAccess):
             yield name, offset, 0
             count += 1
         assert count == number_of_reads, \
-            "Indexed %i records, expected %i" % (count, number_of_reads)
+            "Indexed {0:d} records, expected {1:d}".format(count, number_of_reads)
         SeqIO.SffIO._check_eof(handle, index_offset, index_length)
 
     def get(self, offset):
@@ -180,7 +179,7 @@ class SequentialSeqFileRandomAccess(SeqFileRandomAccess):
                   "uniprot-xml": "<entry ",
                   }[format]
         self._marker = marker
-        self._marker_re = re.compile(_as_bytes("^%s" % marker))
+        self._marker_re = re.compile(_as_bytes("^{0!s}".format(marker)))
 
     def __iter__(self):
         """Returns (id,offset) tuples."""
@@ -406,8 +405,7 @@ class UniprotRandomAccess(SequentialSeqFileRandomAccess):
                 else:
                     length += len(line)
             if not key:
-                raise ValueError("Did not find <accession> line in bytes %i to %i"
-                                 % (start_offset, end_offset))
+                raise ValueError("Did not find <accession> line in bytes {0:d} to {1:d}".format(start_offset, end_offset))
             yield _bytes_to_string(key), start_offset, length
             # Find start of next record
             while not marker_re.match(line) and line:
@@ -443,9 +441,9 @@ class UniprotRandomAccess(SequentialSeqFileRandomAccess):
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://uniprot.org/uniprot
         http://www.uniprot.org/support/docs/uniprot.xsd">
-        %s
+        {0!s}
         </uniprot>
-        """ % _bytes_to_string(self.get_raw(offset))
+        """.format(_bytes_to_string(self.get_raw(offset)))
         # TODO - For consistency, this function should not accept a string:
         return next(SeqIO.UniprotIO.UniprotIterator(data))
 
@@ -547,7 +545,7 @@ class FastqRandomAccess(SeqFileRandomAccess):
         at_char = _as_bytes("@")
         plus_char = _as_bytes("+")
         if line[0:1] != at_char:
-            raise ValueError("Problem with FASTQ @ line:\n%r" % line)
+            raise ValueError("Problem with FASTQ @ line:\n{0!r}".format(line))
         while line:
             # assert line[0]=="@"
             # This record seems OK (so far)
@@ -572,12 +570,12 @@ class FastqRandomAccess(SeqFileRandomAccess):
                         # Special case, quality line should be just "\n"
                         line = handle.readline()
                         if line.strip():
-                            raise ValueError("Expected blank quality line, not %r" % line)
+                            raise ValueError("Expected blank quality line, not {0!r}".format(line))
                     # Should be end of record...
                     end_offset = handle.tell()
                     line = handle.readline()
                     if line and line[0:1] != at_char:
-                        raise ValueError("Problem with line %r" % line)
+                        raise ValueError("Problem with line {0!r}".format(line))
                     break
                 else:
                     line = handle.readline()
@@ -599,7 +597,7 @@ class FastqRandomAccess(SeqFileRandomAccess):
         at_char = _as_bytes("@")
         plus_char = _as_bytes("+")
         if line[0:1] != at_char:
-            raise ValueError("Problem with FASTQ @ line:\n%r" % line)
+            raise ValueError("Problem with FASTQ @ line:\n{0!r}".format(line))
         # Find the seq line(s)
         seq_len = 0
         while line:
@@ -619,12 +617,12 @@ class FastqRandomAccess(SeqFileRandomAccess):
                     # Special case, quality line should be just "\n"
                     line = handle.readline()
                     if line.strip():
-                        raise ValueError("Expected blank quality line, not %r" % line)
+                        raise ValueError("Expected blank quality line, not {0!r}".format(line))
                     data += line
                 # Should be end of record...
                 line = handle.readline()
                 if line and line[0:1] != at_char:
-                    raise ValueError("Problem with line %r" % line)
+                    raise ValueError("Problem with line {0!r}".format(line))
                 break
             else:
                 line = handle.readline()

--- a/Bio/SeqUtils/CheckSum.py
+++ b/Bio/SeqUtils/CheckSum.py
@@ -63,7 +63,7 @@ def crc64(s):
         crch = temp1h ^ _table_h[idx]
         crcl = temp1l
 
-    return "CRC-%08X%08X" % (crch, crcl)
+    return "CRC-{0:08X}{1:08X}".format(crch, crcl)
 
 
 def gcg(seq):

--- a/Bio/SeqUtils/CodonUsage.py
+++ b/Bio/SeqUtils/CodonUsage.py
@@ -133,7 +133,7 @@ class CodonAdaptationIndex(object):
                     cai_value += math.log(self.index[codon])
                     cai_length += 1
             elif codon not in ['TGA', 'TAA', 'TAG']:  # some indices may not include stop codons
-                raise TypeError("illegal codon in sequence: %s.\n%s" % (codon, self.index))
+                raise TypeError("illegal codon in sequence: {0!s}.\n{1!s}".format(codon, self.index))
 
         return math.exp(cai_value / (cai_length - 1.0))
 
@@ -155,10 +155,10 @@ class CodonAdaptationIndex(object):
                     if codon in self.codon_count:
                         self.codon_count[codon] += 1
                     else:
-                        raise TypeError("illegal codon %s in gene: %s" % (codon, cur_record.id))
+                        raise TypeError("illegal codon {0!s} in gene: {1!s}".format(codon, cur_record.id))
 
     # this just gives the index when the objects is printed.
     def print_index(self):
         """Prints out the index used."""
         for i in sorted(self.index):
-            print("%s\t%.3f" % (i, self.index[i]))
+            print("{0!s}\t{1:.3f}".format(i, self.index[i]))

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -996,7 +996,7 @@ def Tm_staluc(s, dnac=50, saltc=50, rna=0):
         return Tm_NN(s, dnac1=dnac / 2.0, dnac2=dnac / 2.0, Na=saltc,
                      nn_table=RNA_NN2)
     else:
-        raise ValueError("rna=%r not supported" % rna)
+        raise ValueError("rna={0!r} not supported".format(rna))
 
 
 def _test():

--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -236,15 +236,14 @@ class ProteinAnalysis(object):
                     back = param_dict[subsequence[window - j - 1]]
                     score += weights[j] * front + weights[j] * back
                 except KeyError:
-                    sys.stderr.write('warning: %s or %s is not a standard amino acid.\n' %
-                             (subsequence[j], subsequence[window - j - 1]))
+                    sys.stderr.write('warning: {0!s} or {1!s} is not a standard amino acid.\n'.format(subsequence[j], subsequence[window - j - 1]))
 
             # Now add the middle value, which always has a weight of 1.
             middle = subsequence[window // 2]
             if middle in param_dict:
                 score += param_dict[middle]
             else:
-                sys.stderr.write('warning: %s  is not a standard amino acid.\n' % (middle))
+                sys.stderr.write('warning: {0!s}  is not a standard amino acid.\n'.format((middle)))
 
             scores.append(score / sum_of_weights)
 

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -136,9 +136,9 @@ def xGC_skew(seq, window=1000, zoom=100,
     x1, x2, y1, y2 = X0 - r, X0 + r, Y0 - r, Y0 + r
 
     ty = Y0
-    canvas.create_text(X0, ty, text='%s...%s (%d nt)' % (seq[:7], seq[-7:], len(seq)))
+    canvas.create_text(X0, ty, text='{0!s}...{1!s} ({2:d} nt)'.format(seq[:7], seq[-7:], len(seq)))
     ty += 20
-    canvas.create_text(X0, ty, text='GC %3.2f%%' % (GC(seq)))
+    canvas.create_text(X0, ty, text='GC {0:3.2f}%'.format((GC(seq))))
     ty += 20
     canvas.create_text(X0, ty, text='GC Skew', fill='blue')
     ty += 20
@@ -186,7 +186,7 @@ def nt_search(seq, subseq):
         if len(value) == 1:
             pattern += value
         else:
-            pattern += '[%s]' % value
+            pattern += '[{0!s}]'.format(value)
 
     pos = -1
     result = [pattern]
@@ -389,19 +389,17 @@ def molecular_weight(seq, seq_type=None, double_stranded=False, circular=False,
             # Convert to one-letter sequence. Have to use a string for seq1
             seq = Seq(seq1(str(seq)), alphabet=Alphabet.ProteinAlphabet())
         elif not isinstance(base_alphabet, Alphabet.Alphabet):
-            raise TypeError("%s is not a valid alphabet for mass calculations"
-                             % base_alphabet)
+            raise TypeError("{0!s} is not a valid alphabet for mass calculations".format(base_alphabet))
         else:
             tmp_type = "DNA"  # backward compatibity
         if seq_type and tmp_type and tmp_type != seq_type:
-            raise ValueError("seq_type=%r contradicts %s from seq alphabet"
-                             % (seq_type, tmp_type))
+            raise ValueError("seq_type={0!r} contradicts {1!s} from seq alphabet".format(seq_type, tmp_type))
         seq_type = tmp_type
     elif isinstance(seq, str):
         if seq_type is None:
             seq_type = "DNA"  # backward compatibity
     else:
-        raise TypeError("Expected a string or Seq object, not seq=%r" % seq)
+        raise TypeError("Expected a string or Seq object, not seq={0!r}".format(seq))
 
     seq = ''.join(str(seq).split()).upper()  # Do the minimum formatting
 
@@ -421,8 +419,7 @@ def molecular_weight(seq, seq_type=None, double_stranded=False, circular=False,
         else:
             weight_table = IUPACData.protein_weights
     else:
-        raise ValueError("Allowed seq_types are DNA, RNA or protein, not %r"
-                         % seq_type)
+        raise ValueError("Allowed seq_types are DNA, RNA or protein, not {0!r}".format(seq_type))
 
     if monoisotopic:
         water = 18.010565
@@ -434,8 +431,7 @@ def molecular_weight(seq, seq_type=None, double_stranded=False, circular=False,
         if circular:
             weight -= water
     except KeyError as e:
-        raise ValueError('%s is not a valid unambiguous letter for %s'
-                         % (e, seq_type))
+        raise ValueError('{0!s} is not a valid unambiguous letter for {1!s}'.format(e, seq_type))
     except:
         raise
 
@@ -487,26 +483,26 @@ def six_frame_translations(seq, genetic_code=1):
 
     # create header
     if length > 20:
-        short = '%s ... %s' % (seq[:10], seq[-10:])
+        short = '{0!s} ... {1!s}'.format(seq[:10], seq[-10:])
     else:
         short = seq
     header = 'GC_Frame: '
     for nt in ['a', 't', 'g', 'c']:
-        header += '%s:%d ' % (nt, seq.count(nt.upper()))
+        header += '{0!s}:{1:d} '.format(nt, seq.count(nt.upper()))
 
-    header += '\nSequence: %s, %d nt, %0.2f %%GC\n\n\n' % (short.lower(), length, GC(seq))
+    header += '\nSequence: {0!s}, {1:d} nt, {2:0.2f} %GC\n\n\n'.format(short.lower(), length, GC(seq))
     res = header
 
     for i in range(0, length, 60):
         subseq = seq[i:i + 60]
         csubseq = comp[i:i + 60]
         p = i // 3
-        res += '%d/%d\n' % (i + 1, i / 3 + 1)
+        res += '{0:d}/{1:d}\n'.format(i + 1, i / 3 + 1)
         res += '  ' + '  '.join(frames[3][p:p + 20]) + '\n'
         res += ' ' + '  '.join(frames[2][p:p + 20]) + '\n'
         res += '  '.join(frames[1][p:p + 20]) + '\n'
         # seq
-        res += subseq.lower() + '%5d %%\n' % int(GC(subseq))
+        res += subseq.lower() + '{0:5d} %\n'.format(int(GC(subseq)))
         res += csubseq.lower() + '\n'
         # - frames
         res += '  '.join(frames[-2][p:p + 20]) + ' \n'

--- a/Bio/Sequencing/Applications/_Novoalign.py
+++ b/Bio/Sequencing/Applications/_Novoalign.py
@@ -55,8 +55,7 @@ class NovoalignCommandline(AbstractCommandline):
                     filename=True,
                     equate=False),
             _Option(["-F", "format"],
-                    "Format of read files.\n\nAllowed values: %s"
-                    % ", ".join(READ_FORMAT),
+                    "Format of read files.\n\nAllowed values: {0!s}".format(", ".join(READ_FORMAT)),
                     checker_function=lambda x: x in READ_FORMAT,
                     equate=False),
 
@@ -111,8 +110,7 @@ class NovoalignCommandline(AbstractCommandline):
                     equate=False),
             # Reporting options
             _Option(["-o", "report"],
-                    "Specifies the report format.\n\nAllowed values: %s\nDefault: Native"
-                    % ", ".join(REPORT_FORMAT),
+                    "Specifies the report format.\n\nAllowed values: {0!s}\nDefault: Native".format(", ".join(REPORT_FORMAT)),
                     checker_function=lambda x: x in REPORT_FORMAT,
                     equate=False),
             _Option(["-Q", "quality"],

--- a/Bio/SubsMat/__init__.py
+++ b/Bio/SubsMat/__init__.py
@@ -333,7 +333,7 @@ class SeqMat(dict):
                 if val == -999:
                     output += '  ND'
                 else:
-                    output += "%4d" % val
+                    output += "{0:4d}".format(val)
             output += '\n'
         output += '%4s' * n % tuple(alphabet) + "\n"
         return output
@@ -595,7 +595,7 @@ def two_mat_correlation(mat_1, mat_2):
         try:
             values.append((mat_1[ab_pair], mat_2[ab_pair]))
         except KeyError:
-            raise ValueError("%s is not a common key" % ab_pair)
+            raise ValueError("{0!s} is not a common key".format(ab_pair))
     correlation_matrix = numpy.corrcoef(values, rowvar=0)
     correlation = correlation_matrix[0, 1]
     return correlation

--- a/Bio/SwissProt/KeyWList.py
+++ b/Bio/SwissProt/KeyWList.py
@@ -81,7 +81,7 @@ def parse(handle):
             elif key in ("DE", "SY", "GO", "HI", "WW"):
                 record[key].append(value)
             else:
-                print("Ignoring: %s" % line.strip())
+                print("Ignoring: {0!s}".format(line.strip()))
     # Read the footer and throw it away
     for line in handle:
         pass

--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -232,7 +232,7 @@ def _read(handle):
             _read_ft(record, line)
         elif key == 'SQ':
             cols = value.split()
-            assert len(cols) == 7, "I don't understand SQ line %s" % line
+            assert len(cols) == 7, "I don't understand SQ line {0!s}".format(line)
             # Do more checking here?
             record.seqinfo = int(cols[1]), int(cols[3]), cols[5]
         elif key == '  ':
@@ -251,7 +251,7 @@ def _read(handle):
             record.sequence = "".join(_sequence_lines)
             return record
         else:
-            raise ValueError("Unknown keyword '%s' found" % key)
+            raise ValueError("Unknown keyword '{0!s}' found".format(key))
     if record:
         raise ValueError("Unexpected end of stream.")
 
@@ -278,13 +278,11 @@ def _read_id(record, line):
     # check if the data class is one of the allowed values
     allowed = ('STANDARD', 'PRELIMINARY', 'IPI', 'Reviewed', 'Unreviewed')
     if record.data_class not in allowed:
-        raise ValueError("Unrecognized data class %s in line\n%s" %
-              (record.data_class, line))
+        raise ValueError("Unrecognized data class {0!s} in line\n{1!s}".format(record.data_class, line))
     # molecule_type should be 'PRT' for PRoTein
     # Note that has been removed in recent releases (set to None)
     if record.molecule_type not in (None, 'PRT'):
-        raise ValueError("Unrecognized molecule type %s in line\n%s" %
-              (record.molecule_type, line))
+        raise ValueError("Unrecognized molecule type {0!s} in line\n{1!s}".format(record.molecule_type, line))
 
 
 def _read_dt(record, line):
@@ -315,7 +313,7 @@ def _read_dt(record, line):
             if 'REL.' in uprcols[index]:
                 rel_index = index
         assert rel_index >= 0, \
-                "Could not find Rel. in DT line: %s" % line
+                "Could not find Rel. in DT line: {0!s}".format(line)
         version_index = rel_index + 1
         # get the version information
         str_version = cols[version_index].rstrip(",")
@@ -378,7 +376,7 @@ def _read_dt(record, line):
         else:
             assert False, "Shouldn't reach this line!"
     else:
-        raise ValueError("I don't understand the date line %s" % line)
+        raise ValueError("I don't understand the date line {0!s}".format(line))
 
 
 def _read_ox(record, line):
@@ -401,13 +399,13 @@ def _read_ox(record, line):
         ids = line[5:].rstrip().rstrip(";")
     else:
         descr, ids = line[5:].rstrip().rstrip(";").split("=")
-        assert descr == "NCBI_TaxID", "Unexpected taxonomy type %s" % descr
+        assert descr == "NCBI_TaxID", "Unexpected taxonomy type {0!s}".format(descr)
     record.taxonomy_id.extend(ids.split(', '))
 
 
 def _read_oh(record, line):
     # Line type OH (Organism Host) for viral hosts
-    assert line[5:].startswith("NCBI_TaxID="), "Unexpected %s" % line
+    assert line[5:].startswith("NCBI_TaxID="), "Unexpected {0!s}".format(line)
     line = line[16:].rstrip()
     assert line[-1] == "." and line.count(";") == 1, line
     taxid, name = line[:-1].split(";")
@@ -422,11 +420,11 @@ def _read_rn(reference, rn):
     # RN   [1] {ECO:0000313|EMBL:AEX14553.1}
     words = rn.split(None, 1)
     number = words[0]
-    assert number.startswith('[') and number.endswith(']'), "Missing brackets %s" % number
+    assert number.startswith('[') and number.endswith(']'), "Missing brackets {0!s}".format(number)
     reference.number = int(number[1:-1])
     if len(words) > 1:
         evidence = words[1]
-        assert evidence.startswith('{') and evidence.endswith('}'), "Missing braces %s" % evidence
+        assert evidence.startswith('{') and evidence.endswith('}'), "Missing braces {0!s}".format(evidence)
         reference.evidence = evidence[1:-1].split('|')
 
 def _read_rc(reference, value):
@@ -446,7 +444,7 @@ def _read_rc(reference, value):
             reference.comments.append(comment)
         else:
             comment = reference.comments[-1]
-            comment = "%s %s" % (comment, col)
+            comment = "{0!s} {1!s}".format(comment, col)
             reference.comments[-1] = comment
     return unread
 
@@ -479,7 +477,7 @@ def _read_rx(reference, value):
             if len(x) != 2 or x == ("DOI", "DOI"):
                 warn = True
                 break
-            assert len(x) == 2, "I don't understand RX line %s" % value
+            assert len(x) == 2, "I don't understand RX line {0!s}".format(value)
             reference.references.append((x[0], x[1].rstrip(";")))
     # otherwise we assume we have the type 'RX   MEDLINE; 85132727.'
     else:
@@ -492,7 +490,7 @@ def _read_rx(reference, value):
     if warn:
         import warnings
         from Bio import BiopythonParserWarning
-        warnings.warn("Possibly corrupt RX line %r" % value,
+        warnings.warn("Possibly corrupt RX line {0!r}".format(value),
                       BiopythonParserWarning)
 
 
@@ -553,7 +551,7 @@ def _read_ft(record, line):
         assert not from_res and not to_res
         name, from_res, to_res, old_description, old_ft_id = record.features[-1]
         del record.features[-1]
-        description = ("%s %s" % (old_description, description)).strip()
+        description = ("{0!s} {1!s}".format(old_description, description)).strip()
 
         # special case -- VARSPLIC, reported by edvard@farmasi.uit.no
         if name == "VARSPLIC":
@@ -587,7 +585,7 @@ if __name__ == "__main__":
 
     import os
     if not os.path.isfile(example_filename):
-        print("Missing test file %s" % example_filename)
+        print("Missing test file {0!s}".format(example_filename))
     else:
         # Try parsing it!
 

--- a/Bio/TogoWS/__init__.py
+++ b/Bio/TogoWS/__init__.py
@@ -65,11 +65,11 @@ def _get_entry_dbs():
 
 
 def _get_entry_fields(db):
-    return _get_fields(_BASE_URL + "/entry/%s?fields" % db)
+    return _get_fields(_BASE_URL + "/entry/{0!s}?fields".format(db))
 
 
 def _get_entry_formats(db):
-    return _get_fields(_BASE_URL + "/entry/%s?formats" % db)
+    return _get_fields(_BASE_URL + "/entry/{0!s}?formats".format(db))
 
 
 def _get_convert_formats():
@@ -137,7 +137,7 @@ def entry(db, id, format=None, field=None):
 
     if isinstance(id, list):
         id = ",".join(id)
-    url = _BASE_URL + "/entry/%s/%s" % (db, _quote(id))
+    url = _BASE_URL + "/entry/{0!s}/{1!s}".format(db, _quote(id))
     if field:
         url += "/" + field
     if format:
@@ -164,14 +164,14 @@ def search_count(db, query):
         import warnings
         warnings.warn("TogoWS search does not officially support database '%s'. "
                       "See %s/search/ for options." % (db, _BASE_URL))
-    url = _BASE_URL + "/search/%s/%s/count" % (db, _quote(query))
+    url = _BASE_URL + "/search/{0!s}/{1!s}/count".format(db, _quote(query))
     handle = _open(url)
     data = handle.read()
     handle.close()
     try:
         count = int(data.strip())
     except ValueError:
-        raise ValueError("Expected an integer from URL %s, got: %r" % (url, data))
+        raise ValueError("Expected an integer from URL {0!s}, got: {1!r}".format(url, data))
     return count
 
 
@@ -206,14 +206,13 @@ def search_iter(db, query, limit=None, batch=100):
         batch = min(batch, remain)
         # print("%r left, asking for %r" % (remain, batch))
         ids = search(db, query, offset, batch).read().strip().split()
-        assert len(ids) == batch, "Got %i, expected %i" % (len(ids), batch)
+        assert len(ids) == batch, "Got {0:d}, expected {1:d}".format(len(ids), batch)
         # print("offset %i, %s ... %s" % (offset, ids[0], ids[-1]))
         if ids == prev_ids:
             raise RuntimeError("Same search results for previous offset")
         for identifier in ids:
             if identifier in prev_ids:
-                raise RuntimeError("Result %s was in previous batch"
-                                   % identifier)
+                raise RuntimeError("Result {0!s} was in previous batch".format(identifier))
             yield identifier
         offset += batch
         remain -= batch
@@ -260,21 +259,21 @@ def search(db, query, offset=None, limit=None, format=None):
         import warnings
         warnings.warn("TogoWS search does not explicitly support database '%s'. "
                       "See %s/search/ for options." % (db, _BASE_URL))
-    url = _BASE_URL + "/search/%s/%s" % (db, _quote(query))
+    url = _BASE_URL + "/search/{0!s}/{1!s}".format(db, _quote(query))
     if offset is not None and limit is not None:
         try:
             offset = int(offset)
         except:
-            raise ValueError("Offset should be an integer (at least one), not %r" % offset)
+            raise ValueError("Offset should be an integer (at least one), not {0!r}".format(offset))
         try:
             limit = int(limit)
         except:
-            raise ValueError("Limit should be an integer (at least one), not %r" % limit)
+            raise ValueError("Limit should be an integer (at least one), not {0!r}".format(limit))
         if offset <= 0:
-            raise ValueError("Offset should be at least one, not %i" % offset)
+            raise ValueError("Offset should be at least one, not {0:d}".format(offset))
         if limit <= 0:
-            raise ValueError("Count should be at least one, not %i" % limit)
-        url += "/%i,%i" % (offset, limit)
+            raise ValueError("Count should be at least one, not {0:d}".format(limit))
+        url += "/{0:d},{1:d}".format(offset, limit)
     elif offset is not None or limit is not None:
         raise ValueError("Expect BOTH offset AND limit to be provided (or neither)")
     if format:
@@ -300,9 +299,9 @@ def convert(data, in_format, out_format):
     if not _convert_formats:
         _convert_formats = _get_convert_formats()
     if [in_format, out_format] not in _convert_formats:
-        msg = "\n".join("%s -> %s" % tuple(pair) for pair in _convert_formats)
-        raise ValueError("Unsupported conversion. Choose from:\n%s" % msg)
-    url = _BASE_URL + "/convert/%s.%s" % (in_format, out_format)
+        msg = "\n".join("{0!s} -> {1!s}".format(*tuple(pair)) for pair in _convert_formats)
+        raise ValueError("Unsupported conversion. Choose from:\n{0!s}".format(msg))
+    url = _BASE_URL + "/convert/{0!s}.{1!s}".format(in_format, out_format)
     # TODO - Should we just accept a string not a handle? What about a filename?
     if hasattr(data, "read"):
         # Handle

--- a/Bio/UniGene/__init__.py
+++ b/Bio/UniGene/__init__.py
@@ -247,7 +247,7 @@ class Record(object):
         self.txmap = []  # TXMAP entries, array of TXMap entries
 
     def __repr__(self):
-        return "<%s> %s %s\n%s" % (self.__class__.__name__,
+        return "<{0!s}> {1!s} {2!s}\n{3!s}".format(self.__class__.__name__,
                           self.ID, self.symbol, self.title)
 
 
@@ -297,7 +297,7 @@ def _read(handle):
             elif value == "NO":
                 record.homol = True
             else:
-                raise ValueError("Cannot parse HOMOL line %s" % line)
+                raise ValueError("Cannot parse HOMOL line {0!s}".format(line))
         elif tag == "EXPRESS":
             record.express = [word.strip() for word in value.split("|")]
         elif tag == "RESTR_EXPR":
@@ -323,6 +323,6 @@ def _read(handle):
                                  " (%d) does not agree with the number of sequences found (%d)" % (scount, len(record.sequence)))
             return record
         else:
-            raise ValueError("Unknown tag %s" % tag)
+            raise ValueError("Unknown tag {0!s}".format(tag))
     if record:
         raise ValueError("Unexpected end of stream.")

--- a/Bio/UniProt/GOA.py
+++ b/Bio/UniProt/GOA.py
@@ -361,7 +361,7 @@ def writerec(outrec, handle, fields=GAF20FIELDS):
         else:
             outstr += outrec[field] + '\t'
     outstr += outrec[fields[-1]] + '\n'
-    handle.write("%s" % outstr)
+    handle.write("{0!s}".format(outstr))
 
 
 def writebyproteinrec(outprotrec, handle, fields=GAF20FIELDS):

--- a/Bio/Wise/__init__.py
+++ b/Bio/Wise/__init__.py
@@ -69,7 +69,7 @@ def align(cmdline, pair, kbyte=None, force_type=None, dry_run=False, quiet=False
     Returns a filehandle
     """
     if not pair or len(pair) != 2:
-        raise ValueError("Expected pair of filename, not %s" % repr(pair))
+        raise ValueError("Expected pair of filename, not {0!s}".format(repr(pair)))
 
     output_file = tempfile.NamedTemporaryFile(mode='r')
     input_files = tempfile.NamedTemporaryFile(mode="w"), tempfile.NamedTemporaryFile(mode="w")
@@ -101,7 +101,7 @@ def align(cmdline, pair, kbyte=None, force_type=None, dry_run=False, quiet=False
                                        quiet)
 
     if debug:
-        sys.stderr.write("%s\n" % cmdline_str)
+        sys.stderr.write("{0!s}\n".format(cmdline_str))
 
     status = os.system(cmdline_str) >> 8
 
@@ -110,7 +110,7 @@ def align(cmdline, pair, kbyte=None, force_type=None, dry_run=False, quiet=False
             sys.stderr.write("INFO trying again with the linear model\n")
             return align(cmdline, pair, 0, force_type, dry_run, quiet, debug)
         else:
-            raise OSError("%s returned %s" % (" ".join(cmdline), status))
+            raise OSError("{0!s} returned {1!s}".format(" ".join(cmdline), status))
 
     return output_file
 

--- a/Bio/Wise/dnal.py
+++ b/Bio/Wise/dnal.py
@@ -78,14 +78,14 @@ class Statistics(object):
     Calculate statistics from an ALB report
     """
     def __init__(self, filename, match, mismatch, gap, extension):
-        self.matches = _fgrep_count('"SEQUENCE" %s' % match, filename)
-        self.mismatches = _fgrep_count('"SEQUENCE" %s' % mismatch, filename)
-        self.gaps = _fgrep_count('"INSERT" %s' % gap, filename)
+        self.matches = _fgrep_count('"SEQUENCE" {0!s}'.format(match), filename)
+        self.mismatches = _fgrep_count('"SEQUENCE" {0!s}'.format(mismatch), filename)
+        self.gaps = _fgrep_count('"INSERT" {0!s}'.format(gap), filename)
 
         if gap == extension:
             self.extensions = 0
         else:
-            self.extensions = _fgrep_count('"INSERT" %s' % extension, filename)
+            self.extensions = _fgrep_count('"INSERT" {0!s}'.format(extension), filename)
 
         self.score = (match * self.matches +
                       mismatch * self.mismatches +
@@ -124,10 +124,10 @@ def align(pair, match=_SCORE_MATCH, mismatch=_SCORE_MISMATCH, gap=_SCORE_GAP_STA
 def main():
     import sys
     stats = align(sys.argv[1:3])
-    print("\n".join("%s: %s" % (attr, getattr(stats, attr))
+    print("\n".join("{0!s}: {1!s}".format(attr, getattr(stats, attr))
                     for attr in ("matches", "mismatches", "gaps", "extensions")))
-    print("identity_fraction: %s" % stats.identity_fraction())
-    print("coords: %s" % stats.coords)
+    print("identity_fraction: {0!s}".format(stats.identity_fraction()))
+    print("coords: {0!s}".format(stats.coords))
 
 
 def _test(*args, **keywds):

--- a/Bio/Wise/psw.py
+++ b/Bio/Wise/psw.py
@@ -50,7 +50,7 @@ class AlignmentColumn(list):
         list.__init__(self, [column_unit.column, None])
 
     def __repr__(self):
-        return "%s(%s, %s)" % (self.kind, self[0], self[1])
+        return "{0!s}({1!s}, {2!s})".format(self.kind, self[0], self[1])
 
     def append(self, column_unit):
         if self[1] is not None:
@@ -69,7 +69,7 @@ class ColumnUnit(object):
         self.kind = kind
 
     def __str__(self):
-        return "ColumnUnit(unit=%s, column=%s, %s)" % (self.unit, self.column, self.kind)
+        return "ColumnUnit(unit={0!s}, column={1!s}, {2!s})".format(self.unit, self.column, self.kind)
 
     __repr__ = __str__
 

--- a/Bio/_py3k/_ordereddict.py
+++ b/Bio/_py3k/_ordereddict.py
@@ -27,7 +27,7 @@ class OrderedDict(dict, DictMixin):
 
     def __init__(self, *args, **kwds):
         if len(args) > 1:
-            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+            raise TypeError('expected at most 1 arguments, got {0:d}'.format(len(args)))
         try:
             self.__end
         except AttributeError:
@@ -101,8 +101,8 @@ class OrderedDict(dict, DictMixin):
 
     def __repr__(self):
         if not self:
-            return '%s()' % (self.__class__.__name__,)
-        return '%s(%r)' % (self.__class__.__name__, self.items())
+            return '{0!s}()'.format(self.__class__.__name__)
+        return '{0!s}({1!r})'.format(self.__class__.__name__, self.items())
 
     def copy(self):
         return self.__class__(self)

--- a/Bio/_utils.py
+++ b/Bio/_utils.py
@@ -91,7 +91,7 @@ def find_test_dir(start_dir=None):
             # Reached root
             break
         target = new
-    raise ValueError("Not within Biopython source tree: %r" % os.path.abspath(start_dir))
+    raise ValueError("Not within Biopython source tree: {0!r}".format(os.path.abspath(start_dir)))
 
 
 def run_doctest(target_dir=None, *args, **kwargs):

--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -251,7 +251,7 @@ def open(filename, mode="rb"):
     elif "w" in mode.lower() or "a" in mode.lower():
         return BgzfWriter(filename, mode)
     else:
-        raise ValueError("Bad mode %r" % mode)
+        raise ValueError("Bad mode {0!r}".format(mode))
 
 
 def make_virtual_offset(block_start_offset, within_block_offset):
@@ -299,9 +299,9 @@ def make_virtual_offset(block_start_offset, within_block_offset):
 
     """
     if within_block_offset < 0 or within_block_offset >= 65536:
-        raise ValueError("Require 0 <= within_block_offset < 2**16, got %i" % within_block_offset)
+        raise ValueError("Require 0 <= within_block_offset < 2**16, got {0:d}".format(within_block_offset))
     if block_start_offset < 0 or block_start_offset >= 281474976710656:
-        raise ValueError("Require 0 <= block_start_offset < 2**48, got %i" % block_start_offset)
+        raise ValueError("Require 0 <= block_start_offset < 2**48, got {0:d}".format(block_start_offset))
     return (block_start_offset << 16) | within_block_offset
 
 
@@ -435,7 +435,7 @@ def _load_bgzf_block(handle, text_mode=False):
     expected_crc = handle.read(4)
     expected_size = struct.unpack("<I", handle.read(4))[0]
     assert expected_size == len(data), \
-           "Decompressed to %i, not %i" % (len(data), expected_size)
+           "Decompressed to {0:d}, not {1:d}".format(len(data), expected_size)
     # Should cope with a mix of Python platforms...
     crc = zlib.crc32(data)
     if crc < 0:
@@ -443,7 +443,7 @@ def _load_bgzf_block(handle, text_mode=False):
     else:
         crc = struct.pack("<I", crc)
     assert expected_crc == crc, \
-           "CRC is %s, not %s" % (crc, expected_crc)
+           "CRC is {0!s}, not {1!s}".format(crc, expected_crc)
     if text_mode:
         return block_size, _as_string(data)
     else:
@@ -614,8 +614,7 @@ class BgzfReader(object):
             assert start_offset == self._block_start_offset
         if within_block > len(self._buffer) \
         and not (within_block == 0 and len(self._buffer) == 0):
-            raise ValueError("Within offset %i but block size only %i"
-                             % (within_block, len(self._buffer)))
+            raise ValueError("Within offset {0:d} but block size only {1:d}".format(within_block, len(self._buffer)))
         self._within_block_offset = within_block
         # assert virtual_offset == self.tell(), \
         #    "Did seek to %i (%i, %i), but tell says %i (%i, %i)" \
@@ -724,7 +723,7 @@ class BgzfWriter(object):
         else:
             if "w" not in mode.lower() \
             and "a" not in mode.lower():
-                raise ValueError("Must use write or append mode, not %r" % mode)
+                raise ValueError("Must use write or append mode, not {0!r}".format(mode))
             if "a" in mode.lower():
                 handle = _open(filename, "ab")
             else:

--- a/Bio/codonalign/__init__.py
+++ b/Bio/codonalign/__init__.py
@@ -159,7 +159,7 @@ def build(pro_align, nucl_seqs, corr_dict=None, gap_char='-', unknown='X',
             try:
                 nucl_id = corr_dict[pro_rec.id]
             except KeyError:
-                print("Protein record (%s) is not in corr_dict!" % pro_rec.id)
+                print("Protein record ({0!s}) is not in corr_dict!".format(pro_rec.id))
                 exit(1)
             pro_nucl_pair.append((pro_rec, nucl_seqs[nucl_id]))
 
@@ -582,8 +582,7 @@ def _get_codon_rec(pro, nucl, span_mode, alphabet, gap_char="-",
                                             (span[0] + 3 * (aa_num + 1))]
                 if not str(Seq(this_codon.upper()).translate(table=codon_table)) == aa:
                     max_score -= 1
-                    warnings.warn("%s(%s %d) does not correspond to %s(%s)"
-                                  % (pro.id, aa, aa_num, nucl.id, this_codon))
+                    warnings.warn("{0!s}({1!s} {2:d}) does not correspond to {3!s}({4!s})".format(pro.id, aa, aa_num, nucl.id, this_codon))
                 if max_score == 0:
                     raise RuntimeError("max_score reached for {0}! Please "
                                        "raise up the tolerance to get an "

--- a/Bio/codonalign/codonalignment.py
+++ b/Bio/codonalign/codonalignment.py
@@ -59,8 +59,7 @@ class CodonAlignment(MultipleSeqAlignment):
 
         """
         rows = len(self._records)
-        lines = ["%s CodonAlignment with %i rows and %i columns (%i codons)"
-                 % (str(self._alphabet), rows,
+        lines = ["{0!s} CodonAlignment with {1:d} rows and {2:d} columns ({3:d} codons)".format(str(self._alphabet), rows,
                     self.get_alignment_length(), self.get_aln_length())]
 
         if rows <= 60:

--- a/Bio/codonalign/codonalphabet.py
+++ b/Bio/codonalign/codonalphabet.py
@@ -50,7 +50,7 @@ class CodonAlphabet(Alphabet):
     name = ''
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, self.names[0])
+        return "{0!s}({1!s})".format(self.__class__.__name__, self.names[0])
 
 
 def get_codon_alphabet(codon_table, gap_char="-"):

--- a/Bio/codonalign/codonseq.py
+++ b/Bio/codonalign/codonseq.py
@@ -245,8 +245,7 @@ class CodonSeq(Seq):
             if not gap:
                 gap = self.alphabet.gap_char
             elif gap != self.alphabet.gap_char:
-                raise ValueError("Gap %s does not match %s from alphabet"
-                        % (repr(gap), repr(self.alphabet.alphabet.gap_char)))
+                raise ValueError("Gap {0!s} does not match {1!s} from alphabet".format(repr(gap), repr(self.alphabet.alphabet.gap_char)))
             alpha = _ungap(self.alphabet)
         elif not gap:
             raise ValueError("Gap character not given and not defined in "
@@ -254,7 +253,7 @@ class CodonSeq(Seq):
         else:
             alpha = self.alphabet  # modify!
         if len(gap) != 1 or not isinstance(gap, str):
-            raise ValueError("Unexpected gap character, %s" % repr(gap))
+            raise ValueError("Unexpected gap character, {0!s}".format(repr(gap)))
         return CodonSeq(str(self._data).replace(gap, ""), alpha,
                         rf_table=self.rf_table)
 
@@ -638,7 +637,7 @@ def _diff_codon(codon1, codon2, fold_dict):
                 elif fold_num[n] == '4':
                     P4 += 1
                 else:
-                    raise RuntimeError("Unexpected fold_num %d" % fold_num[n])
+                    raise RuntimeError("Unexpected fold_num {0:d}".format(fold_num[n]))
             if i != j and (i in pyrimidine and j in pyrimidine):
                 if fold_num[n] == '0':
                     P0 += 1
@@ -647,7 +646,7 @@ def _diff_codon(codon1, codon2, fold_dict):
                 elif fold_num[n] == '4':
                     P4 += 1
                 else:
-                    raise RuntimeError("Unexpected fold_num %d" % fold_num[n])
+                    raise RuntimeError("Unexpected fold_num {0:d}".format(fold_num[n]))
             if i != j and ((i in purine and j in pyrimidine)
                     or (i in pyrimidine and j in purine)):
                 if fold_num[n] == '0':
@@ -657,7 +656,7 @@ def _diff_codon(codon1, codon2, fold_dict):
                 elif fold_num[n] == '4':
                     Q4 += 1
                 else:
-                    raise RuntimeError("Unexpected fold_num %d" % fold_num[n])
+                    raise RuntimeError("Unexpected fold_num {0:d}".format(fold_num[n]))
     return (P0, P2, P4, Q0, Q2, Q4)
 
 

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -90,7 +90,7 @@ def parse(handle, format):
         record = jaspar.read(handle, format)
         return record
     else:
-        raise ValueError("Unknown format %s" % format)
+        raise ValueError("Unknown format {0!s}".format(format))
 
 
 def read(handle, format):
@@ -162,7 +162,7 @@ class Instances(list):
             if self.length is None:
                 self.length = len(instance)
             elif self.length != len(instance):
-                message = "All instances should have the same length (%d found, %d expected)" % (len(instance), self.length)
+                message = "All instances should have the same length ({0:d} found, {1:d} expected)".format(len(instance), self.length)
                 raise ValueError(message)
             try:
                 a = instance.alphabet
@@ -270,7 +270,7 @@ class Motif(object):
                 elif char == " ":
                     self.__mask.append(0)
                 else:
-                    raise ValueError("Mask should contain only '*' or ' ' and not a '%s'" % char)
+                    raise ValueError("Mask should contain only '*' or ' ' and not a '{0!s}'".format(char))
             self.__mask = tuple(self.__mask)
         else:
             self.__mask = tuple(int(bool(c)) for c in mask)
@@ -507,7 +507,7 @@ class Motif(object):
             motifs = [self]
             return transfac.write(motifs)
         else:
-            raise ValueError("Unknown format type %s" % format)
+            raise ValueError("Unknown format type {0!s}".format(format))
 
 
 def write(motifs, format):
@@ -527,7 +527,7 @@ def write(motifs, format):
         from Bio.motifs import transfac
         return transfac.write(motifs)
     else:
-        raise ValueError("Unknown format type %s" % format)
+        raise ValueError("Unknown format type {0!s}".format(format))
 
 
 if __name__ == "__main__":

--- a/Bio/motifs/jaspar/__init__.py
+++ b/Bio/motifs/jaspar/__init__.py
@@ -151,7 +151,7 @@ def read(handle, format):
         record = _read_jaspar(handle)
         return record
     else:
-        raise ValueError("Unknown JASPAR format %s" % format)
+        raise ValueError("Unknown JASPAR format {0!s}".format(format))
 
 
 def write(motifs, format):
@@ -179,7 +179,7 @@ def write(motifs, format):
                 line = "{0} [{1}]\n".format(letter, " ".join(terms))
                 lines.append(line)
     else:
-        raise ValueError("Unknown JASPAR format %s" % format)
+        raise ValueError("Unknown JASPAR format {0!s}".format(format))
 
     # Finished; glue the lines together
     text = "".join(lines)

--- a/Bio/motifs/jaspar/db.py
+++ b/Bio/motifs/jaspar/db.py
@@ -117,7 +117,7 @@ class JASPAR5(object):
 
         """
 
-        text = "%s\@%s:%s" % (self.user, self.host, self.name)
+        text = "{0!s}\@{1!s}:{2!s}".format(self.user, self.host, self.name)
 
         return text
 
@@ -563,7 +563,7 @@ class JASPAR5(object):
                 clause = "".join([clause, "')"])
             else:
                 # A single collection - typical usage
-                clause = "m.COLLECTION = '%s'" % collection
+                clause = "m.COLLECTION = '{0!s}'".format(collection)
 
             where_clauses.append(clause)
 
@@ -576,7 +576,7 @@ class JASPAR5(object):
                 clause = "".join([clause, "')"])
             else:
                 # A single name
-                clause = "m.NAME = '%s'" % tf_name
+                clause = "m.NAME = '{0!s}'".format(tf_name)
 
             where_clauses.append(clause)
 
@@ -596,7 +596,7 @@ class JASPAR5(object):
                 clause = "".join([clause, "')"])
             else:
                 # A single tax ID
-                clause = "ms.TAX_ID = '%s'" % str(species)
+                clause = "ms.TAX_ID = '{0!s}'".format(str(species))
 
             where_clauses.append(clause)
 
@@ -635,7 +635,7 @@ class JASPAR5(object):
                 clause = "".join([clause, "')"])
             else:
                 # A single TF class
-                clause = "".join([clause, " and ma1.VAL = '%s' " % tf_class])
+                clause = "".join([clause, " and ma1.VAL = '{0!s}' ".format(tf_class)])
 
             where_clauses.append(clause)
 
@@ -652,7 +652,7 @@ class JASPAR5(object):
                 clause = "".join([clause, "')"])
             else:
                 # A single TF family
-                clause = "".join([clause, " and ma2.VAL = '%s' " % tf_family])
+                clause = "".join([clause, " and ma2.VAL = '{0!s}' ".format(tf_family)])
 
             where_clauses.append(clause)
 
@@ -669,7 +669,7 @@ class JASPAR5(object):
                 clause = "".join([clause, "')"])
             else:
                 # A single PAZAR ID
-                clause = "".join([" and ma3.VAL = '%s' " % pazar_id])
+                clause = "".join([" and ma3.VAL = '{0!s}' ".format(pazar_id)])
 
             where_clauses.append(clause)
 
@@ -686,7 +686,7 @@ class JASPAR5(object):
                 clause = "".join([clause, "')"])
             else:
                 # A single PubMed ID
-                clause = "".join([" and ma4.VAL = '%s' " % medline])
+                clause = "".join([" and ma4.VAL = '{0!s}' ".format(medline)])
 
             where_clauses.append(clause)
 
@@ -704,7 +704,7 @@ class JASPAR5(object):
                 clause = "".join([clause, "')"])
             else:
                 # A single data type
-                clause = "".join([" and ma5.VAL = '%s' " % data_type])
+                clause = "".join([" and ma5.VAL = '{0!s}' ".format(data_type)])
 
             where_clauses.append(clause)
 
@@ -721,7 +721,7 @@ class JASPAR5(object):
                 clause = "".join([clause, "')"])
             else:
                 # A single tax ID
-                clause = "".join([clause, " and ma6.VAL = '%s' " % tax_group])
+                clause = "".join([clause, " and ma6.VAL = '{0!s}' ".format(tax_group)])
 
             where_clauses.append(clause)
 

--- a/Bio/motifs/mast.py
+++ b/Bio/motifs/mast.py
@@ -76,10 +76,10 @@ def __read_database_and_motifs(record, handle):
             break
     line = next(handle)
     if not line.startswith('****'):
-        raise ValueError("Line does not start with '****':\n%s" % line)
+        raise ValueError("Line does not start with '****':\n{0!s}".format(line))
     line = next(handle)
     if 'DATABASE' not in line:
-        raise ValueError("Line does not contain 'DATABASE':\n%s" % line)
+        raise ValueError("Line does not contain 'DATABASE':\n{0!s}".format(line))
     words = line.strip().split()
     record.database = words[1]
     if words[2] == '(nucleotide)':
@@ -91,7 +91,7 @@ def __read_database_and_motifs(record, handle):
             break
     line = next(handle)
     if '----' not in line:
-        raise ValueError("Line does not contain '----':\n%s" % line)
+        raise ValueError("Line does not contain '----':\n{0!s}".format(line))
     for line in handle:
         if not line.strip():
             break
@@ -112,7 +112,7 @@ def __read_section_i(record, handle):
             break
     line = next(handle)
     if not line.startswith('---'):
-        raise ValueError("Line does not start with '---':\n%s" % line)
+        raise ValueError("Line does not start with '---':\n{0!s}".format(line))
     for line in handle:
         if not line.strip():
             break
@@ -121,7 +121,7 @@ def __read_section_i(record, handle):
             record.sequences.append(sequence)
     line = next(handle)
     if not line.startswith('****'):
-        raise ValueError("Line does not start with '****':\n%s" % line)
+        raise ValueError("Line does not start with '****':\n{0!s}".format(line))
 
 
 def __read_section_ii(record, handle):
@@ -133,7 +133,7 @@ def __read_section_ii(record, handle):
             break
     line = next(handle)
     if not line.startswith('---'):
-        raise ValueError("Line does not start with '---':\n%s" % line)
+        raise ValueError("Line does not start with '---':\n{0!s}".format(line))
     for line in handle:
         if not line.strip():
             break
@@ -145,7 +145,7 @@ def __read_section_ii(record, handle):
             record.diagrams[sequence] = diagram
     line = next(handle)
     if not line.startswith('****'):
-        raise ValueError("Line does not start with '****':\n%s" % line)
+        raise ValueError("Line does not start with '****':\n{0!s}".format(line))
 
 
 def __read_section_iii(record, handle):

--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -29,11 +29,11 @@ class GenericPositionMatrix(dict):
         self._letters = sorted(self.alphabet.letters)
 
     def __str__(self):
-        words = ["%6d" % i for i in range(self.length)]
+        words = ["{0:6d}".format(i) for i in range(self.length)]
         line = "   " + " ".join(words)
         lines = [line]
         for letter in self._letters:
-            words = ["%6.2f" % value for value in self[letter]]
+            words = ["{0:6.2f}".format(value) for value in self[letter]]
             line = "%c: " % letter + " ".join(words)
             lines.append(line)
         text = "\n".join(lines) + "\n"
@@ -354,11 +354,9 @@ class PositionSpecificScoringMatrix(GenericPositionMatrix):
         """
         # TODO - Code itself tolerates ambiguous bases (as NaN).
         if not isinstance(self.alphabet, IUPAC.IUPACUnambiguousDNA):
-            raise ValueError("PSSM has wrong alphabet: %s - Use only with DNA motifs"
-                                 % self.alphabet)
+            raise ValueError("PSSM has wrong alphabet: {0!s} - Use only with DNA motifs".format(self.alphabet))
         if not isinstance(sequence.alphabet, IUPAC.IUPACUnambiguousDNA):
-            raise ValueError("Sequence has wrong alphabet: %r - Use only with DNA sequences"
-                                 % sequence.alphabet)
+            raise ValueError("Sequence has wrong alphabet: {0!r} - Use only with DNA sequences".format(sequence.alphabet))
 
         # TODO - Force uppercase here and optimise switch statement in C
         # by assuming upper case?

--- a/Bio/motifs/meme.py
+++ b/Bio/motifs/meme.py
@@ -56,7 +56,7 @@ def read(handle):
         if line.startswith("SUMMARY OF MOTIFS"):
             break
         if not line.startswith('MOTIF'):
-            raise ValueError("Line does not start with 'MOTIF':\n%s" % line)
+            raise ValueError("Line does not start with 'MOTIF':\n{0!s}".format(line))
     return record
 
 
@@ -150,13 +150,13 @@ def __read_datafile(record, handle):
     except StopIteration:
         raise ValueError("Unexpected end of stream: Expected to find line starting with '****'")
     if not line.startswith('****'):
-        raise ValueError("Line does not start with '****':\n%s" % line)
+        raise ValueError("Line does not start with '****':\n{0!s}".format(line))
     try:
         line = next(handle)
     except StopIteration:
         raise ValueError("Unexpected end of stream: Expected to find line starting with 'DATAFILE'")
     if not line.startswith('DATAFILE'):
-        raise ValueError("Line does not start with 'DATAFILE':\n%s" % line)
+        raise ValueError("Line does not start with 'DATAFILE':\n{0!s}".format(line))
     line = line.strip()
     line = line.replace('DATAFILE= ', '')
     record.datafile = line
@@ -168,7 +168,7 @@ def __read_alphabet(record, handle):
     except StopIteration:
         raise ValueError("Unexpected end of stream: Expected to find line starting with 'ALPHABET'")
     if not line.startswith('ALPHABET'):
-        raise ValueError("Line does not start with 'ALPHABET':\n%s" % line)
+        raise ValueError("Line does not start with 'ALPHABET':\n{0!s}".format(line))
     line = line.strip()
     line = line.replace('ALPHABET= ', '')
     if line == 'ACGT':
@@ -184,13 +184,13 @@ def __read_sequences(record, handle):
     except StopIteration:
         raise ValueError("Unexpected end of stream: Expected to find line starting with 'Sequence name'")
     if not line.startswith('Sequence name'):
-        raise ValueError("Line does not start with 'Sequence name':\n%s" % line)
+        raise ValueError("Line does not start with 'Sequence name':\n{0!s}".format(line))
     try:
         line = next(handle)
     except StopIteration:
         raise ValueError("Unexpected end of stream: Expected to find line starting with '----'")
     if not line.startswith('----'):
-        raise ValueError("Line does not start with '----':\n%s" % line)
+        raise ValueError("Line does not start with '----':\n{0!s}".format(line))
     for line in handle:
         if line.startswith('***'):
             break
@@ -256,19 +256,19 @@ def __read_motif_sequences(handle, motif_name, alphabet, length, revcomp):
     except StopIteration:
         raise ValueError('Unexpected end of stream: Failed to find motif sequences')
     if not line.startswith('---'):
-        raise ValueError("Line does not start with '---':\n%s" % line)
+        raise ValueError("Line does not start with '---':\n{0!s}".format(line))
     try:
         line = next(handle)
     except StopIteration:
         raise ValueError("Unexpected end of stream: Expected to find line starting with 'Sequence name'")
     if not line.startswith('Sequence name'):
-        raise ValueError("Line does not start with 'Sequence name':\n%s" % line)
+        raise ValueError("Line does not start with 'Sequence name':\n{0!s}".format(line))
     try:
         line = next(handle)
     except StopIteration:
         raise ValueError('Unexpected end of stream: Failed to find motif sequences')
     if not line.startswith('---'):
-        raise ValueError("Line does not start with '---':\n%s" % line)
+        raise ValueError("Line does not start with '---':\n{0!s}".format(line))
     instances = []
     for line in handle:
         if line.startswith('---'):
@@ -325,17 +325,17 @@ def __skip_unused_lines(handle):
     except StopIteration:
         raise ValueError('Unexpected end of stream: Expected to find blank line')
     if line.strip():
-        raise ValueError("Expected blank line, but got:\n%s" % line)
+        raise ValueError("Expected blank line, but got:\n{0!s}".format(line))
     try:
         line = next(handle)
     except StopIteration:
         raise ValueError("Unexpected end of stream: Expected to find line starting with '***'")
     if not line.startswith('***'):
-        raise ValueError("Line does not start with '***':\n%s" % line)
+        raise ValueError("Line does not start with '***':\n{0!s}".format(line))
     for line in handle:
         if line.strip():
             break
     else:
         raise ValueError("Unexpected end of stream: Expected to find line starting with '***'")
     if not line.startswith('***'):
-        raise ValueError("Line does not start with '***':\n%s" % line)
+        raise ValueError("Line does not start with '***':\n{0!s}".format(line))

--- a/Bio/motifs/transfac.py
+++ b/Bio/motifs/transfac.py
@@ -152,10 +152,10 @@ def write(motifs):
     else:
         if version is not None:
             block = """\
-VV  %s
+VV  {0!s}
 XX
 //
-""" % version
+""".format(version)
             blocks.append(block)
     multiple_value_keys = Motif.multiple_value_keys
     sections = (('AC', 'AS',),  # Accession
@@ -188,13 +188,13 @@ XX
                     line = "P0      A      C      G      T"
                     lines.append(line)
                     for i in range(length):
-                        line = "%02.d %6.20g %6.20g %6.20g %6.20g      %s" % (
+                        line = "{0:02d} {1:6.20g} {2:6.20g} {3:6.20g} {4:6.20g}      {5!s}".format(
                                              i + 1,
                                              motif.counts['A'][i],
                                              motif.counts['C'][i],
                                              motif.counts['G'][i],
                                              motif.counts['T'][i],
-                                             sequence[i],
+                                             sequence[i]
                                             )
                         lines.append(line)
                     blank = True
@@ -206,10 +206,10 @@ XX
                     if value is not None:
                         if key in multiple_value_keys:
                             for v in value:
-                                line = "%s  %s" % (key, v)
+                                line = "{0!s}  {1!s}".format(key, v)
                                 lines.append(line)
                         else:
-                            line = "%s  %s" % (key, value)
+                            line = "{0!s}  {1!s}".format(key, value)
                             lines.append(line)
                         blank = True
                 if key == 'PV':
@@ -225,7 +225,7 @@ XX
                                 value = reference.get(key)
                                 if value is None:
                                     continue
-                                line = "%s  %s" % (key, value)
+                                line = "{0!s}  {1!s}".format(key, value)
                                 lines.append(line)
                                 blank = True
             if blank:

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -214,11 +214,11 @@ should return a gap penalty."""),
             try:
                 match_args, match_doc = self.match2args[match_type]
             except KeyError as x:
-                raise AttributeError("unknown match type %r" % match_type)
+                raise AttributeError("unknown match type {0!r}".format(match_type))
             try:
                 penalty_args, penalty_doc = self.penalty2args[penalty_type]
             except KeyError as x:
-                raise AttributeError("unknown penalty type %r" % penalty_type)
+                raise AttributeError("unknown penalty type {0!r}".format(penalty_type))
 
             # Now get the names of the parameters to this function.
             param_names = ['sequenceA', 'sequenceB']
@@ -230,12 +230,12 @@ should return a gap penalty."""),
 
             self.__name__ = self.function_name
             # Set the doc string.
-            doc = "%s(%s) -> alignments\n" % (
+            doc = "{0!s}({1!s}) -> alignments\n".format(
                 self.__name__, ', '.join(self.param_names))
             if match_doc:
-                doc += "\n%s\n" % match_doc
+                doc += "\n{0!s}\n".format(match_doc)
             if penalty_doc:
-                doc += "\n%s\n" % penalty_doc
+                doc += "\n{0!s}\n".format(penalty_doc)
             doc += (
 """\nalignments is a list of tuples (seqA, seqB, score, begin, end).
 seqA and seqB are strings showing the alignment between the
@@ -251,8 +251,7 @@ alignment occurs.
             # this function into forms appropriate for _align.
             keywds = keywds.copy()
             if len(args) != len(self.param_names):
-                raise TypeError("%s takes exactly %d argument (%d given)"
-                    % (self.function_name, len(self.param_names), len(args)))
+                raise TypeError("{0!s} takes exactly {1:d} argument ({2:d} given)".format(self.function_name, len(self.param_names), len(args)))
             i = 0
             while i < len(self.param_names):
                 if self.param_names[i] in [
@@ -283,8 +282,7 @@ alignment occurs.
                     keywds['gap_B_fn'] = affine_penalty(openB, extendB, pe)
                     i += 4
                 else:
-                    raise ValueError("unknown parameter %r"
-                                     % self.param_names[i])
+                    raise ValueError("unknown parameter {0!r}".format(self.param_names[i]))
 
             # Here are the default parameters for _align.  Assign
             # these to keywds, unless already specified.
@@ -869,10 +867,10 @@ def format_alignment(align1, align2, score, begin, end):
 
     """
     s = []
-    s.append("%s\n" % align1)
-    s.append("%s%s\n" % (" " * begin, "|" * (end - begin)))
-    s.append("%s\n" % align2)
-    s.append("  Score=%g\n" % score)
+    s.append("{0!s}\n".format(align1))
+    s.append("{0!s}{1!s}\n".format(" " * begin, "|" * (end - begin)))
+    s.append("{0!s}\n".format(align2))
+    s.append("  Score={0:g}\n".format(score))
     return ''.join(s)
 
 

--- a/Bio/triefind.py
+++ b/Bio/triefind.py
@@ -80,7 +80,7 @@ def find_words(string, trie):
     Word boundaries are defined as any punctuation or whitespace.
 
     """
-    _boundary_re = re.compile(r"[%s]+" % re.escape(DEFAULT_BOUNDARY_CHARS))
+    _boundary_re = re.compile(r"[{0!s}]+".format(re.escape(DEFAULT_BOUNDARY_CHARS)))
 
     results = []
     start = 0     # index of word boundary

--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -184,7 +184,7 @@ def _retrieve_seq(adaptor, primary_id):
         # for any generic or nucleotide alphabets.
         alphabet = Alphabet.single_letter_alphabet
     else:
-        raise AssertionError("Unknown moltype: %s" % moltype)
+        raise AssertionError("Unknown moltype: {0!s}".format(moltype))
 
     if have_seq:
         return DBSeq(primary_id, adaptor, alphabet, 0, int(length))
@@ -202,10 +202,10 @@ def _retrieve_dbxrefs(adaptor, primary_id):
         " ORDER BY rank", (primary_id,))
     for dbname, accession, version in dbxrefs:
         if version and version != "0":
-            v = "%s.%s" % (accession, version)
+            v = "{0!s}.{1!s}".format(accession, version)
         else:
             v = accession
-        _dbxrefs.append("%s:%s" % (dbname, v))
+        _dbxrefs.append("{0!s}:{1!s}".format(dbname, v))
     return _dbxrefs
 
 
@@ -233,7 +233,7 @@ def _retrieve_features(adaptor, primary_id):
             " WHERE seqfeature_dbxref.seqfeature_id = %s"
             " ORDER BY rank", (seqfeature_id,))
         for qv_name, qv_value in qvs:
-            value = "%s:%s" % (qv_name, qv_value)
+            value = "{0!s}:{1!s}".format(qv_name, qv_value)
             qualifiers.setdefault("db_xref", []).append(value)
         # Get locations
         results = adaptor.execute_and_fetchall(
@@ -271,7 +271,7 @@ def _retrieve_features(adaptor, primary_id):
         lookup = {}
         for location_id, dbname, accession, version in remote_results:
             if version and version != "0":
-                v = "%s.%s" % (accession, version)
+                v = "{0!s}.{1!s}".format(accession, version)
             else:
                 v = accession
             # subfeature remote location db_ref are stored as a empty string when
@@ -504,7 +504,7 @@ class DBSeqRecord(SeqRecord):
             " FROM bioentry"
             " WHERE bioentry_id = %s", (self._primary_id,))
         if version and version != "0":
-            self.id = "%s.%s" % (accession, version)
+            self.id = "{0!s}.{1!s}".format(accession, version)
         else:
             self.id = accession
         # We don't yet record any per-letter-annotations in the

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -148,7 +148,7 @@ class DBServer(object):
         self.module_name = module_name
 
     def __repr__(self):
-        return self.__class__.__name__ + "(%r)" % self.adaptor.conn
+        return self.__class__.__name__ + "({0!r})".format(self.adaptor.conn)
 
     def __getitem__(self, name):
         return BioSeqDatabase(self.adaptor, name)
@@ -281,8 +281,8 @@ class DBServer(object):
             for sql_line in sql_parts[:-1]:
                 self.adaptor.cursor.execute(sql_line)
         else:
-            raise ValueError("Module %s not supported by the loader." %
-                             (self.module_name))
+            raise ValueError("Module {0!s} not supported by the loader.".format(
+                             (self.module_name)))
 
     def commit(self):
         """Commits the current transaction to the database."""
@@ -370,7 +370,7 @@ class Adaptor(object):
             (dbname,))
         rv = self.cursor.fetchall()
         if not rv:
-            raise KeyError("Cannot find biodatabase with name %r" % dbname)
+            raise KeyError("Cannot find biodatabase with name {0!r}".format(dbname))
         return rv[0][0]
 
     def fetch_seqid_by_display_id(self, dbid, name):
@@ -382,9 +382,9 @@ class Adaptor(object):
         self.execute(sql, fields)
         rv = self.cursor.fetchall()
         if not rv:
-            raise IndexError("Cannot find display id %r" % name)
+            raise IndexError("Cannot find display id {0!r}".format(name))
         if len(rv) > 1:
-            raise IndexError("More than one entry with display id %r" % name)
+            raise IndexError("More than one entry with display id {0!r}".format(name))
         return rv[0][0]
 
     def fetch_seqid_by_accession(self, dbid, name):
@@ -396,9 +396,9 @@ class Adaptor(object):
         self.execute(sql, fields)
         rv = self.cursor.fetchall()
         if not rv:
-            raise IndexError("Cannot find accession %r" % name)
+            raise IndexError("Cannot find accession {0!r}".format(name))
         if len(rv) > 1:
-            raise IndexError("More than one entry with accession %r" % name)
+            raise IndexError("More than one entry with accession {0!r}".format(name))
         return rv[0][0]
 
     def fetch_seqids_by_accession(self, dbid, name):
@@ -412,7 +412,7 @@ class Adaptor(object):
     def fetch_seqid_by_version(self, dbid, name):
         acc_version = name.split(".")
         if len(acc_version) > 2:
-            raise IndexError("Bad version %r" % name)
+            raise IndexError("Bad version {0!r}".format(name))
         acc = acc_version[0]
         if len(acc_version) == 2:
             version = acc_version[1]
@@ -427,9 +427,9 @@ class Adaptor(object):
         self.execute(sql, fields)
         rv = self.cursor.fetchall()
         if not rv:
-            raise IndexError("Cannot find version %r" % name)
+            raise IndexError("Cannot find version {0!r}".format(name))
         if len(rv) > 1:
-            raise IndexError("More than one entry with version %r" % name)
+            raise IndexError("More than one entry with version {0!r}".format(name))
         return rv[0][0]
 
     def fetch_seqid_by_identifier(self, dbid, identifier):
@@ -442,7 +442,7 @@ class Adaptor(object):
         self.execute(sql, fields)
         rv = self.cursor.fetchall()
         if not rv:
-            raise IndexError("Cannot find display id %r" % identifier)
+            raise IndexError("Cannot find display id {0!r}".format(identifier))
         return rv[0][0]
 
     def list_biodatabase_names(self):
@@ -472,7 +472,7 @@ class Adaptor(object):
         """Execute sql that returns 1 record, and return the record"""
         self.execute(sql, args or ())
         rv = self.cursor.fetchall()
-        assert len(rv) == 1, "Expected 1 response, got %d" % len(rv)
+        assert len(rv) == 1, "Expected 1 response, got {0:d}".format(len(rv))
         return rv[0]
 
     def execute(self, sql, args=None):
@@ -559,7 +559,7 @@ class BioSeqDatabase(object):
         self.dbid = self.adaptor.fetch_dbid_by_dbname(name)
 
     def __repr__(self):
-        return "BioSeqDatabase(%r, %r)" % (self.adaptor, self.name)
+        return "BioSeqDatabase({0!r}, {1!r})".format(self.adaptor, self.name)
 
     def get_Seq_by_id(self, name):
         """Gets a DBSeqRecord object by its name
@@ -705,8 +705,7 @@ class BioSeqDatabase(object):
             raise TypeError("single key/value parameter expected")
         k, v = list(kwargs.items())[0]
         if k not in _allowed_lookups:
-            raise TypeError("lookup() expects one of %r, not %r" %
-                            (list(_allowed_lookups.keys()), k))
+            raise TypeError("lookup() expects one of {0!r}, not {1!r}".format(list(_allowed_lookups.keys()), k))
         lookup_name = _allowed_lookups[k]
         lookup_func = getattr(self.adaptor, lookup_name)
         seqid = lookup_func(self.dbid, v)

--- a/BioSQL/DBUtils.py
+++ b/BioSQL/DBUtils.py
@@ -28,7 +28,7 @@ class Generic_dbutils(object):
     def last_id(self, cursor, table):
         # XXX: Unsafe without transactions isolation
         table = self.tname(table)
-        sql = r"select max(%s_id) from %s" % (table, table)
+        sql = r"select max({0!s}_id) from {1!s}".format(table, table)
         cursor.execute(sql)
         rv = cursor.fetchone()
         return rv[0]
@@ -77,14 +77,14 @@ class _PostgreSQL_dbutils(Generic_dbutils):
 
     def next_id(self, cursor, table):
         table = self.tname(table)
-        sql = r"select nextval('%s_pk_seq')" % table
+        sql = r"select nextval('{0!s}_pk_seq')".format(table)
         cursor.execute(sql)
         rv = cursor.fetchone()
         return rv[0]
 
     def last_id(self, cursor, table):
         table = self.tname(table)
-        sql = r"select currval('%s_pk_seq')" % table
+        sql = r"select currval('{0!s}_pk_seq')".format(table)
         cursor.execute(sql)
         rv = cursor.fetchone()
         return rv[0]

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -113,8 +113,7 @@ class DatabaseLoader(object):
         id_results = self.adaptor.execute_and_fetchall(sql, fields)
         # something is wrong
         if len(id_results) > 1:
-            raise ValueError("Multiple term ids for %s: %r" %
-                             (name, id_results))
+            raise ValueError("Multiple term ids for {0!s}: {1!r}".format(name, id_results))
         elif len(id_results) == 1:
             return id_results[0][0]
         else:
@@ -222,7 +221,7 @@ class DatabaseLoader(object):
             # Its natural that several distinct taxa will have the same common
             # name - in which case we can't resolve the taxon uniquely.
             if len(taxa) > 1:
-                raise ValueError("Taxa: %d species have name %r" % (
+                raise ValueError("Taxa: {0:d} species have name {1!r}".format(
                     len(taxa),
                     common_name))
             if taxa:
@@ -385,7 +384,7 @@ class DatabaseLoader(object):
             taxonomic_record = Entrez.read(handle)
             if len(taxonomic_record) == 1:
                 assert taxonomic_record[0]["TaxId"] == str(ncbi_taxon_id), \
-                    "%s versus %s" % (taxonomic_record[0]["TaxId"],
+                    "{0!s} versus {1!s}".format(taxonomic_record[0]["TaxId"],
                                       ncbi_taxon_id)
                 parent_taxon_id = self._get_taxon_id_from_ncbi_lineage(
                     taxonomic_record[0]["LineageEx"])
@@ -818,8 +817,7 @@ class DatabaseLoader(object):
             # will become a "join" on reloading. What does BioPerl do?
             import warnings
             from Bio import BiopythonWarning
-            warnings.warn("%s location operators are not fully supported"
-                          % feature.location_operator, BiopythonWarning)
+            warnings.warn("{0!s} location operators are not fully supported".format(feature.location_operator), BiopythonWarning)
         # This will be a list of length one for simple FeatureLocation:
         parts = feature.location.parts
         if parts and set(loc.strand for loc in parts) == set([-1]):
@@ -952,7 +950,7 @@ class DatabaseLoader(object):
                 db = dbxref_data[0]
                 accessions = dbxref_data[1:]
             except:
-                raise ValueError("Parsing of db_xref failed: '%s'" % value)
+                raise ValueError("Parsing of db_xref failed: '{0!s}'".format(value))
             # Loop over all the grabbed accessions, and attempt to fill the
             # table
             for accession in accessions:
@@ -1029,7 +1027,7 @@ class DatabaseLoader(object):
                 accession = accession.strip()
             except:
                 raise ValueError(
-                    "Parsing of dbxrefs list failed: '%s'" % value)
+                    "Parsing of dbxrefs list failed: '{0!s}'".format(value))
             # Get the dbxref_id value for the dbxref data
             dbxref_id = self._get_dbxref_id(db, accession)
             # Insert the bioentry_dbxref  data

--- a/Doc/examples/ACT_example.py
+++ b/Doc/examples/ACT_example.py
@@ -29,7 +29,7 @@ file_a_vs_b = "af063097_v_b132222.crunch"
 
 for f in [file_a, file_b, file_a_vs_b]:
     if not os.path.isfile(os.path.join(input_folder, f)):
-        print("Missing input file %s.fna" % f)
+        print("Missing input file {0!s}.fna".format(f))
         sys.exit(1)
 
 # Only doing a_vs_b here, could also have b_vs_c and c_vs_d etc

--- a/Doc/examples/Proux_et_al_2002_Figure_6.py
+++ b/Doc/examples/Proux_et_al_2002_Figure_6.py
@@ -160,7 +160,7 @@ for record, gene_colors in zip([A_rec, B_rec, C_rec], [A_colors, B_colors, C_col
         try:
             g_color = gene_colors[i]
         except IndexError:
-            print("Don't have color for %s gene %i" % (record.name, i))
+            print("Don't have color for {0!s} gene {1:d}".format(record.name, i))
             g_color = grey
         gd_feature_set.add_feature(feature, sigil="BIGARROW",
                                    color=g_color, label=True,

--- a/Doc/examples/clustal_run.py
+++ b/Doc/examples/clustal_run.py
@@ -33,11 +33,11 @@ alignment = AlignIO.read("test.aln", "clustal",
 
 print(alignment)
 
-print('first description: %s' % alignment[0].description)
-print('first sequence: %s' % alignment[0].seq)
+print('first description: {0!s}'.format(alignment[0].description))
+print('first sequence: {0!s}'.format(alignment[0].seq))
 
 # get the length of the alignment
-print('length %i' % alignment.get_alignment_length())
+print('length {0:d}'.format(alignment.get_alignment_length()))
 
 print(alignment)
 
@@ -45,7 +45,7 @@ print(alignment)
 summary_align = AlignInfo.SummaryInfo(alignment)
 
 consensus = summary_align.dumb_consensus()
-print('consensus %s' % consensus)
+print('consensus {0!s}'.format(consensus))
 
 my_pssm = summary_align.pos_specific_score_matrix(consensus,
                                                   chars_to_ignore=['N'])
@@ -65,4 +65,4 @@ info_content = summary_align.information_content(5, 30,
                                                  chars_to_ignore=['N'],
                                                  e_freq_table=freq_table_info)
 
-print("relative info content: %f" % info_content)
+print("relative info content: {0:f}".format(info_content))

--- a/Doc/examples/fasta_dictionary.py
+++ b/Doc/examples/fasta_dictionary.py
@@ -38,9 +38,9 @@ rec_iterator = SeqIO.parse("ls_orchid.fasta", "fasta", generic_dna)
 orchid_dict = SeqIO.to_dict(rec_iterator, get_accession_num)
 
 for id_num in orchid_dict:
-    print('id number: %s' % id_num)
-    print('description: %s' % orchid_dict[id_num].description)
-    print('sequence: %s' % orchid_dict[id_num].seq)
+    print('id number: {0!s}'.format(id_num))
+    print('description: {0!s}'.format(orchid_dict[id_num].description))
+    print('sequence: {0!s}'.format(orchid_dict[id_num].seq))
 
 
 # Indexed
@@ -53,6 +53,6 @@ for id_num in orchid_dict:
 orchid_dict = SeqIO.index("ls_orchid.fasta", "fasta", generic_dna)
 
 for id_num in orchid_dict:
-    print('id number: %s' % id_num)
-    print('description: %s' % orchid_dict[id_num].description)
-    print('sequence: %s' % orchid_dict[id_num].seq)
+    print('id number: {0!s}'.format(id_num))
+    print('description: {0!s}'.format(orchid_dict[id_num].description))
+    print('sequence: {0!s}'.format(orchid_dict[id_num].seq))

--- a/Doc/examples/fasta_iterator.py
+++ b/Doc/examples/fasta_iterator.py
@@ -25,5 +25,5 @@ def extract_organisms(file_to_parse, format):
 if __name__ == "__main__":
     print("Using Bio.SeqIO on a FASTA file")
     all_species = extract_organisms("ls_orchid.fasta", "fasta")
-    print("number of species: %i" % len(all_species))
-    print("species names: %s" % all_species)
+    print("number of species: {0:d}".format(len(all_species)))
+    print("species names: {0!s}".format(all_species))

--- a/Doc/examples/getgene.py
+++ b/Doc/examples/getgene.py
@@ -70,13 +70,13 @@ class DB_Index(object):
                 elif line[:2] == '//':
                     stop = fid.tell()
                     try:
-                        value = '%d %d' % (start, stop)
+                        value = '{0:d} {1:d}'.format(start, stop)
                         db[id] = value
                         db[acc] = value
                         id, acc, start, stop = None, None, None, None
                     except:
-                        print("AARRGGGG %d %d %s %s" % (start, stop, type(start), type(stop)))
-                        print("%s %s" % (id, acc))
+                        print("AARRGGGG {0:d} {1:d} {2!s} {3!s}".format(start, stop, type(start), type(stop)))
+                        print("{0!s} {1!s}".format(id, acc))
 
             db.close()
 
@@ -150,7 +150,7 @@ class DB_Index(object):
         elif kd == "Viridae" or kd == "Viruses":
             return "V"
         else:
-            print("%s UNKNOWN" % kd)
+            print("{0!s} UNKNOWN".format(kd))
             return "U"
 
     def Get_Gene(self, id):
@@ -228,7 +228,7 @@ class DB_Index(object):
 
         SQ = re.sub('[ \n]', '', SQ)
         if fasta:
-            SQ = '>%s\n%s' % (id, re.sub('(.{60})', '\\1\n', SQ))
+            SQ = '>{0!s}\n{1!s}'.format(id, re.sub('(.{60})', '\\1\n', SQ))
         return SQ
 
     def Get_XX(self, id, xx):
@@ -237,7 +237,7 @@ class DB_Index(object):
             return ""
         XX = ""
         for line in string.split(entry, '\n'):
-            if line[0:5] == '%s   ' % xx:
+            if line[0:5] == '{0!s}   '.format(xx):
                 XX = XX + string.strip(line[5:])
                 if XX[-1] == ".":
                     XX = XX[0:-1]
@@ -266,8 +266,8 @@ class DB_Index(object):
 
 def help(exit=0):
     name = os.path.basename(sys.argv[0])
-    print('Usage: %s <db> <gene ID>' % name)
-    print('  or   %s --index <db.dat>' % name)
+    print('Usage: {0!s} <db> <gene ID>'.format(name))
+    print('  or   {0!s} --index <db.dat>'.format(name))
     if exit:
         sys.exit(0)
 

--- a/Doc/examples/make_subsmat.py
+++ b/Doc/examples/make_subsmat.py
@@ -27,6 +27,6 @@ print(replace_info)
 
 my_lom = SubsMat.make_log_odds_matrix(my_arm)
 
-print('log_odds_mat: %s' % my_lom)
+print('log_odds_mat: {0!s}'.format(my_lom))
 
 my_lom.print_mat()

--- a/Doc/examples/swissprot.py
+++ b/Doc/examples/swissprot.py
@@ -17,10 +17,10 @@ ids = ['O23729', 'O23730', 'O23731']
 for id in ids:
     handle = ExPASy.get_sprot_raw(id)
     record = SwissProt.read(handle)
-    print("description: %s" % record.description)
+    print("description: {0!s}".format(record.description))
     for ref in record.references:
-        print("authors: %s" % ref.authors)
-        print("title: %s" % ref.title)
+        print("authors: {0!s}".format(ref.authors))
+        print("title: {0!s}".format(ref.title))
 
-    print("classification: %s" % record.organism_classification)
+    print("classification: {0!s}".format(record.organism_classification))
     print("")

--- a/Doc/examples/www_blast.py
+++ b/Doc/examples/www_blast.py
@@ -42,9 +42,9 @@ for alignment in b_record.alignments:
     for hsp in alignment.hsps:
         if hsp.expect < E_VALUE_THRESH:
             print('****Alignment****')
-            print('sequence: %s' % alignment.title)
-            print('length: %i' % alignment.length)
-            print('e value: %f' % hsp.expect)
+            print('sequence: {0!s}'.format(alignment.title))
+            print('length: {0:d}'.format(alignment.length))
+            print('e value: {0:f}'.format(hsp.expect))
             print(hsp.query[0:75] + '...')
             print(hsp.match[0:75] + '...')
             print(hsp.sbjct[0:75] + '...')

--- a/Scripts/GenBank/check_output.py
+++ b/Scripts/GenBank/check_output.py
@@ -42,21 +42,19 @@ def do_comparison(good_record, test_record):
 
         if not(good_line):
             if good_line.strip():
-                raise AssertionError("Extra info in Test: `%s`" % test_line)
+                raise AssertionError("Extra info in Test: `{0!s}`".format(test_line))
         if not(test_line):
             if test_line.strip():
-                raise AssertionError("Extra info in Expected: `%s`"
-                                     % good_line)
+                raise AssertionError("Extra info in Expected: `{0!s}`".format(good_line))
 
         assert test_line == good_line, \
-               "Expected does not match Test.\nExpect:`%s`\nTest  :`%s`\n" % \
-               (good_line, test_line)
+               "Expected does not match Test.\nExpect:`{0!s}`\nTest  :`{1!s}`\n".format(good_line, test_line)
 
 
 def write_format(file):
     record_parser = GenBank.RecordParser(debug_level=2)
 
-    print("Testing GenBank writing for %s..." % os.path.basename(file))
+    print("Testing GenBank writing for {0!s}...".format(os.path.basename(file)))
     # be able to handle gzipped files
     if '.gz' in file:
         cur_handle = gzip.open(file, "r")
@@ -81,7 +79,7 @@ def write_format(file):
         try:
             do_comparison(compare_record, output_record)
         except AssertionError as msg:
-            print("\tTesting for %s" % cur_record.version)
+            print("\tTesting for {0!s}".format(cur_record.version))
             print(msg)
 
     cur_handle.close()

--- a/Scripts/GenBank/check_output_simple.py
+++ b/Scripts/GenBank/check_output_simple.py
@@ -34,15 +34,15 @@ with open(sys.argv[1], 'r') as handle:
             break
 
         print("***Record")
-        print("Seq: %s" % cur_record.seq)
-        print("Id: %s" % cur_record.id)
-        print("Name: %s" % cur_record.name)
-        print("Description: %s" % cur_record.description)
+        print("Seq: {0!s}".format(cur_record.seq))
+        print("Id: {0!s}".format(cur_record.id))
+        print("Name: {0!s}".format(cur_record.name))
+        print("Description: {0!s}".format(cur_record.description))
         print("Annotations****")
         for annotation_key in cur_record.annotations:
             if annotation_key != 'references':
-                print("Key: %s" % annotation_key)
-                print("Value: %s" % cur_record.annotations[annotation_key])
+                print("Key: {0!s}".format(annotation_key))
+                print("Value: {0!s}".format(cur_record.annotations[annotation_key]))
             else:
                 print("References*")
                 for reference in cur_record.annotations[annotation_key]:

--- a/Scripts/PDB/generate_three_to_one_dict.py
+++ b/Scripts/PDB/generate_three_to_one_dict.py
@@ -75,23 +75,23 @@ while line:
         one = line.strip().split()[-1]
         found_one = True
     if line.startswith('_chem_comp.three_letter_code'):
-        three = '%-3s' % (line.strip().split()[-1],)  # make it three-letter
+        three = '{0:<3!s}'.format(line.strip().split()[-1])  # make it three-letter
         found_three = True
 
     if found_one and found_three:
         if counter % 5 == 0:
-            three_to_one_buf.append('%s\n' % (current_line,))
+            three_to_one_buf.append('{0!s}\n'.format(current_line))
             current_line = '    '
 
-        current_line = '%s\'%s\':\'%s\',' % (current_line, three, one)
+        current_line = '{0!s}\'{1!s}\':\'{2!s}\','.format(current_line, three, one)
         counter += 1
 
         if one != '?':
             if counter_noq % 5 == 0:
-                three_to_one_buf_noq.append('%s\n' % (current_line_noq,))
+                three_to_one_buf_noq.append('{0!s}\n'.format(current_line_noq))
                 current_line_noq = '    '
 
-            current_line_noq = '%s\'%s\':\'%s\',' % (current_line_noq, three, one)
+            current_line_noq = '{0!s}\'{1!s}\':\'{2!s}\','.format(current_line_noq, three, one)
             counter_noq += 1
 
         found_one = False
@@ -103,13 +103,13 @@ if len(current_line) < 5:
     three_to_one_buf[-1] = three_to_one_buf[:-1]  # remove the last comma
     three_to_one_buf.append('}')
 else:
-    three_to_one_buf.append('%s }' % (current_line[:-1]))
+    three_to_one_buf.append('{0!s} }}'.format((current_line[:-1])))
 
 if len(current_line_noq) < 5:
     three_to_one_buf_noq[-1] = three_to_one_buf_noq[:-1]
     three_to_one_buf_noq.append('}')
 else:
-    three_to_one_buf_noq.append('%s }' % (current_line_noq[:-1]))
+    three_to_one_buf_noq.append('{0!s} }}'.format((current_line_noq[:-1])))
 
 # Find path of current script
 _scriptPath = os.path.abspath(os.path.split(inspect.getfile(inspect.currentframe()))[0])

--- a/Scripts/Performance/biosql_performance_load.py
+++ b/Scripts/Performance/biosql_performance_load.py
@@ -30,5 +30,4 @@ num_records = db.load(iterator)
 end_time = time.time()
 elapsed_time = end_time - start_time
 print("Loading")
-print("\tDid %s records in %s seconds for\n\t%f records per second" % \
-      (num_records, elapsed_time, float(num_records) / float(elapsed_time)))
+print("\tDid {0!s} records in {1!s} seconds for\n\t{2:f} records per second".format(num_records, elapsed_time, float(num_records) / float(elapsed_time)))

--- a/Scripts/Performance/biosql_performance_read.py
+++ b/Scripts/Performance/biosql_performance_read.py
@@ -23,8 +23,7 @@ for junk_id, record in db.items():
 end_time = time.time()
 elapsed_time = end_time - start_time
 print("Fasta")
-print("\tDid %s records in %s seconds for\n\t%f records per second" % \
-      (num_records, elapsed_time, float(num_records) / float(elapsed_time)))
+print("\tDid {0!s} records in {1!s} seconds for\n\t{2:f} records per second".format(num_records, elapsed_time, float(num_records) / float(elapsed_time)))
 
 # -- do the "EMBL" timing part
 start_time = time.time()
@@ -43,5 +42,4 @@ for junk_id, record in db.items():
 end_time = time.time()
 elapsed_time = end_time - start_time
 print("EMBL")
-print("\tDid %s records in %s seconds for\n\t%f records per second" % \
-      (num_records, elapsed_time, float(num_records) / float(elapsed_time)))
+print("\tDid {0!s} records in {1!s} seconds for\n\t{2:f} records per second".format(num_records, elapsed_time, float(num_records) / float(elapsed_time)))

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -287,12 +287,12 @@ class newenzyme(object):
         cls.charac = (cls.fst5, cls.fst3, cls.scd5, cls.scd3, cls.site)
         if not target[2] and cls.suppl:
             supp = ', '.join(suppliersdict[s][0] for s in cls.suppl)
-            print('WARNING : It seems that %s is both commercially available\
+            print('WARNING : It seems that {0!s} is both commercially available\
             \n\tand its characteristics are unknown. \
             \n\tThis seems counter-intuitive.\
             \n\tThere is certainly an error either in ranacompiler or\
             \n\tin this REBASE release.\
-            \n\tThe supplier is : %s.' % (name, supp))
+            \n\tThe supplier is : {1!s}.'.format(name, supp))
         return
 
 
@@ -348,10 +348,10 @@ class TypeCompiler(object):
 
             class klass(type):
                 def __new__(cls):
-                    return type.__new__(cls, 'type%i'%n, ty, dct)
+                    return type.__new__(cls, 'type{0:d}'.format(n), ty, dct)
 
                 def __init__(cls):
-                    super(klass, cls).__init__('type%i'%n, ty, dct)
+                    super(klass, cls).__init__('type{0:d}'.format(n), ty, dct)
 
             yield klass()
             n+=1
@@ -472,7 +472,7 @@ class DictionaryBuilder(object):
         #
         #   How many enzymes this time?
         #
-        print('\nThe new database contains %i enzymes.\n' % len(classdict))
+        print('\nThe new database contains {0:d} enzymes.\n'.format(len(classdict)))
         #
         #   the dictionaries are done. Build the file
         #
@@ -487,9 +487,9 @@ class DictionaryBuilder(object):
                 results.write("def _temp():\n")
                 results.write("    return {\n")
                 for key, value in classdict[name].items():
-                    results.write("        %s: %s,\n" % (repr(key), repr(value)))
+                    results.write("        {0!s}: {1!s},\n".format(repr(key), repr(value)))
                 results.write("    }\n")
-                results.write("rest_dict[%s] = _temp()\n" % repr(name))
+                results.write("rest_dict[{0!s}] = _temp()\n".format(repr(name)))
                 results.write("\n")
             print('OK.\n')
             print('Writing the dictionary containing the suppliers data...')
@@ -498,9 +498,9 @@ class DictionaryBuilder(object):
                 results.write("def _temp():\n")
                 results.write("    return (\n")
                 for value in suppliersdict[name]:
-                    results.write("        %s,\n" % repr(value))
+                    results.write("        {0!s},\n".format(repr(value)))
                 results.write("    )\n")
-                results.write("suppliers[%s] = _temp()\n" % repr(name))
+                results.write("suppliers[{0!s}] = _temp()\n".format(repr(name)))
                 results.write("\n")
             print('OK.\n')
             print('Writing the dictionary containing the Restriction types...')
@@ -509,9 +509,9 @@ class DictionaryBuilder(object):
                 results.write("def _temp():\n")
                 results.write("    return (\n")
                 for value in typedict[name]:
-                    results.write("        %s,\n" % repr(value))
+                    results.write("        {0!s},\n".format(repr(value)))
                 results.write("    )\n")
-                results.write("typedict[%s] = _temp()\n" % repr(name))
+                results.write("typedict[{0!s}] = _temp()\n".format(repr(name)))
                 results.write("\n")
             # I had wanted to do "del _temp" at each stage (just for clarity), but
             # that pushed the code size just over the Jython JVM limit. We include
@@ -568,7 +568,7 @@ class DictionaryBuilder(object):
             print('\
             \n\t WARNING : Impossible to install the new dictionary.\
             \n\t Are you sure you have write permission to the folder :\n\
-            \n\t %s ?\n\n' % os.path.split(old)[0])
+            \n\t {0!s} ?\n\n'.format(os.path.split(old)[0]))
             return self.no_install()
         return
 
@@ -597,12 +597,12 @@ class DictionaryBuilder(object):
         \n\t\tInstallation : No.\n\
         \n You will find the newly created 'Restriction_Dictionary.py' file\
         \n in the folder : \n\
-        \n\t%s\n\
+        \n\t{0!s}\n\
         \n Make a copy of 'Restriction_Dictionary.py' and place it with \
         \n the other Restriction libraries.\n\
         \n note : \
         \n This folder should be :\n\
-        \n\t%s\n" % places)
+        \n\t{1!s}\n".format(*places))
         print('\n ' +'*'*78 + '\n')
         return
 
@@ -630,7 +630,7 @@ class DictionaryBuilder(object):
             #
             #   nothing to be done
             #
-            print('\n Using the files : %s'% ', '.join(emboss_now))
+            print('\n Using the files : {0!s}'.format(', '.join(emboss_now)))
             return tuple(open(os.path.join(base, n)) for n in emboss_now)
         else:
             #
@@ -645,7 +645,7 @@ class DictionaryBuilder(object):
                 updt.getfiles()
                 updt.close()
                 print('\n Update complete. Creating the dictionaries.\n')
-                print('\n Using the files : %s'% ', '.join(emboss_now))
+                print('\n Using the files : {0!s}'.format(', '.join(emboss_now)))
                 return tuple(open(os.path.join(base, n)) for n in emboss_now)
             else:
                 #
@@ -663,7 +663,7 @@ class DictionaryBuilder(object):
                             pass
                         raise NotFoundError
                     except NotFoundError:
-                        print("\nNo %s file found. Upgrade is impossible.\n"%name)
+                        print("\nNo {0!s} file found. Upgrade is impossible.\n".format(name))
                         sys.exit()
                     continue
                 pass
@@ -689,18 +689,18 @@ class DictionaryBuilder(object):
             last[0], last[-1] = last[-1], last[0]
 
         for number in last:
-            files = [(name, name+'.%s'%number) for name in embossnames]
+            files = [(name, name+'.{0!s}'.format(number)) for name in embossnames]
             strmess = '\nLast EMBOSS files found are :\n'
             try:
                 for name, file in files:
                     if os.path.isfile(os.path.join(base, file)):
-                        strmess += '\t%s.\n'%file
+                        strmess += '\t{0!s}.\n'.format(file)
                     else:
                         raise ValueError
                 print(strmess)
-                emboss_e = open(os.path.join(base, 'emboss_e.%s'%number), 'r')
-                emboss_r = open(os.path.join(base, 'emboss_r.%s'%number), 'r')
-                emboss_s = open(os.path.join(base, 'emboss_s.%s'%number), 'r')
+                emboss_e = open(os.path.join(base, 'emboss_e.{0!s}'.format(number)), 'r')
+                emboss_r = open(os.path.join(base, 'emboss_r.{0!s}'.format(number)), 'r')
+                emboss_s = open(os.path.join(base, 'emboss_s.{0!s}'.format(number)), 'r')
                 return emboss_e, emboss_r, emboss_s
             except ValueError:
                 continue
@@ -751,9 +751,9 @@ class DictionaryBuilder(object):
             #   new enzymes be added, this might be modified.
             #
             print('\
-            \nWARNING : %s cut twice with different overhang length each time.\
+            \nWARNING : {0!s} cut twice with different overhang length each time.\
             \n\tUnable to deal with this behaviour. \
-            \n\tThis enzyme will not be included in the database. Sorry.' %name)
+            \n\tThis enzyme will not be included in the database. Sorry.'.format(name))
             print('\tChecking...')
             raise OverhangError
         if 0 <= fst5 <= size and 0 <= fst3 <= size:
@@ -962,9 +962,9 @@ class DictionaryBuilder(object):
                 except OverhangError:   # overhang error
                     n = name            # do not include the enzyme
                     if not bl[2]:
-                        print('Anyway, %s is not commercially available.\n' %n)
+                        print('Anyway, {0!s} is not commercially available.\n'.format(n))
                     else:
-                        print('Unfortunately, %s is commercially available.\n'%n)
+                        print('Unfortunately, {0!s} is commercially available.\n'.format(n))
 
                     continue
                 # Hyphens and dots can't be used as a Python name, nor as a
@@ -974,7 +974,7 @@ class DictionaryBuilder(object):
                     #
                     #   deal with TaqII and its two sites.
                     #
-                    print('\nWARNING : %s has two different sites.\n' % name)
+                    print('\nWARNING : {0!s} has two different sites.\n'.format(name))
                     other = line[0].replace("-", "_").replace(".", "_")
                     dna = Seq(line[1], generic_dna)
                     sense1 = regex(dna)

--- a/Scripts/Restriction/rebase_update.py
+++ b/Scripts/Restriction/rebase_update.py
@@ -59,11 +59,11 @@ class RebaseUpdate(FancyURLopener):
 
     def getfiles(self, *files):
         for file in self.update(*files):
-            print('copying %s' % file)
+            print('copying {0!s}'.format(file))
             fn = os.path.basename(file)
             # filename = os.path.join(Rebase, fn)
             filename = os.path.join(os.getcwd(), fn)
-            print('to %s' % filename)
+            print('to {0!s}'.format(filename))
             self.retrieve(file, filename)
         self.close()
         return
@@ -93,8 +93,8 @@ class RebaseUpdate(FancyURLopener):
 class FtpNameError(ValueError):
 
     def __init__(self, which_server):
-        print(" In order to connect to %s ftp server, you must provide a name.\
-        \n Please edit Bio.Restriction.RanaConfig\n" % which_server)
+        print(" In order to connect to {0!s} ftp server, you must provide a name.\
+        \n Please edit Bio.Restriction.RanaConfig\n".format(which_server))
         sys.exit()
 
 
@@ -102,9 +102,9 @@ class FtpPasswordError(ValueError):
 
     def __init__(self, which_server):
         print("\n\
-        \n In order to connect to %s ftp server, you must provide a password.\
+        \n In order to connect to {0!s} ftp server, you must provide a password.\
         \n Use the --e-mail switch to enter your e-mail address.\
-        \n\n" % which_server)
+        \n\n".format(which_server))
         sys.exit()
 
 
@@ -112,11 +112,11 @@ class ConnectionError(IOError):
 
     def __init__(self, which_server):
         print('\
-        \n Unable to connect to the %s ftp server, make sure your computer\
+        \n Unable to connect to the {0!s} ftp server, make sure your computer\
         \n is connected to the internet and that you have correctly configured\
         \n the ftp proxy.\
         \n Use the --proxy switch to enter the address of your proxy\
-        \n' % which_server)
+        \n'.format(which_server))
         sys.exit()
 
 

--- a/Scripts/debug/debug_blast_parser.py
+++ b/Scripts/debug/debug_blast_parser.py
@@ -18,7 +18,7 @@ from Bio.Blast import NCBIStandalone
 
 CONTEXT = 5   # show 5 lines of context around the error in the format file
 
-USAGE = """%s [-h] [-v] [-p] [-n] [-o] <testfile>
+USAGE = """{0!s} [-h] [-v] [-p] [-n] [-o] <testfile>
 
 This script helps diagnose problems with the BLAST parser.
 
@@ -34,7 +34,7 @@ OPTIONS:
 
 -o    <testfile> is a BLAST output file.
 
-""" % sys.argv[0]
+""".format(sys.argv[0])
 
 
 class DebuggingConsumer(object):
@@ -83,8 +83,7 @@ def test_blast_output(outfile):
 
         parser_class = choose_parser(outfile)
         print("It looks like you have given output that should be parsed")
-        print("with %s.%s.  If I'm wrong, you can select the correct parser" %
-              (parser_class.__module__, parser_class.__name__))
+        print("with {0!s}.{1!s}.  If I'm wrong, you can select the correct parser".format(parser_class.__module__, parser_class.__name__))
         print("on the command line of this script (NOT IMPLEMENTED YET).")
     else:
         raise NotImplementedError("Biopython no longer has an HTML BLAST parser.")
@@ -134,12 +133,11 @@ def test_blast_output(outfile):
         traceback.print_exception(etype, value, tb)
         return 1
     else:
-        print("I found the problem in %s.%s.%s, line %d:" %
-              (class_found.__module__, class_found.__name__,
+        print("I found the problem in {0!s}.{1!s}.{2!s}, line {3:d}:".format(class_found.__module__, class_found.__name__,
                err_function, err_line))
-        print("    %s" % err_text)
-        print("This output caused an %s to be raised with the" % etype)
-        print("information %r." % exception_info)
+        print("    {0!s}".format(err_text))
+        print("This output caused an {0!s} to be raised with the".format(etype))
+        print("information {0!r}.".format(exception_info))
     print("")
 
     print("Let me find the line in the file that triggers the problem...")
@@ -153,7 +151,7 @@ def test_blast_output(outfile):
     else:
         print("Odd, the exception disappeared!  What happened?")
         return 3
-    print("It's caused by line %d:" % consumer.linenum)
+    print("It's caused by line {0:d}:".format(consumer.linenum))
     lines = open(outfile).readlines()
     start, end = consumer.linenum - CONTEXT, consumer.linenum + CONTEXT + 1
     if start < 0:
@@ -174,10 +172,9 @@ def test_blast_output(outfile):
     print("")
 
     if class_found == scanner_class:
-        print("Problems in %s are most likely caused by changed formats." %
-              class_found.__name__)
-        print("You can start to fix this by going to line %d in module %s." %
-              (err_line, class_found.__module__))
+        print("Problems in {0!s} are most likely caused by changed formats.".format(
+              class_found.__name__))
+        print("You can start to fix this by going to line {0:d} in module {1!s}.".format(err_line, class_found.__module__))
         print("Perhaps the scanner needs to be made more lenient by accepting")
         print("the changed format?")
         print("")
@@ -199,18 +196,17 @@ def test_blast_output(outfile):
         print("")
 
     elif class_found == consumer_class:
-        print("Problems in %s can be caused by two things:" %
-              class_found.__name__)
-        print("    - The format of the line parsed by '%s' changed." %
-              err_function)
+        print("Problems in {0!s} can be caused by two things:".format(
+              class_found.__name__))
+        print("    - The format of the line parsed by '{0!s}' changed.".format(
+              err_function))
         print("    - The scanner misidentified the line.")
-        print("Check to make sure '%s' should parse the line:" %
-              err_function)
-        s = "    %s" % chomp(lines[consumer.linenum])
+        print("Check to make sure '{0!s}' should parse the line:".format(
+              err_function))
+        s = "    {0!s}".format(chomp(lines[consumer.linenum]))
         s = s[:80]
         print(s)
-        print("If so, debug %s.%s.  Otherwise, debug %s." %
-              (class_found.__name__, err_function, scanner_class.__name__))
+        print("If so, debug {0!s}.{1!s}.  Otherwise, debug {2!s}.".format(class_found.__name__, err_function, scanner_class.__name__))
 
 
 VERBOSITY = 0
@@ -218,14 +214,14 @@ if __name__ == '__main__':
     try:
         optlist, args = getopt.getopt(sys.argv[1:], "hpnov")
     except getopt.error as x:
-        sys.stderr.write("%s\n" % x)
+        sys.stderr.write("{0!s}\n".format(x))
         sys.exit(-1)
     if len(args) != 1:
         sys.stderr.write(USAGE)
         sys.exit(-1)
     TESTFILE, = args
     if not os.path.exists(TESTFILE):
-        sys.stderr.write("I could not find file: %s\n" % TESTFILE)
+        sys.stderr.write("I could not find file: {0!s}\n".format(TESTFILE))
         sys.exit(-1)
 
     PROTEIN = NUCLEOTIDE = OUTPUT = None

--- a/Scripts/query_pubmed.py
+++ b/Scripts/query_pubmed.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
         print_usage()
         sys.exit(0)
 
-    print("Doing a PubMed search for %s..." % repr(query))
+    print("Doing a PubMed search for {0!s}...".format(repr(query)))
 
     if count_only:
         handle = Entrez.esearch(db="pubmed", term=query)
@@ -59,7 +59,7 @@ if __name__ == '__main__':
     search_results = Entrez.read(handle)
     ids = search_results["IdList"]
     count = len(ids)
-    print("Found %d citations" % count)
+    print("Found {0:d} citations".format(count))
 
     if count_only:
         sys.exit(0)

--- a/Scripts/scop_pdb.py
+++ b/Scripts/scop_pdb.py
@@ -126,7 +126,7 @@ def main():
             pdbid = id[1:5]
             s = pdbid[0:1]
             if s == '0' or s == 's':
-                sys.stderr.write("No coordinates for domain %s\n" % id)
+                sys.stderr.write("No coordinates for domain {0!s}\n".format(id))
                 continue
 
             if output is None:
@@ -150,7 +150,7 @@ def main():
                     finally:
                         f.close()
                 except (IOError, KeyError, RuntimeError) as e:
-                    sys.stderr.write("I cannot do SCOP domain %s : %s\n" % (id, e))
+                    sys.stderr.write("I cannot do SCOP domain {0!s} : {1!s}\n".format(id, e))
             finally:
                 out_handle.close()
     finally:

--- a/Scripts/xbbtools/nextorf.py
+++ b/Scripts/xbbtools/nextorf.py
@@ -86,7 +86,7 @@ class NextOrf(object):
 
     def ToFasta(self, header, seq):
         seq = re.sub('(............................................................)', '\\1\n', seq)
-        return '>%s\n%s' % (header, seq)
+        return '>{0!s}\n{1!s}'.format(header, seq)
 
     def Gc(self, seq):
         d = {}
@@ -126,7 +126,7 @@ class NextOrf(object):
             nall += n
 
         gcall = 100.0 * gcall / nall
-        res = '%.1f%%, %.1f%%, %.1f%%, %.1f%%' % (gcall, gc[0], gc[1], gc[2])
+        res = '{0:.1f}%, {1:.1f}%, {2:.1f}%, {3:.1f}%'.format(gcall, gc[0], gc[1], gc[2])
         return res
 
     def GetOrfCoordinates(self, seq):
@@ -200,11 +200,11 @@ class NextOrf(object):
         for start, stop, length, subs, strand in CDS:
             self.counter += 1
             if strand > 0:
-                head = 'orf_%s:%s:%d:%d:%d' % (self.counter, self.header, strand, start, stop)
+                head = 'orf_{0!s}:{1!s}:{2:d}:{3:d}:{4:d}'.format(self.counter, self.header, strand, start, stop)
             if strand < 0:
-                head = 'orf_%s:%s:%d:%d:%d' % (self.counter, self.header, strand, n - stop + 1, n - start + 1)
+                head = 'orf_{0!s}:{1!s}:{2:d}:{3:d}:{4:d}'.format(self.counter, self.header, strand, n - stop + 1, n - start + 1)
             if self.options['gc']:
-                head = '%s:%s' % (head, self.Gc2(subs.data))
+                head = '{0!s}:{1!s}'.format(head, self.Gc2(subs.data))
 
             if out == 'aa':
                 orf = subs.translate(table=self.genetic_code)
@@ -217,7 +217,7 @@ class NextOrf(object):
 
 def help():
     global options
-    print('Usage: %s (<options>) <FASTA file>' % sys.argv[0])
+    print('Usage: {0!s} (<options>) <FASTA file>'.format(sys.argv[0]))
     print("")
     print('Options:                                                       default')
     print('--start       Start position in sequence                             0')
@@ -236,7 +236,7 @@ def help():
 #    print("")
     print("\nNCBI's Codon Tables:")
     for key, table in CodonTable.ambiguous_dna_by_id.items():
-        print('\t%s %s' % (key, table._codon_table.names[0]))
+        print('\t{0!s} {1!s}'.format(key, table._codon_table.names[0]))
     print('\ne.g.\n./nextorf.py --minlength 5 --strand plus --output nt --gc 1 testjan.fas')
     sys.exit(0)
 
@@ -279,7 +279,7 @@ if __name__ == '__main__':
                 options[key] = arg[1]
 
         if arg[0] == '-v':
-            print('OPTIONS %s' % options)
+            print('OPTIONS {0!s}'.format(options))
 
     file = args[0]
     nextorf = NextOrf(file, options)

--- a/Scripts/xbbtools/xbb_blast.py
+++ b/Scripts/xbbtools/xbb_blast.py
@@ -99,7 +99,7 @@ class BlastIt(object):
         else:
             db = self.dbs.get()
             prog = self.blasts.get()
-            self.command = 'echo %s | nice blastall -d %s -p %s' % (self.seq, db, prog)
+            self.command = 'echo {0!s} | nice blastall -d {1!s} -p {2!s}'.format(self.seq, db, prog)
 
         self.Run()
 

--- a/Scripts/xbbtools/xbb_blastbg.py
+++ b/Scripts/xbbtools/xbb_blastbg.py
@@ -38,7 +38,7 @@ class BlastDisplayer(object):
         with open(self.outfile, 'w+') as fid:
             pass
 
-        com = '%s > %s' % (self.command, self.outfile)
+        com = '{0!s} > {1!s}'.format(self.command, self.outfile)
 
         self.worker = BlastWorker(com)
         self.worker.start()
@@ -90,7 +90,7 @@ class BlastWorker(threading.Thread):
         del self.queue
 
     def run(self):
-        print('running %s' % self.com)
+        print('running {0!s}'.format(self.com))
         os.system(self.com)
         self.finished = 1
 

--- a/Scripts/xbbtools/xbb_search.py
+++ b/Scripts/xbbtools/xbb_search.py
@@ -52,7 +52,7 @@ class DNAsearch(object):
         for i in s:
             r = self.alphabet.get(i, i)
             if len(r) > 1:
-                rx = '%s[%s]' % (rx, r)
+                rx = '{0!s}[{1!s}]'.format(rx, r)
             else:
                 rx += r
         return rx
@@ -126,7 +126,7 @@ class XDNAsearch(Toplevel, DNAsearch):
             except:
                 color = 'cyan'
         self.current_color = color
-        self.current_tag = 'searched_%s' % self.current_color
+        self.current_tag = 'searched_{0!s}'.format(self.current_color)
         self.master.tag_config(self.current_tag, background=self.current_color)
         self.master.tag_config(self.current_tag + 'R', background=self.current_color, underline=1)
         self.colors.append(color)
@@ -152,15 +152,15 @@ class XDNAsearch(Toplevel, DNAsearch):
             if self.highlight:
                 start, stop = pos, pos + len(self.pattern)
                 if other_strand:
-                    w.tag_add(self.current_tag + 'R', '1.%d' % start, '1.%s' % stop)
+                    w.tag_add(self.current_tag + 'R', '1.{0:d}'.format(start), '1.{0!s}'.format(stop))
                 else:
-                    w.tag_add(self.current_tag, '1.%d' % start, '1.%s' % stop)
-                w.see('1.%d' % start)
+                    w.tag_add(self.current_tag, '1.{0:d}'.format(start), '1.{0!s}'.format(stop))
+                w.see('1.{0:d}'.format(start))
 
     def exit(self):
         for c in self.colors:
-            self.master.tag_remove('searched_%s' % c, 1.0, END)
-            self.master.tag_remove('searched_%sR' % c, 1.0, END)
+            self.master.tag_remove('searched_{0!s}'.format(c), 1.0, END)
+            self.master.tag_remove('searched_{0!s}R'.format(c), 1.0, END)
         self.destroy()
         del(self)
 

--- a/Scripts/xbbtools/xbb_translations.py
+++ b/Scripts/xbbtools/xbb_translations.py
@@ -52,17 +52,17 @@ class xbb_translations(object):
     def header_nice(self, txt, seq):
         length = len(seq)
         if length > 20:
-            short = '%s ... %s' % (seq[:10], seq[-10:])
+            short = '{0!s} ... {1!s}'.format(seq[:10], seq[-10:])
         else:
             short = seq
 
         date = time.strftime('%y %b %d, %X', time.localtime(time.time()))
-        res = '%s: %s, ' % (txt, date)
+        res = '{0!s}: {1!s}, '.format(txt, date)
 
         for nt in ['a', 't', 'g', 'c']:
-            res += '%s:%d ' % (nt, seq.count(nt.upper()))
+            res += '{0!s}:{1:d} '.format(nt, seq.count(nt.upper()))
 
-        res += '\nSequence: %s, %d nt, %0.2f %%GC\n' % (short.lower(), length, self.gc(seq))
+        res += '\nSequence: {0!s}, {1:d} nt, {2:0.2f} %GC\n'.format(short.lower(), length, self.gc(seq))
         res += '\n\n'
         return res
 
@@ -73,10 +73,10 @@ class xbb_translations(object):
         for i in range(0, length, 60):
             subseq = seq[i:i + 60]
             p = i // 3
-            res += '%d/%d\n' % (i + 1, i // 3 + 1)
+            res += '{0:d}/{1:d}\n'.format(i + 1, i // 3 + 1)
             res += '  '.join(protein[p:p + 20]) + '\n'
             # seq
-            res += subseq.lower() + '%5d %%\n' % int(self.gc(subseq))
+            res += subseq.lower() + '{0:5d} %\n'.format(int(self.gc(subseq)))
 
         return res
 
@@ -101,12 +101,12 @@ class xbb_translations(object):
             csubseq = comp[i:i + 60]
             p = i // 3
             # + frames
-            res += '%d/%d\n' % (i + 1, i // 3 + 1)
+            res += '{0:d}/{1:d}\n'.format(i + 1, i // 3 + 1)
             res += '  ' + '  '.join(frames[3][p:p + 20]) + '\n'
             res += ' ' + '  '.join(frames[2][p:p + 20]) + '\n'
             res += '  '.join(frames[1][p:p + 20]) + '\n'
             # seq
-            res += subseq.lower() + '%5d %%\n' % int(self.gc(subseq))
+            res += subseq.lower() + '{0:5d} %\n'.format(int(self.gc(subseq)))
             res += csubseq.lower() + '\n'
             # - frames
             res += '  '.join(frames[-2][p:p + 20]) + ' \n'

--- a/Scripts/xbbtools/xbb_widget.py
+++ b/Scripts/xbbtools/xbb_widget.py
@@ -277,7 +277,7 @@ class xbb_widget(object):
     def select(self, a, b):
         w = self.sequence_id
         w.selection_own()
-        w.tag_add('sel', '1.%d' % (a - 1), '1.%d' % b)
+        w.tag_add('sel', '1.{0:d}'.format((a - 1)), '1.{0:d}'.format(b))
         self.count_selection(None)
 
     def get_selection_or_sequence(self):
@@ -317,22 +317,22 @@ class xbb_widget(object):
             b = int(w.index('sel.last').split('.')[1])
             length = b - a + 1
 
-            self.position_ids['from_id'].configure(text='Start:%d' % a)
-            self.position_ids['to_id'].configure(text='Stop:%d' % b)
-            self.position_ids['length_id'].configure(text='%d nt' % length)
+            self.position_ids['from_id'].configure(text='Start:{0:d}'.format(a))
+            self.position_ids['to_id'].configure(text='Stop:{0:d}'.format(b))
+            self.position_ids['length_id'].configure(text='{0:d} nt'.format(length))
 
-            self.statistics_ids['length_id'].configure(text='Length=%d' % length)
+            self.statistics_ids['length_id'].configure(text='Length={0:d}'.format(length))
             seq = self.get_self_selection()
             for nt in ['A', 'C', 'G', 'T']:
                 n = seq.count(nt)
-                self.statistics_ids[nt].configure(text='%s=%d' % (nt, n))
+                self.statistics_ids[nt].configure(text='{0!s}={1:d}'.format(nt, n))
         except:
             pass
 
     def position(self, event):
         x = event.x
         y = event.y
-        pos = self.sequence_id.index('@%d,%d' % (x, y)).split('.')
+        pos = self.sequence_id.index('@{0:d},{1:d}'.format(x, y)).split('.')
         pos = int(pos[1]) + 1
         self.position_ids['id'].configure(text=str(pos))
 
@@ -365,7 +365,7 @@ class xbb_widget(object):
 
     def export(self):
         seq = self.get_self_selection()
-        print("%s %i" % (seq, len(seq)))
+        print("{0!s} {1:d}".format(seq, len(seq)))
 
     def gcframe(self):
         seq = self.get_selection_or_sequence()
@@ -388,11 +388,11 @@ class xbb_widget(object):
         if not seq:
             return
         aa_seq = self.translator.frame(seq, frame, self.current_codon_table_id)
-        print('>%s<' % aa_seq)
+        print('>{0!s}<'.format(aa_seq))
         aa_seq = re.sub('(.{50})', '\\1\n', str(aa_seq))
         np = NotePad()
         tid = np.text_id()
-        tid.insert(END, '>frame%d\n%s' % (frame, aa_seq))
+        tid.insert(END, '>frame{0:d}\n{1!s}'.format(frame, aa_seq))
 
     def statistics(self):
         seq = self.get_selection_or_sequence()
@@ -410,13 +410,13 @@ class xbb_widget(object):
         np = NotePad()
         tid = np.text_id()
 
-        tid.insert(END, """%s
+        tid.insert(END, """{0!s}
 
-Length = %d
-A=%d C=%d G=%d T=%d other=%d
-GC=%f
+Length = {1:d}
+A={2:d} C={3:d} G={4:d} T={5:d} other={6:d}
+GC={7:f}
 
-""" % (time.strftime('%y %b %d, %X\n', time.localtime(time.time())),
+""".format(time.strftime('%y %b %d, %X\n', time.localtime(time.time())),
                len(seq), aa['A'], aa['C'], aa['G'], aa['T'], aa['N'], GC)
                    )
 
@@ -503,12 +503,12 @@ GC=%f
                 return
 
         self.sequence_id.focus()
-        self.sequence_id.mark_set('insert', '1.%d' % pos)
+        self.sequence_id.mark_set('insert', '1.{0:d}'.format(pos))
 
     def mark(self, start, stop):
         self.sequence_id.focus()
-        self.sequence_id.mark_set('insert', '1.%d' % start)
-        self.sequence_id.tag_add(SEL, '1.%d' % start, '1.%d' % stop)
+        self.sequence_id.mark_set('insert', '1.{0:d}'.format(start))
+        self.sequence_id.tag_add(SEL, '1.{0:d}'.format(start), '1.{0:d}'.format(stop))
 
 if __name__ == '__main__':
     xbbtools = xbb_widget()

--- a/Tests/PAML/gen_results.py
+++ b/Tests/PAML/gen_results.py
@@ -132,13 +132,13 @@ Generate result files to be used in Bio.Phylo.PAML unit tests.
 
   -v         Use verbose output
   PROGRAM    codeml, baseml or yn00
-  VERSION    %s
+  VERSION    {0!s}
 
 To use this, the PAML programs must be in your executable path and
 they must be named programX_Y, where X and Y are the version numbers
 (i.e. baseml4_5 or codeml4_4c). If VERSION is not specified, test
 results will be generated for all versions listed above.
-'''%(versions)
+'''.format((versions))
     sys.exit(usage)
 
 if __name__ == "__main__":

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -74,13 +74,13 @@ def check_config(dbdriver, dbtype, dbhost, dbuser, dbpasswd, testdb):
             elif DBDRIVER in ["psycopg2"]:
                 import org.postgresql.Driver
         except ImportError:
-            message = "Install the JDBC driver for %s to use BioSQL " % DBTYPE
+            message = "Install the JDBC driver for {0!s} to use BioSQL ".format(DBTYPE)
             raise MissingExternalDependencyError(message)
     else:
         try:
             __import__(DBDRIVER)
         except ImportError:
-            message = "Install %s if you want to use %s with BioSQL " % (DBDRIVER, DBTYPE)
+            message = "Install {0!s} if you want to use {1!s} with BioSQL ".format(DBDRIVER, DBTYPE)
             raise MissingExternalDependencyError(message)
 
     try:
@@ -92,14 +92,14 @@ def check_config(dbdriver, dbtype, dbhost, dbuser, dbpasswd, testdb):
         server.close()
         del server
     except Exception as e:
-        message = "Connection failed, check settings if you plan to use BioSQL: %s" % e
+        message = "Connection failed, check settings if you plan to use BioSQL: {0!s}".format(e)
         raise MissingExternalDependencyError(message)
 
     DBSCHEMA = "biosqldb-" + DBTYPE + ".sql"
     SQL_FILE = os.path.join(os.getcwd(), "BioSQL", DBSCHEMA)
 
     if not os.path.isfile(SQL_FILE):
-        message = "Missing SQL schema file: %s" % SQL_FILE
+        message = "Missing SQL schema file: {0!s}".format(SQL_FILE)
         raise MissingExternalDependencyError(message)
 
 
@@ -138,7 +138,7 @@ def _do_db_create():
         pass
     except (server.module.IntegrityError,
             server.module.ProgrammingError) as e:  # ditto--perhaps
-        if str(e).find('database "%s" does not exist' % TESTDB) == -1:
+        if str(e).find('database "{0!s}" does not exist'.format(TESTDB)) == -1:
             server.close()
             raise
     # create a new database
@@ -161,7 +161,7 @@ def create_database():
                 except:
                     # Seen this with PyPy 2.1 (and older) on Windows -
                     # which suggests an open handle still exists?
-                    print("Could not remove %r" % TESTDB)
+                    print("Could not remove {0!r}".format(TESTDB))
                     pass
         # Now pick a new filename - just in case there is a stale handle
         # (which might be happening under Windows...)
@@ -411,8 +411,7 @@ class SeqInterfaceTest(unittest.TestCase):
             self.assertEqual(cds_feature.qualifiers["protein_id"], ["CAA44171.1"])
             self.assertEqual(cds_feature.qualifiers["codon_start"], ["1"])
         except KeyError:
-            raise KeyError("Missing expected entries, have %s"
-                           % repr(cds_feature.qualifiers))
+            raise KeyError("Missing expected entries, have {0!s}".format(repr(cds_feature.qualifiers)))
 
         self.assertTrue("db_xref" in cds_feature.qualifiers)
         multi_ann = cds_feature.qualifiers["db_xref"]
@@ -510,7 +509,7 @@ class DupLoadTest(unittest.TestCase):
                                                        "OperationalError"],
                             err.__class__.__name__)
             return
-        raise Exception("Should have failed! Loaded %i records" % count)
+        raise Exception("Should have failed! Loaded {0:d} records".format(count))
 
     def test_duplicate_load2(self):
         """Make sure can't import a single record twice (in steps)."""
@@ -526,7 +525,7 @@ class DupLoadTest(unittest.TestCase):
                                                        "AttributeError"],
                             err.__class__.__name__)
             return
-        raise Exception("Should have failed! Loaded %i records" % count)
+        raise Exception("Should have failed! Loaded {0:d} records".format(count))
 
     def test_duplicate_id_load(self):
         """Make sure can't import records with same ID (in one go)."""
@@ -542,7 +541,7 @@ class DupLoadTest(unittest.TestCase):
                                                        "AttributeError"],
                             err.__class__.__name__)
             return
-        raise Exception("Should have failed! Loaded %i records" % count)
+        raise Exception("Should have failed! Loaded {0:d} records".format(count))
 
 
 class ClosedLoopTest(unittest.TestCase):
@@ -589,7 +588,7 @@ class ClosedLoopTest(unittest.TestCase):
         server = BioSeqDatabase.open_database(driver=DBDRIVER,
                                               user=DBUSER, passwd=DBPASSWD,
                                               host=DBHOST, db=TESTDB)
-        db_name = "test_loop_%s" % filename  # new namespace!
+        db_name = "test_loop_{0!s}".format(filename)  # new namespace!
         db = server.new_database(db_name)
         count = db.load(original_records)
         self.assertEqual(count, len(original_records))
@@ -665,7 +664,7 @@ class TransferTest(unittest.TestCase):
         server = BioSeqDatabase.open_database(driver=DBDRIVER,
                                               user=DBUSER, passwd=DBPASSWD,
                                               host=DBHOST, db=TESTDB)
-        db_name = "test_trans1_%s" % filename  # new namespace!
+        db_name = "test_trans1_{0!s}".format(filename)  # new namespace!
         db = server.new_database(db_name)
         count = db.load(original_records)
         self.assertEqual(count, len(original_records))
@@ -676,7 +675,7 @@ class TransferTest(unittest.TestCase):
         # And check they agree
         self.assertTrue(compare_records(original_records, biosql_records))
         # Now write to a second name space...
-        db_name = "test_trans2_%s" % filename  # new namespace!
+        db_name = "test_trans2_{0!s}".format(filename)  # new namespace!
         db = server.new_database(db_name)
         count = db.load(biosql_records)
         self.assertEqual(count, len(original_records))
@@ -741,7 +740,7 @@ class InDepthLoadTest(unittest.TestCase):
                                                        "AttributeError"],
                             err.__class__.__name__)
             return
-        raise Exception("Should have failed! Loaded %i records" % count)
+        raise Exception("Should have failed! Loaded {0:d} records".format(count))
 
     def test_record_loading(self):
         """Make sure all records are correctly loaded.
@@ -868,7 +867,7 @@ class AutoSeqIOTests(unittest.TestCase):
             if "accessions" in record.annotations:
                 # Only expect FIRST accession to work!
                 key = record.annotations["accessions"][0]
-                assert key, "Blank accession in annotation %s" % repr(record.annotations)
+                assert key, "Blank accession in annotation {0!s}".format(repr(record.annotations))
                 if key != record.id:
                     # print(" - Retrieving by accession '%s'," % key)
                     db_rec = db.lookup(accession=key)

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -174,7 +174,7 @@ def _have_bug17666():
     try:
         data = h.read()
         h.close()
-        assert not data, "Should be zero length, not %i" % len(data)
+        assert not data, "Should be zero length, not {0:d}".format(len(data))
         return False
     except TypeError as err:
         # TypeError: integer argument expected, got 'tuple'
@@ -196,9 +196,9 @@ def main(argv):
     # Q. Then, why ".."?
     # A. Because Martel may not be in ../build/lib.*
     test_path = sys.path[0] or "."
-    source_path = os.path.abspath("%s/.." % test_path)
+    source_path = os.path.abspath("{0!s}/..".format(test_path))
     sys.path.insert(1, source_path)
-    build_path = os.path.abspath("%s/../build/lib.%s-%s" % (
+    build_path = os.path.abspath("{0!s}/../build/lib.{1!s}-{2!s}".format(
         test_path, distutils.util.get_platform(), sys.version[:3]))
     if os.access(build_path, os.F_OK):
         sys.path.insert(1, build_path)
@@ -258,8 +258,8 @@ def main(argv):
         if args[arg_num][-3:] == ".py":
             args[arg_num] = args[arg_num][:-3]
 
-    print("Python version: %s" % sys.version)
-    print("Operating system: %s %s" % (os.name, sys.platform))
+    print("Python version: {0!s}".format(sys.version))
+    print("Operating system: {0!s} {1!s}".format(os.name, sys.platform))
 
     # run the tests
     runner = TestRunner(args, verbosity)
@@ -298,8 +298,7 @@ class ComparisonTestCase(unittest.TestCase):
             else:
                 expected = open(outputfile, "rU")
         except IOError:
-            self.fail("Warning: Can't open %s for test %s" %
-                      (outputfile, self.name))
+            self.fail("Warning: Can't open {0!s} for test {1!s}".format(outputfile, self.name))
 
         self.output.seek(0)
         # first check that we are dealing with the right output
@@ -308,8 +307,7 @@ class ComparisonTestCase(unittest.TestCase):
 
         if expected_test != self.name:
             expected.close()
-            raise ValueError("\nOutput:   %s\nExpected: %s"
-                             % (self.name, expected_test))
+            raise ValueError("\nOutput:   {0!s}\nExpected: {1!s}".format(self.name, expected_test))
 
         # now loop through the output and compare it to the expected file
         while True:
@@ -319,8 +317,8 @@ class ComparisonTestCase(unittest.TestCase):
             # stop looping if either of the info handles reach the end
             if not(expected_line) or not(output_line):
                 # make sure both have no information left
-                assert expected_line == '', "Unread: %s" % expected_line
-                assert output_line == '', "Extra output: %s" % output_line
+                assert expected_line == '', "Unread: {0!s}".format(expected_line)
+                assert output_line == '', "Extra output: {0!s}".format(output_line)
                 break
 
             # normalize the newlines in the two lines
@@ -335,8 +333,7 @@ class ComparisonTestCase(unittest.TestCase):
             # otherwise make sure the two lines are the same
             elif expected_line != output_line:
                 expected.close()
-                raise ValueError("\nOutput  : %s\nExpected: %s"
-                                 % (repr(output_line), repr(expected_line)))
+                raise ValueError("\nOutput  : {0!s}\nExpected: {1!s}".format(repr(output_line), repr(expected_line)))
         expected.close()
 
     def generate_output(self):
@@ -404,7 +401,7 @@ class TestRunner(unittest.TextTestRunner):
             stdout = sys.stdout
             sys.stdout = output
             if name.startswith("test_"):
-                sys.stderr.write("%s ... " % name)
+                sys.stderr.write("{0!s} ... ".format(name))
                 # It's either a unittest or a print-and-compare test
                 loader = unittest.TestLoader()
                 suite = loader.loadTestsFromName(name)
@@ -417,12 +414,12 @@ class TestRunner(unittest.TextTestRunner):
                             # Remove the traceback etc
                             msg = msg[msg.find("Bio.Missing"):]
                             msg = msg[msg.find("Error: "):]
-                            sys.stderr.write("skipping. %s\n" % msg)
+                            sys.stderr.write("skipping. {0!s}\n".format(msg))
                             return True
                     # Looks like a real failure
                     sys.stderr.write("loading tests failed:\n")
                     for msg in loader.errors:
-                        sys.stderr.write("%s\n" % msg)
+                        sys.stderr.write("{0!s}\n".format(msg))
                     return False
                 if suite.countTestCases() == 0:
                     # This is a print-and-compare test instead of a
@@ -431,7 +428,7 @@ class TestRunner(unittest.TextTestRunner):
                     suite = unittest.TestSuite([test])
             else:
                 # It's a doc test
-                sys.stderr.write("%s docstring test ... " % name)
+                sys.stderr.write("{0!s} docstring test ... ".format(name))
                 # Can't use fromlist=name.split(".") until python 2.5+
                 module = __import__(name, None, None, name.split("."))
                 suite = doctest.DocTestSuite(module,
@@ -441,11 +438,11 @@ class TestRunner(unittest.TextTestRunner):
             if self.testdir != os.path.abspath("."):
                 sys.stderr.write("FAIL\n")
                 result.stream.write(result.separator1 + "\n")
-                result.stream.write("ERROR: %s\n" % name)
+                result.stream.write("ERROR: {0!s}\n".format(name))
                 result.stream.write(result.separator2 + "\n")
                 result.stream.write("Current directory changed\n")
-                result.stream.write("Was: %s\n" % self.testdir)
-                result.stream.write("Now: %s\n" % os.path.abspath("."))
+                result.stream.write("Was: {0!s}\n".format(self.testdir))
+                result.stream.write("Now: {0!s}\n".format(os.path.abspath(".")))
                 os.chdir(self.testdir)
                 if not result.wasSuccessful():
                     result.printErrors()
@@ -460,13 +457,13 @@ class TestRunner(unittest.TextTestRunner):
         except MissingExternalDependencyError as msg:
             # Seems this isn't always triggered on Python 3.5,
             # exception messages can be in loader.errors instead.
-            sys.stderr.write("skipping. %s\n" % msg)
+            sys.stderr.write("skipping. {0!s}\n".format(msg))
             return True
         except Exception as msg:
             # This happened during the import
             sys.stderr.write("ERROR\n")
             result.stream.write(result.separator1 + "\n")
-            result.stream.write("ERROR: %s\n" % name)
+            result.stream.write("ERROR: {0!s}\n".format(name))
             result.stream.write(result.separator2 + "\n")
             result.stream.write(traceback.format_exc())
             return False
@@ -479,7 +476,7 @@ class TestRunner(unittest.TextTestRunner):
             # Invalid method Code length ...
             sys.stderr.write("ERROR\n")
             result.stream.write(result.separator1 + "\n")
-            result.stream.write("ERROR: %s\n" % name)
+            result.stream.write("ERROR: {0!s}\n".format(name))
             result.stream.write(result.separator2 + "\n")
             result.stream.write(traceback.format_exc())
             return False
@@ -501,11 +498,10 @@ class TestRunner(unittest.TextTestRunner):
         timeTaken = stopTime - startTime
         sys.stderr.write(self.stream.getvalue())
         sys.stderr.write('-' * 70 + "\n")
-        sys.stderr.write("Ran %d test%s in %.3f seconds\n" %
-                         (total, total != 1 and "s" or "", timeTaken))
+        sys.stderr.write("Ran {0:d} test{1!s} in {2:.3f} seconds\n".format(total, total != 1 and "s" or "", timeTaken))
         sys.stderr.write("\n")
         if failures:
-            sys.stderr.write("FAILED (failures = %d)\n" % failures)
+            sys.stderr.write("FAILED (failures = {0:d})\n".format(failures))
         return failures
 
 

--- a/Tests/search_tests_common.py
+++ b/Tests/search_tests_common.py
@@ -48,7 +48,7 @@ class CheckRaw(unittest.TestCase):
 
         if os.path.isfile(filename + ".bgz"):
             # Do the tests again with the BGZF compressed file
-            print("[BONUS %s.bgz]" % filename)
+            print("[BONUS {0!s}.bgz]".format(filename))
             self.check_raw(filename + ".bgz", id, raw, **kwargs)
 
 
@@ -71,14 +71,12 @@ class CheckIndex(unittest.TestCase):
         # compare values by index
         indexed = SearchIO.index(filename, format, **kwargs)
         self.assertEqual(len(parsed), len(indexed),
-                         "Should be %i records in %s, index says %i"
-                         % (len(parsed), filename, len(indexed)))
+                         "Should be {0:d} records in {1!s}, index says {2:d}".format(len(parsed), filename, len(indexed)))
         # compare values by index_db, only if sqlite3 is present
         if sqlite3 is not None:
             db_indexed = SearchIO.index_db(':memory:', [filename], format, **kwargs)
             self.assertEqual(len(parsed), len(db_indexed),
-                             "Should be %i records in %s, index_db says %i"
-                             % (len(parsed), filename, len(db_indexed)))
+                             "Should be {0:d} records in {1!s}, index_db says {2:d}".format(len(parsed), filename, len(db_indexed)))
 
         for qres in parsed:
             idx_qres = indexed[qres.id]
@@ -99,7 +97,7 @@ class CheckIndex(unittest.TestCase):
 
         if os.path.isfile(filename + ".bgz"):
             # Do the tests again with the BGZF compressed file
-            print("[BONUS %s.bgz]" % filename)
+            print("[BONUS {0!s}.bgz]".format(filename))
             self.check_index(filename + ".bgz", format, **kwargs)
 
 
@@ -125,7 +123,7 @@ def compare_search_obj(obj_a, obj_b):
     # compare objects recursively if it's not an HSPFragment
     if not isinstance(obj_a, SearchIO.HSPFragment):
         # check the number of hits contained
-        assert len(obj_a) == len(obj_b), "length: %i vs %i for %r vs %r" % (len(obj_a),
+        assert len(obj_a) == len(obj_b), "length: {0:d} vs {1:d} for {2!r} vs {3!r}".format(len(obj_a),
                 len(obj_b), obj_a, obj_b)
         for item_a, item_b in zip(obj_a, obj_b):
             assert compare_search_obj(item_a, item_b)
@@ -151,11 +149,11 @@ def compare_attrs(obj_a, obj_b, attrs):
             # compare seq directly if it's a contiguous hsp
             if isinstance(val_a, SeqRecord) and isinstance(val_b, SeqRecord):
                 assert str(val_a.seq) == str(val_b.seq), \
-                        "%s: %r vs %r" % (attr, val_a, val_b)
+                        "{0!s}: {1!r} vs {2!r}".format(attr, val_a, val_b)
             elif isinstance(val_a, list) and isinstance(val_b, list):
                 for seq_a, seq_b in zip(val_a, val_b):
                     assert str(seq_a.seq) == str(seq_b.seq), \
-                            "%s: %r vs %r" % (attr, seq_a, seq_b)
+                            "{0!s}: {1!r} vs {2!r}".format(attr, seq_a, seq_b)
         # if it's a dictionary, compare values and keys
         elif isinstance(val_a, dict):
             assert isinstance(val_b, dict)
@@ -163,15 +161,15 @@ def compare_attrs(obj_a, obj_b, attrs):
             values_a = sorted(val_a.values())
             keys_b = sorted(val_b)
             values_b = sorted(val_b.values())
-            assert keys_a == keys_b, "%s: %r vs %r" % (attr, keys_a, keys_b)
-            assert values_a == values_b, "%s: %r vs %r" % (attr, values_a,
+            assert keys_a == keys_b, "{0!s}: {1!r} vs {2!r}".format(attr, keys_a, keys_b)
+            assert values_a == values_b, "{0!s}: {1!r} vs {2!r}".format(attr, values_a,
                     values_b)
         # if it's an alphabet, check the class names as alphabets are instances
         elif attr == '_alphabet':
             alph_a = val_a.__class__.__name__
             alph_b = val_b.__class__.__name__
-            assert alph_a == alph_b, "%s: %r vs %r" % (attr, alph_a, alph_b)
+            assert alph_a == alph_b, "{0!s}: {1!r} vs {2!r}".format(attr, alph_a, alph_b)
         else:
-            assert val_a == val_b, "%s: %r vs %r" % (attr, val_a, val_b)
+            assert val_a == val_b, "{0!s}: {1!r} vs {2!r}".format(attr, val_a, val_b)
 
     return True

--- a/Tests/seq_tests_common.py
+++ b/Tests/seq_tests_common.py
@@ -20,8 +20,7 @@ def checksum_summary(record):
     else:
         short = str(record.seq)[:19] \
               + "..." + str(record.seq)[-3:]
-    return "%s [%s] len %i" \
-           % (short, seguid(record.seq), len(record.seq))
+    return "{0!s} [{1!s}] len {2:d}".format(short, seguid(record.seq), len(record.seq))
 
 
 def compare_reference(old_r, new_r):
@@ -31,13 +30,13 @@ def compare_reference(old_r, new_r):
     of the BioSQL table structure.
     """
     assert old_r.title == new_r.title, \
-           "%s vs %s" % (old_r.title, new_r.title)
+           "{0!s} vs {1!s}".format(old_r.title, new_r.title)
     assert old_r.authors == new_r.authors, \
-           "%s vs %s" % (old_r.authors, new_r.authors)
+           "{0!s} vs {1!s}".format(old_r.authors, new_r.authors)
     assert old_r.journal == new_r.journal, \
-           "%s vs %s" % (old_r.journal, new_r.journal)
+           "{0!s} vs {1!s}".format(old_r.journal, new_r.journal)
     assert old_r.medline_id == new_r.medline_id, \
-           "%s vs %s" % (old_r.medline_id, new_r.medline_id)
+           "{0!s} vs {1!s}".format(old_r.medline_id, new_r.medline_id)
 
     if old_r.pubmed_id and new_r.pubmed_id:
         assert old_r.pubmed_id == new_r.pubmed_id
@@ -50,7 +49,7 @@ def compare_reference(old_r, new_r):
     # Looking at the tables, I *think* the current schema does not
     # allow us to store a reference comment.  Must confirm this.
     assert old_r.comment == new_r.comment or new_r.comment == "", \
-                          "%r vs %r" % (old_r.comment, new_r.comment)
+                          "{0!r} vs {1!r}".format(old_r.comment, new_r.comment)
 
     # TODO - assert old_r.consrtm == new_r.consrtm
     # Looking at the tables, I *think* the current schema does not
@@ -76,16 +75,16 @@ def compare_feature(old_f, new_f):
     assert isinstance(new_f, SeqFeature)
 
     assert old_f.type == new_f.type, \
-        "%s -> %s" % (old_f.type, new_f.type)
+        "{0!s} -> {1!s}".format(old_f.type, new_f.type)
 
     assert old_f.strand == new_f.strand, \
-        "%s -> %s" % (old_f.strand, new_f.strand)
+        "{0!s} -> {1!s}".format(old_f.strand, new_f.strand)
 
     assert old_f.ref == new_f.ref, \
-        "%s -> %s" % (old_f.ref, new_f.ref)
+        "{0!s} -> {1!s}".format(old_f.ref, new_f.ref)
 
     assert old_f.ref_db == new_f.ref_db, \
-        "%s -> %s" % (old_f.ref_db, new_f.ref_db)
+        "{0!s} -> {1!s}".format(old_f.ref_db, new_f.ref_db)
 
     # TODO - BioSQL does not store/retrieve feature's id (Bug 2526)
     assert old_f.id == new_f.id or new_f.id == "<unknown id>"
@@ -99,12 +98,12 @@ def compare_feature(old_f, new_f):
     assert old_f.location.start == new_f.location.start \
     or (isinstance(old_f.location.start, UnknownPosition) and
         isinstance(new_f.location.start, UnknownPosition)), \
-               "%s -> %s" % (old_f.location.start,
+               "{0!s} -> {1!s}".format(old_f.location.start,
                              new_f.location.start)
     assert old_f.location.end == new_f.location.end \
     or (isinstance(old_f.location.end, UnknownPosition) and
         isinstance(new_f.location.end, UnknownPosition)), \
-               "%s -> %s" % (old_f.location.end,
+               "{0!s} -> {1!s}".format(old_f.location.end,
                              new_f.location.end)
 
     assert isinstance(old_f.location, CompoundLocation) == \
@@ -127,22 +126,21 @@ def compare_feature(old_f, new_f):
 
     # Using private variable to avoid deprecation warnings
     assert len(old_f._sub_features) == len(new_f._sub_features), \
-        "number of sub_features: %s -> %s" % \
-        (len(old_f._sub_features), len(new_f._sub_features))
+        "number of sub_features: {0!s} -> {1!s}".format(len(old_f._sub_features), len(new_f._sub_features))
 
     for old_sub, new_sub in zip(old_f._sub_features, new_f._sub_features):
         # These are SeqFeature objects
         assert old_sub.type == new_sub.type, \
-            "%s -> %s" % (old_sub.type, new_sub.type)
+            "{0!s} -> {1!s}".format(old_sub.type, new_sub.type)
 
         assert old_sub.strand == new_sub.strand, \
-            "%s -> %s" % (old_sub.strand, new_sub.strand)
+            "{0!s} -> {1!s}".format(old_sub.strand, new_sub.strand)
 
         assert old_sub.ref == new_sub.ref, \
-            "%s -> %s" % (old_sub.ref, new_sub.ref)
+            "{0!s} -> {1!s}".format(old_sub.ref, new_sub.ref)
 
         assert old_sub.ref_db == new_sub.ref_db, \
-            "%s -> %s" % (old_sub.ref_db, new_sub.ref_db)
+            "{0!s} -> {1!s}".format(old_sub.ref_db, new_sub.ref_db)
 
         # TODO - Work out how the location_qualifier_value table should
         # be used, given BioPerl seems to ignore it (Bug 2766)
@@ -158,7 +156,7 @@ def compare_feature(old_f, new_f):
 
         try:
             assert str(old_sub.location) == str(new_sub.location), \
-               "%s -> %s" % (str(old_sub.location), str(new_sub.location))
+               "{0!s} -> {1!s}".format(str(old_sub.location), str(new_sub.location))
         except AssertionError as e:
             if isinstance(old_sub.location.start, ExactPosition) and \
                isinstance(old_sub.location.end, ExactPosition):
@@ -168,11 +166,11 @@ def compare_feature(old_f, new_f):
                 # At least one of the locations is fuzzy
                 assert old_sub.location.nofuzzy_start == \
                        new_sub.location.nofuzzy_start, \
-                       "%s -> %s" % (old_sub.location.nofuzzy_start,
+                       "{0!s} -> {1!s}".format(old_sub.location.nofuzzy_start,
                                      new_sub.location.nofuzzy_start)
                 assert old_sub.location.nofuzzy_end == \
                        new_sub.location.nofuzzy_end, \
-                       "%s -> %s" % (old_sub.location.nofuzzy_end,
+                       "{0!s} -> {1!s}".format(old_sub.location.nofuzzy_end,
                                      new_sub.location.nofuzzy_end)
 
     assert len(old_f.qualifiers) == len(new_f.qualifiers)
@@ -184,21 +182,20 @@ def compare_feature(old_f, new_f):
             elif isinstance(new_f.qualifiers[key], list):
                 # Maybe a string turning into a list of strings?
                 assert [old_f.qualifiers[key]] == new_f.qualifiers[key], \
-                        "%s -> %s" \
-                        % (repr(old_f.qualifiers[key]),
+                        "{0!s} -> {1!s}".format(repr(old_f.qualifiers[key]),
                            repr(new_f.qualifiers[key]))
             else:
-                assert False, "Problem with feature's '%s' qualifier" % key
+                assert False, "Problem with feature's '{0!s}' qualifier".format(key)
         else:
             # Should both be lists of strings...
             assert old_f.qualifiers[key] == new_f.qualifiers[key], \
-                "%s -> %s" % (old_f.qualifiers[key], new_f.qualifiers[key])
+                "{0!s} -> {1!s}".format(old_f.qualifiers[key], new_f.qualifiers[key])
     return True
 
 
 def compare_sequence(old, new):
     """Compare two Seq or DBSeq objects"""
-    assert len(old) == len(new), "%i vs %i" % (len(old), len(new))
+    assert len(old) == len(new), "{0:d} vs {1:d}".format(len(old), len(new))
     assert str(old) == str(new)
 
     if isinstance(old, UnknownSeq):
@@ -232,9 +229,9 @@ def compare_sequence(old, new):
         for j in indices:
             expected = s[i:j]
             assert expected == str(old[i:j]), \
-                   "Slice %s vs %s" % (repr(expected), repr(old[i:j]))
+                   "Slice {0!s} vs {1!s}".format(repr(expected), repr(old[i:j]))
             assert expected == str(new[i:j]), \
-                   "Slice %s vs %s" % (repr(expected), repr(new[i:j]))
+                   "Slice {0!s} vs {1!s}".format(repr(expected), repr(new[i:j]))
             # Slicing with step of 1 should make no difference.
             # Slicing with step 3 might be useful for codons.
             for step in [1, 3]:
@@ -278,8 +275,7 @@ def compare_record(old, new):
     assert old.name == new.name
     assert old.description == new.description
     assert old.dbxrefs == new.dbxrefs, \
-           "dbxrefs mismatch\nOld: %s\nNew: %s" \
-           % (old.dbxrefs, new.dbxrefs)
+           "dbxrefs mismatch\nOld: {0!s}\nNew: {1!s}".format(old.dbxrefs, new.dbxrefs)
     # Features:
     if not compare_features(old.features, new.features):
         return False
@@ -292,13 +288,11 @@ def compare_record(old, new):
     new_keys = set(new.annotations).difference(old.annotations)
     new_keys = new_keys.difference(['cross_references', 'date',
                                     'data_file_division', 'ncbi_taxid', 'gi'])
-    assert not new_keys, "Unexpected new annotation keys: %s" \
-           % ", ".join(new_keys)
+    assert not new_keys, "Unexpected new annotation keys: {0!s}".format(", ".join(new_keys))
     missing_keys = set(old.annotations).difference(new.annotations)
     missing_keys = missing_keys.difference(['ncbi_taxid',  # Can't store chimeras
                                             ])
-    assert not missing_keys, "Unexpectedly missing annotation keys: %s" \
-           % ", ".join(missing_keys)
+    assert not missing_keys, "Unexpectedly missing annotation keys: {0!s}".format(", ".join(missing_keys))
 
     # In the short term, just compare any shared keys:
     for key in set(old.annotations).intersection(new.annotations):
@@ -332,20 +326,17 @@ def compare_record(old, new):
                 or isinstance(new.annotations[key], list)
         elif type(old.annotations[key]) == type(new.annotations[key]):
             assert old.annotations[key] == new.annotations[key], \
-                "Annotation '%s' changed by load/retrieve\nWas:%s\nNow:%s" \
-                % (key, old.annotations[key], new.annotations[key])
+                "Annotation '{0!s}' changed by load/retrieve\nWas:{1!s}\nNow:{2!s}".format(key, old.annotations[key], new.annotations[key])
         elif isinstance(old.annotations[key], str) \
         and isinstance(new.annotations[key], list):
             # Any annotation which is a single string gets turned into
             # a list containing one string by BioSQL at the moment.
             assert [old.annotations[key]] == new.annotations[key], \
-                "Annotation '%s' changed by load/retrieve\nWas:%s\nNow:%s" \
-                % (key, old.annotations[key], new.annotations[key])
+                "Annotation '{0!s}' changed by load/retrieve\nWas:{1!s}\nNow:{2!s}".format(key, old.annotations[key], new.annotations[key])
         elif isinstance(old.annotations[key], list) \
         and isinstance(new.annotations[key], str):
             assert old.annotations[key] == [new.annotations[key]], \
-                "Annotation '%s' changed by load/retrieve\nWas:%s\nNow:%s" \
-                % (key, old.annotations[key], new.annotations[key])
+                "Annotation '{0!s}' changed by load/retrieve\nWas:{1!s}\nNow:{2!s}".format(key, old.annotations[key], new.annotations[key])
     return True
 
 

--- a/Tests/test_AlignIO.py
+++ b/Tests/test_AlignIO.py
@@ -86,19 +86,18 @@ def alignment_summary(alignment, index="  ", vertical_threshold=5):
     if rec_count < vertical_threshold:
         # Show each sequence row horizontally
         for record in alignment:
-            answer.append("%s%s %s"
-            % (index, str_summary(str(record.seq)), record.id))
+            answer.append("{0!s}{1!s} {2!s}".format(index, str_summary(str(record.seq)), record.id))
     else:
         # Show each sequence row vertically
         for i in range(min(5, alignment_len)):
             answer.append(index + str_summary(alignment[:, i])
-                                + " alignment column %i" % i)
+                                + " alignment column {0:d}".format(i))
         if alignment_len > 5:
             i = alignment_len - 1
             answer.append(index + str_summary("|" * rec_count)
                                 + " ...")
             answer.append(index + str_summary(alignment[:, i])
-                                + " alignment column %i" % i)
+                                + " alignment column {0:d}".format(i))
     return "\n".join(answer)
 
 
@@ -114,7 +113,7 @@ def check_simple_write_read(alignments, indent=" "):
         and format not in test_write_read_alignment_formats:
             continue
 
-        print(indent + "Checking can write/read as '%s' format" % format)
+        print(indent + "Checking can write/read as '{0!s}' format".format(format))
 
         # Going to write to a handle...
         handle = StringIO()
@@ -125,7 +124,7 @@ def check_simple_write_read(alignments, indent=" "):
         except ValueError as e:
             # This is often expected to happen, for example when we try and
             # write sequences of different lengths to an alignment file.
-            print(indent + "Failed: %s" % str(e))
+            print(indent + "Failed: {0!s}".format(str(e)))
             # Carry on to the next format:
             continue
 
@@ -141,8 +140,7 @@ def check_simple_write_read(alignments, indent=" "):
                 # I want to see the output when called from the test harness,
                 # run_tests.py (which can be funny about new lines on Windows)
                 handle.seek(0)
-                raise ValueError("%s\n\n%s\n\n%s"
-                                  % (str(e), repr(handle.read()), repr(alignments2)))
+                raise ValueError("{0!s}\n\n{1!s}\n\n{2!s}".format(str(e), repr(handle.read()), repr(alignments2)))
             simple_alignment_comparison(alignments, alignments2, format)
 
         if format in test_write_read_alignment_formats:
@@ -156,8 +154,7 @@ def check_simple_write_read(alignments, indent=" "):
                 # I want to see the output when called from the test harness,
                 # run_tests.py (which can be funny about new lines on Windows)
                 handle.seek(0)
-                raise ValueError("%s\n\n%s\n\n%s"
-                                  % (str(e), repr(handle.read()), repr(alignments2)))
+                raise ValueError("{0!s}\n\n{1!s}\n\n{2!s}".format(str(e), repr(handle.read()), repr(alignments2)))
             simple_alignment_comparison(alignments, alignments2, format)
 
         if len(alignments) > 1:
@@ -183,21 +180,21 @@ def simple_alignment_comparison(alignments, alignments2, format):
             # valid character sets and the identifier lengths!
             if format in ["phylip", "phylip-sequential"]:
                 assert r1.id.replace("[", "").replace("]", "")[:10] == r2.id, \
-                       "'%s' vs '%s'" % (r1.id, r2.id)
+                       "'{0!s}' vs '{1!s}'".format(r1.id, r2.id)
             elif format == "phylip-relaxed":
                 assert r1.id.replace(" ", "").replace(':', '|') == r2.id, \
-                        "'%s' vs '%s'" % (r1.id, r2.id)
+                        "'{0!s}' vs '{1!s}'".format(r1.id, r2.id)
             elif format == "clustal":
                 assert r1.id.replace(" ", "_")[:30] == r2.id, \
-                       "'%s' vs '%s'" % (r1.id, r2.id)
+                       "'{0!s}' vs '{1!s}'".format(r1.id, r2.id)
             elif format == "stockholm":
                 assert r1.id.replace(" ", "_") == r2.id, \
-                       "'%s' vs '%s'" % (r1.id, r2.id)
+                       "'{0!s}' vs '{1!s}'".format(r1.id, r2.id)
             elif format == "fasta":
                 assert r1.id.split()[0] == r2.id
             else:
                 assert r1.id == r2.id, \
-                       "'%s' vs '%s'" % (r1.id, r2.id)
+                       "'{0!s}' vs '{1!s}'".format(r1.id, r2.id)
     return True
 
 
@@ -233,8 +230,7 @@ for t_format in AlignIO._FormatToIterator:
 for t_format in list(AlignIO._FormatToWriter) + list(SeqIO._FormatToWriter):
     handle = StringIO()
     assert 0 == AlignIO.write([], handle, t_format), \
-           "Writing no alignments to %s format should work!" \
-           % t_format
+           "Writing no alignments to {0!s} format should work!".format(t_format)
     handle.close()
 
 # Check writers reject non-alignments
@@ -243,8 +239,7 @@ for t_format in list(AlignIO._FormatToWriter) + list(SeqIO._FormatToWriter):
     handle = StringIO()
     try:
         AlignIO.write([list_of_records], handle, t_format)
-        assert False, "Writing non-alignment to %s format should fail!" \
-            % t_format
+        assert False, "Writing non-alignment to {0!s} format should fail!".format(t_format)
     except (TypeError, AttributeError, ValueError):
         pass
     handle.close()
@@ -253,19 +248,17 @@ del list_of_records, t_format
 
 # Main tests...
 for (t_format, t_per, t_count, t_filename) in test_files:
-    print("Testing reading %s format file %s with %i alignments"
-          % (t_format, t_filename, t_count))
+    print("Testing reading {0!s} format file {1!s} with {2:d} alignments".format(t_format, t_filename, t_count))
     assert os.path.isfile(t_filename), t_filename
 
     # Try as an iterator using handle
     with open(t_filename, "r") as handle:
         alignments = list(AlignIO.parse(handle, format=t_format))
     assert len(alignments) == t_count, \
-         "Found %i alignments but expected %i" % (len(alignments), t_count)
+         "Found {0:d} alignments but expected {1:d}".format(len(alignments), t_count)
     for alignment in alignments:
         assert len(alignment) == t_per, \
-            "Expected %i records per alignment, got %i" \
-            % (t_per, len(alignment))
+            "Expected {0:d} records per alignment, got {1:d}".format(t_per, len(alignment))
 
     # Try using the iterator with a for loop and a filename not handle
     alignments2 = []
@@ -328,8 +321,7 @@ for (t_format, t_per, t_count, t_filename) in test_files:
     # Show the alignment
     for i, alignment in enumerate(alignments):
         if i < 3 or i + 1 == t_count:
-            print(" Alignment %i, with %i sequences of length %i"
-                  % (i,
+            print(" Alignment {0:d}, with {1:d} sequences of length {2:d}".format(i,
                      len(alignment),
                      alignment.get_alignment_length()))
             print(alignment_summary(alignment))

--- a/Tests/test_AlignIO_FastaIO.py
+++ b/Tests/test_AlignIO_FastaIO.py
@@ -35,29 +35,26 @@ test_files = [
 for (t_format, t_per, t_count, t_filename) in test_files:
     assert t_format == "fasta-m10" and t_per == 2
 
-    print("Testing reading %s format file %s with %i alignments"
-          % (t_format, t_filename, t_count))
+    print("Testing reading {0!s} format file {1!s} with {2:d} alignments".format(t_format, t_filename, t_count))
     assert os.path.isfile(t_filename), t_filename
 
     # Try as an iterator using handle
     with open(t_filename, "r") as handle:
         alignments = list(AlignIO.parse(handle, format=t_format))
     assert len(alignments) == t_count, \
-         "Found %i alignments but expected %i" % (len(alignments), t_count)
+         "Found {0:d} alignments but expected {1:d}".format(len(alignments), t_count)
     for alignment in alignments:
         assert len(alignment) == t_per, \
-            "Expected %i records per alignment, got %i" \
-            % (t_per, len(alignment))
+            "Expected {0:d} records per alignment, got {1:d}".format(t_per, len(alignment))
 
     # Print the alignment
     for i, alignment in enumerate(alignments):
         print("=" * 78)
-        print("Alignment %i, with %i sequences of length %i"
-              % (i,
+        print("Alignment {0:d}, with {1:d} sequences of length {2:d}".format(i,
                  len(alignment),
                  alignment.get_alignment_length()))
         for k in sorted(alignment._annotations):
-            print(" - %s: %r" % (k, alignment._annotations[k]))
+            print(" - {0!s}: {1!r}".format(k, alignment._annotations[k]))
         assert alignment[0].name == "query"
         assert alignment[1].name == "match"
         # Show each sequence row horizontally
@@ -69,6 +66,6 @@ for (t_format, t_per, t_count, t_filename) in test_files:
             assert not record.features
             assert not record.letter_annotations
             for k in sorted(record.annotations):
-                print(" - %s: %r" % (k, record.annotations[k]))
+                print(" - {0!s}: {1!r}".format(k, record.annotations[k]))
     print("=" * 78)
 print("Finished tested reading files")

--- a/Tests/test_AlignIO_convert.py
+++ b/Tests/test_AlignIO_convert.py
@@ -62,10 +62,9 @@ for filename, in_format, alphabet in tests:
     for out_format in output_formats:
         def funct(fn, fmt1, fmt2, alpha):
             f = lambda x: x.simple_check(fn, fmt1, fmt2, alpha)
-            f.__doc__ = "Convert %s from %s to %s" % (fn, fmt1, fmt2)
+            f.__doc__ = "Convert {0!s} from {1!s} to {2!s}".format(fn, fmt1, fmt2)
             return f
-        setattr(ConvertTests, "test_%s_%s_to_%s"
-                % (filename.replace("/", "_").replace(".", "_"), in_format, out_format),
+        setattr(ConvertTests, "test_{0!s}_{1!s}_to_{2!s}".format(filename.replace("/", "_").replace(".", "_"), in_format, out_format),
                 funct(filename, in_format, out_format, alphabet))
     del funct
 

--- a/Tests/test_BWA_tool.py
+++ b/Tests/test_BWA_tool.py
@@ -95,11 +95,9 @@ class BwaTestCase(unittest.TestCase):
         for extension in self.reference_extensions:
             index_file = self.reference_file + "." + extension
             self.assertTrue(os.path.exists(index_file),
-                            "Index File %s not found"
-                            % (index_file))
+                            "Index File {0!s} not found".format((index_file)))
         self.assertTrue(stdout.startswith("[bwt_gen]"),
-                        "FASTA indexing failed:\n%s\nStdout:%s"
-                        % (cmdline, stdout))
+                        "FASTA indexing failed:\n{0!s}\nStdout:{1!s}".format(cmdline, stdout))
 
     def do_aln(self, in_file, out_file):
         """Test for generating sai files given the reference and read file"""
@@ -110,8 +108,7 @@ class BwaTestCase(unittest.TestCase):
         stdout, stderr = cmdline(stdout=out_file)
 
         self.assertTrue("fail to locate the index" not in stderr,
-                        "Error aligning sequence to reference:\n%s\nStderr:%s"
-                        % (cmdline, stderr))
+                        "Error aligning sequence to reference:\n{0!s}\nStderr:{1!s}".format(cmdline, stderr))
 
     def create_fasta_index(self):
         """Creates index for fasta file.
@@ -140,8 +137,7 @@ class BwaTestCase(unittest.TestCase):
             with open(self.samfile1, "r") as handle:
                 headline = handle.readline()
             self.assertTrue(headline.startswith("@SQ"),
-                            "Error generating sam files:\n%s\nOutput starts:%s"
-                            % (cmdline, headline))
+                            "Error generating sam files:\n{0!s}\nOutput starts:{1!s}".format(cmdline, headline))
 
         def test_sampe(self):
             """Test for generating samfile by paired end sequencing"""
@@ -162,8 +158,7 @@ class BwaTestCase(unittest.TestCase):
             with open(self.samfile, "r") as handle:
                 headline = handle.readline()
             self.assertTrue(headline.startswith("@SQ"),
-                            "Error generating sam files:\n%s\nOutput starts:%s"
-                            % (cmdline, headline))
+                            "Error generating sam files:\n{0!s}\nOutput starts:{1!s}".format(cmdline, headline))
 
 
 if __name__ == "__main__":

--- a/Tests/test_CAPS.py
+++ b/Tests/test_CAPS.py
@@ -15,7 +15,7 @@ from Bio.Align import MultipleSeqAlignment
 
 def createAlignment(sequences, alphabet):
     """Create an Alignment object from a list of sequences"""
-    return MultipleSeqAlignment((SeqRecord(Seq(s, alphabet), id="sequence%i" % (i + 1))
+    return MultipleSeqAlignment((SeqRecord(Seq(s, alphabet), id="sequence{0:d}".format((i + 1)))
                                  for (i, s) in enumerate(sequences)),
                                 alphabet)
 

--- a/Tests/test_ClustalOmega_tool.py
+++ b/Tests/test_ClustalOmega_tool.py
@@ -98,7 +98,7 @@ class ClustalOmegaTestErrorConditions(ClustalOmegaTestCase):
                             "Cannot open input file" in str(err) or
                             "Non-zero return code" in str(err), str(err))
         else:
-            self.fail("Should have failed, returned:\n%s\n%s" % (stdout, stderr))
+            self.fail("Should have failed, returned:\n{0!s}\n{1!s}".format(stdout, stderr))
 
     def test_single_sequence(self):
         """Test an input file containing a single sequence."""
@@ -111,7 +111,7 @@ class ClustalOmegaTestErrorConditions(ClustalOmegaTestCase):
         except ApplicationError as err:
             self.assertTrue("contains 1 sequence, nothing to align" in str(err))
         else:
-            self.fail("Should have failed, returned:\n%s\n%s" % (stdout, stderr))
+            self.fail("Should have failed, returned:\n{0!s}\n{1!s}".format(stdout, stderr))
 
     def test_invalid_format(self):
         """Test an input file in an invalid format."""
@@ -125,7 +125,7 @@ class ClustalOmegaTestErrorConditions(ClustalOmegaTestCase):
             # error for "invalid format".
             self.assertTrue("Can't determine format of sequence file" in str(err))
         else:
-            self.fail("Should have failed, returned:\n%s\n%s" % (stdout, stderr))
+            self.fail("Should have failed, returned:\n{0!s}\n{1!s}".format(stdout, stderr))
 
 #################################################################
 

--- a/Tests/test_CodonUsage.py
+++ b/Tests/test_CodonUsage.py
@@ -27,4 +27,4 @@ print("The current index used:")
 X.print_index()
 
 print("-" * 60)
-print("codon adaptation index for test gene: %.2f" % X.cai_for_gene("ATGAAACGCATTAGCACCACCATTACCACCACCATCACCATTACCACAGGTAACGGTGCGGGCTGA"))
+print("codon adaptation index for test gene: {0:.2f}".format(X.cai_for_gene("ATGAAACGCATTAGCACCACCATTACCACCACCATCACCATTACCACAGGTAACGGTGCGGGCTGA")))

--- a/Tests/test_ColorSpiral.py
+++ b/Tests/test_ColorSpiral.py
@@ -41,7 +41,7 @@ class SpiralTest(unittest.TestCase):
         """Get set of eight colours, no jitter, using ColorSpiral."""
         cs = ColorSpiral(a=4, b=0.33, jitter=0)
         colours = list(cs.get_colors(8))
-        cstr = ["(%.2f, %.2f, %.2f)" % (r, g, b)
+        cstr = ["({0:.2f}, {1:.2f}, {2:.2f})".format(r, g, b)
                     for r, g, b in colours]
         expected = \
             ['(0.64, 0.74, 0.81)', '(0.68, 0.52, 0.76)', '(0.72, 0.41, 0.55)',
@@ -100,7 +100,7 @@ class DictTest(unittest.TestCase):
         """get_color_dict() for classes A-D, no jitter."""
         classes = ['A', 'B', 'C', 'D']
         colors = get_color_dict(classes, jitter=0)
-        cstr = ["%s: (%.2f, %.2f, %.2f)" % (c, r, g, b)
+        cstr = ["{0!s}: ({1:.2f}, {2:.2f}, {3:.2f})".format(c, r, g, b)
                     for c, (r, g, b) in sorted(colors.items())]
         expected = ['A: (0.52, 0.76, 0.69)',
                     'B: (0.40, 0.31, 0.68)',

--- a/Tests/test_Emboss.py
+++ b/Tests/test_Emboss.py
@@ -41,13 +41,13 @@ if "EMBOSS_ROOT" in os.environ:
         del name
     else:
         raise MissingExternalDependencyError(
-                  "$EMBOSS_ROOT=%r which does not exist!" % path)
+                  "$EMBOSS_ROOT={0!r} which does not exist!".format(path))
     del path
 if sys.platform != "win32":
     from Bio._py3k import getoutput
     for name in exes_wanted:
         # This will "just work" if installed on the path as normal on Unix
-        output = getoutput("%s -help" % name)
+        output = getoutput("{0!s} -help".format(name))
         if "not found" not in output and "not recognized" not in output:
             exes[name] = name
         del output
@@ -96,8 +96,7 @@ def get_emboss_version():
             # Either we can't understand the output, or this is really
             # an error message not caught earlier (e.g. not in English)
             raise MissingExternalDependencyError(
-                "Install EMBOSS if you want to use Bio.Emboss (%s)."
-                % line)
+                "Install EMBOSS if you want to use Bio.Emboss ({0!s}).".format(line))
     # In case there was no output at all...
     raise MissingExternalDependencyError("Could not get EMBOSS version")
 
@@ -202,30 +201,27 @@ def emboss_piped_AlignIO_convert(alignments, old_format, new_format):
 def compare_records(old_list, new_list):
     """Check two lists of SeqRecords agree, raises a ValueError if mismatch."""
     if len(old_list) != len(new_list):
-        raise ValueError("%i vs %i records" % (len(old_list), len(new_list)))
+        raise ValueError("{0:d} vs {1:d} records".format(len(old_list), len(new_list)))
     for old, new in zip(old_list, new_list):
         # Note the name matching is a bit fuzzy, e.g. truncation and
         # no spaces in PHYLIP files.
         if old.id != new.id and old.name != new.name \
         and (old.id not in new.id) and (new.id not in old.id) \
         and (old.id.replace(" ", "_") != new.id.replace(" ", "_")):
-            raise ValueError("'%s' or '%s' vs '%s' or '%s' records"
-                             % (old.id, old.name, new.id, new.name))
+            raise ValueError("'{0!s}' or '{1!s}' vs '{2!s}' or '{3!s}' records".format(old.id, old.name, new.id, new.name))
         if len(old.seq) != len(new.seq):
-            raise ValueError("%i vs %i" % (len(old.seq), len(new.seq)))
+            raise ValueError("{0:d} vs {1:d}".format(len(old.seq), len(new.seq)))
         if str(old.seq).upper() != str(new.seq).upper():
             if str(old.seq).replace("X", "N") == str(new.seq):
                 raise ValueError("X -> N (protein forced into nucleotide?)")
             if len(old.seq) < 200:
-                raise ValueError("'%s' vs '%s'" % (old.seq, new.seq))
+                raise ValueError("'{0!s}' vs '{1!s}'".format(old.seq, new.seq))
             else:
-                raise ValueError("'%s...%s' vs '%s...%s'"
-                                 % (old.seq[:60], old.seq[-10:],
+                raise ValueError("'{0!s}...{1!s}' vs '{2!s}...{3!s}'".format(old.seq[:60], old.seq[-10:],
                                     new.seq[:60], new.seq[-10:]))
         if old.features and new.features \
         and len(old.features) != len(new.features):
-            raise ValueError("%i vs %i features"
-                             % (len(old.features), len(new.features)))
+            raise ValueError("{0:d} vs {1:d} features".format(len(old.features), len(new.features)))
         # TODO - check annotation
     return True
 
@@ -234,11 +230,10 @@ def compare_records(old_list, new_list):
 def compare_alignments(old_list, new_list):
     """Check two lists of Alignments agree, raises a ValueError if mismatch."""
     if len(old_list) != len(new_list):
-        raise ValueError("%i vs %i alignments" % (len(old_list), len(new_list)))
+        raise ValueError("{0:d} vs {1:d} alignments".format(len(old_list), len(new_list)))
     for old, new in zip(old_list, new_list):
         if len(old) != len(new):
-            raise ValueError("Alignment with %i vs %i records"
-                             % (len(old), len(new)))
+            raise ValueError("Alignment with {0:d} vs {1:d} records".format(len(old), len(new)))
         compare_records(old, new)
     return True
 
@@ -263,8 +258,7 @@ class SeqRetSeqIOTests(unittest.TestCase):
             try:
                 self.assertTrue(compare_records(records, new_records))
             except ValueError as err:
-                raise ValueError("Disagree on file %s %s in %s format: %s"
-                                 % (in_format, in_filename, temp_format, err))
+                raise ValueError("Disagree on file {0!s} {1!s} in {2!s} format: {3!s}".format(in_format, in_filename, temp_format, err))
 
     def check_EMBOSS_to_SeqIO(self, filename, old_format,
                               skip_formats=()):
@@ -281,8 +275,7 @@ class SeqRetSeqIOTests(unittest.TestCase):
             try:
                 self.assertTrue(compare_records(old_records, new_records))
             except ValueError as err:
-                raise ValueError("Disagree on %s file %s in %s format: %s"
-                                 % (old_format, filename, new_format, err))
+                raise ValueError("Disagree on {0!s} file {1!s} in {2!s} format: {3!s}".format(old_format, filename, new_format, err))
 
     def check_SeqIO_with_EMBOSS(self, filename, old_format, skip_formats=(),
                                 alphabet=None):
@@ -376,14 +369,12 @@ class SeqRetAlignIOTests(unittest.TestCase):
                 new_aligns = list(AlignIO.parse(handle, new_format))
             except:
                 handle.close()
-                raise ValueError("Can't parse %s file %s in %s format."
-                                 % (old_format, filename, new_format))
+                raise ValueError("Can't parse {0!s} file {1!s} in {2!s} format.".format(old_format, filename, new_format))
             handle.close()
             try:
                 self.assertTrue(compare_alignments(old_aligns, new_aligns))
             except ValueError as err:
-                raise ValueError("Disagree on %s file %s in %s format: %s"
-                                 % (old_format, filename, new_format, err))
+                raise ValueError("Disagree on {0!s} file {1!s} in {2!s} format: {3!s}".format(old_format, filename, new_format, err))
 
     def check_AlignIO_to_EMBOSS(self, in_filename, in_format, skip_formats=(),
                                 alphabet=None):
@@ -412,8 +403,7 @@ class SeqRetAlignIOTests(unittest.TestCase):
             try:
                 self.assertTrue(compare_alignments(old_aligns, new_aligns))
             except ValueError as err:
-                raise ValueError("Disagree on file %s %s in %s format: %s"
-                                 % (in_format, in_filename, temp_format, err))
+                raise ValueError("Disagree on file {0!s} {1!s} in {2!s} format: {3!s}".format(in_format, in_filename, temp_format, err))
 
     def check_AlignIO_with_EMBOSS(self, filename, old_format, skip_formats=(),
                                   alphabet=None):
@@ -462,8 +452,7 @@ class PairwiseAlignmentTests(unittest.TestCase):
             # self.assertEqual(target.id, alignment[1].id) #too strict
             if alignment[1].id not in target.id \
             and alignment[1].id not in target.name:
-                raise AssertionError("%s vs %s or %s"
-                                     % (alignment[1].id, target.id, target.name))
+                raise AssertionError("{0!s} vs {1!s} or {2!s}".format(alignment[1].id, target.id, target.name))
             if local:
                 # Local alignment
                 self.assertTrue(str(alignment[0].seq).replace("-", "")
@@ -485,7 +474,7 @@ class PairwiseAlignmentTests(unittest.TestCase):
         if cline.outfile:
             self.assertEqual(stdout.strip(), "")
             self.assertTrue(os.path.isfile(cline.outfile),
-                            "Missing output file %r from:\n%s" % (cline.outfile, cline))
+                            "Missing output file {0!r} from:\n{1!s}".format(cline.outfile, cline))
         else:
             # Don't use this yet... could return stdout handle instead?
             return stdout
@@ -562,7 +551,7 @@ class PairwiseAlignmentTests(unittest.TestCase):
         self.assertEqual(stdout.strip(), "")
         filename = cline.outfile
         self.assertTrue(os.path.isfile(filename),
-                        "Missing output file %r from:\n%s" % (filename, cline))
+                        "Missing output file {0!r} from:\n{1!s}".format(filename, cline))
         # Check we can parse the output...
         align = AlignIO.read(filename, "emboss")
         self.assertEqual(len(align), 2)
@@ -613,7 +602,7 @@ class PairwiseAlignmentTests(unittest.TestCase):
         if os.path.isfile(out_file):
             os.remove(out_file)
         cline = WaterCommandline(cmd=exes["water"])
-        cline.set_parameter("-asequence", "asis:%s" % query)
+        cline.set_parameter("-asequence", "asis:{0!s}".format(query))
         cline.set_parameter("-bsequence", in_file)
         cline.set_parameter("-gapopen", "10")
         cline.set_parameter("-gapextend", "0.5")
@@ -639,7 +628,7 @@ class PairwiseAlignmentTests(unittest.TestCase):
         if os.path.isfile(out_file):
             os.remove(out_file)
         cline = WaterCommandline(cmd=exes["water"])
-        cline.set_parameter("asequence", "asis:%s" % query)
+        cline.set_parameter("asequence", "asis:{0!s}".format(query))
         cline.set_parameter("bsequence", in_file)
         # TODO - Tell water this is a GenBank file!
         cline.set_parameter("gapopen", "1")
@@ -666,7 +655,7 @@ class PairwiseAlignmentTests(unittest.TestCase):
         if os.path.isfile(out_file):
             os.remove(out_file)
         cline = WaterCommandline(cmd=exes["water"])
-        cline.set_parameter("-asequence", "asis:%s" % query)
+        cline.set_parameter("-asequence", "asis:{0!s}".format(query))
         cline.set_parameter("-bsequence", in_file)
         # EMBOSS should work this out, but let's be explicit:
         cline.set_parameter("-sprotein", True)
@@ -786,20 +775,20 @@ def emboss_translate(sequence, table=None, frame=None):
 
     if len(sequence) < 100:
         filename = None
-        cline += " -sequence asis:%s" % sequence
+        cline += " -sequence asis:{0!s}".format(sequence)
     else:
         # There are limits on command line string lengths...
         # use a temp file instead.
         filename = "Emboss/temp_transeq.txt"
         SeqIO.write(SeqRecord(sequence, id="Test"), filename, "fasta")
-        cline += " -sequence %s" % filename
+        cline += " -sequence {0!s}".format(filename)
 
     cline += " -auto"  # no prompting
     cline += " -filter"  # use stdout
     if table is not None:
-        cline += " -table %s" % str(table)
+        cline += " -table {0!s}".format(str(table))
     if frame is not None:
-        cline += " -frame %s" % str(frame)
+        cline += " -frame {0!s}".format(str(frame))
     # Run the tool,
     child = subprocess.Popen(str(cline),
                              stdin=subprocess.PIPE,
@@ -841,11 +830,9 @@ def check_translation(sequence, translation, table=None):
         for i, amino in enumerate(translation):
             codon = sequence[i * 3:i * 3 + 3]
             if amino != str(codon.translate(t)):
-                raise ValueError("%s -> %s not %s (table %s)"
-                         % (codon, amino, codon.translate(t), t))
+                raise ValueError("{0!s} -> {1!s} not {2!s} (table {3!s})".format(codon, amino, codon.translate(t), t))
         # Shouldn't reach this line:
-        raise ValueError("%s -> %s (table %s)"
-                         % (sequence, translation, t))
+        raise ValueError("{0!s} -> {1!s} (table {2!s})".format(sequence, translation, t))
     return True
 
 

--- a/Tests/test_EmbossPhylipNew.py
+++ b/Tests/test_EmbossPhylipNew.py
@@ -36,7 +36,7 @@ if sys.platform != "win32":
     from Bio._py3k import getoutput
     for name in exes_wanted:
         # This will "just work" if installed on the path as normal on Unix
-        output = getoutput("%s -help" % name)
+        output = getoutput("{0!s} -help".format(name))
         if "not found" not in output and "not recognized" not in output:
             exes[name] = name
         del output
@@ -90,7 +90,7 @@ class DistanceTests(unittest.TestCase):
 
     def distances_from_alignment(self, filename, DNA=True):
         """check we can make distance matrix from a given alignment"""
-        self.assertTrue(os.path.isfile(filename), "Missing %s" % filename)
+        self.assertTrue(os.path.isfile(filename), "Missing {0!s}".format(filename))
         if DNA:
             cline = FDNADistCommandline(exes["fdnadist"],
                                          method='j',
@@ -109,7 +109,7 @@ class DistanceTests(unittest.TestCase):
 
     def tree_from_distances(self, filename):
         """Check we can estimate a tree from a distance matrix"""
-        self.assertTrue(os.path.isfile(filename), "Missing %s" % filename)
+        self.assertTrue(os.path.isfile(filename), "Missing {0!s}".format(filename))
         cline = FNeighborCommandline(exes["fneighbor"],
                                      datafile=filename,
                                      outtreefile="test_file",
@@ -165,7 +165,7 @@ class ParsimonyTests(unittest.TestCase):
 
     def parsimony_tree(self, filename, format, DNA=True):
         """Estimate a parsimony tree from an alignment"""
-        self.assertTrue(os.path.isfile(filename), "Missing %s" % filename)
+        self.assertTrue(os.path.isfile(filename), "Missing {0!s}".format(filename))
         if DNA:
             cline = FDNAParsCommandline(exes["fdnapars"],
                                         sequence=filename,
@@ -224,7 +224,7 @@ class BootstrapTests(unittest.TestCase):
         The align_type type argument is passed to the commandline object to
         set the output format to use (from [D]na,[p]rotein and [r]na )
         """
-        self.assertTrue(os.path.isfile(filename), "Missing %s" % filename)
+        self.assertTrue(os.path.isfile(filename), "Missing {0!s}".format(filename))
         cline = FSeqBootCommandline(exes["fseqboot"],
                                     sequence=filename,
                                     outfile="test_file",

--- a/Tests/test_FSSP.py
+++ b/Tests/test_FSSP.py
@@ -11,16 +11,15 @@ import os
 
 test_file = os.path.join('FSSP', '1cnv.fssp')
 f = sys.stdout
-f.write("\nRead in %s\n" % os.path.basename(test_file))
+f.write("\nRead in {0!s}\n".format(os.path.basename(test_file)))
 handle = open(test_file)
 head_rec, sum_rec, align_rec = FSSP.read_fssp(handle)
 handle.close()
 f.write("...1cnv.fssp read\n")
 for i in ["author", "compnd", "database", "header", "nalign",
           "pdbid", "seqlength", "source"]:
-    f.write('head_rec.%s %s\n' % (i, str(getattr(head_rec, i))))
-f.write("\nlen(sum_rec) = %d; head_rec.nalign = %d\n" %
-        (len(sum_rec), head_rec.nalign))
+    f.write('head_rec.{0!s} {1!s}\n'.format(i, str(getattr(head_rec, i))))
+f.write("\nlen(sum_rec) = {0:d}; head_rec.nalign = {1:d}\n".format(len(sum_rec), head_rec.nalign))
 f.write("The above two numbers should be the same\n")
 f.write("\nCreate a multiple alignment instance using Bio.Align\n")
 alignment = FSSPTools.mult_align(sum_rec, align_rec)
@@ -40,12 +39,12 @@ f.write("...Done\n")
 
 f.write("\nFilter by name\n")
 name_list = ['2hvm0', '1hvq0', '1nar0', '2ebn0']
-f.write("\nname list %s\n" % str(name_list))
+f.write("\nname list {0!s}\n".format(str(name_list)))
 sum_newnames, align_newnames = FSSPTools.name_filter(sum_rec, align_rec,
                                                      name_list)
 for key in sorted(sum_newnames):
-    f.write("%s : %s\n" % (key, sum_newnames[key]))
+    f.write("{0!s} : {1!s}\n".format(key, sum_newnames[key]))
 
 new_dict = align_newnames['0P168'].pos_align_dict
 for key in sorted(new_dict):
-    f.write("%s : %s\n" % (key, new_dict[key]))
+    f.write("{0!s} : {1!s}\n".format(key, new_dict[key]))

--- a/Tests/test_Fasttree_tool.py
+++ b/Tests/test_Fasttree_tool.py
@@ -55,7 +55,7 @@ else:
     likely_exes = ["FastTree", "fasttree"]
     for filename in likely_exes:
         # Checking the -help argument
-        output = getoutput("%s -help" % filename)
+        output = getoutput("{0!s} -help".format(filename))
         # Since "is not recognized" may be in another language, try and be sure this
         # is really the fasttree tool's output
         if "is not recognized" not in output and "protein_alignment" in output \
@@ -79,7 +79,7 @@ assert not os.path.isfile(input_file)
 cline = FastTreeCommandline(fasttree_exe, input=input_file)
 try:
     stdout, stderr = cline()
-    assert False, "Should have failed, returned:\n%s\n%s" % (stdout, stderr)
+    assert False, "Should have failed, returned:\n{0!s}\n{1!s}".format(stdout, stderr)
 except ApplicationError as err:
     print("Failed (good)")
     # Python 2.3 on Windows gave (0, 'Error')
@@ -99,7 +99,7 @@ try:
     if "Unique: 1/1" in stderr:
         print("Failed (good)")
     else:
-        assert False, "Should have failed, returned:\n%s\n%s" % (stdout, stderr)
+        assert False, "Should have failed, returned:\n{0!s}\n{1!s}".format(stdout, stderr)
 except ApplicationError as err:
     print("Failed (good)")
     # assert str(err) == "No records found in handle", str(err)
@@ -111,7 +111,7 @@ assert os.path.isfile(input_file)
 cline = FastTreeCommandline(fasttree_exe, input=input_file)
 try:
     stdout, stderr = cline()
-    assert False, "Should have failed, returned:\n%s\n%s" % (stdout, stderr)
+    assert False, "Should have failed, returned:\n{0!s}\n{1!s}".format(stdout, stderr)
 except ApplicationError as err:
     print("Failed (good)")
     # Ideally we'd catch the return code and raise the specific
@@ -139,8 +139,7 @@ handle.close()
 for input_file in ["Quality/example.fasta", "Clustalw/temp horses.fasta"]:
     input_records = SeqIO.to_dict(SeqIO.parse(input_file, "fasta"))
     print("")
-    print("Calling fasttree on %s (with %i records)"
-          % (repr(input_file), len(input_records)))
+    print("Calling fasttree on {0!s} (with {1:d} records)".format(repr(input_file), len(input_records)))
 
     # Any filesnames with spaces should get escaped with quotes automatically.
     # Using keyword arguments here.
@@ -159,7 +158,7 @@ for input_file in ["Quality/example.fasta", "Clustalw/temp horses.fasta"]:
         for clade in tree.find_clades():
             if clade.name:
                 if clade.name in names:
-                    raise ValueError("Duplicate key: %s" % clade.name)
+                    raise ValueError("Duplicate key: {0!s}".format(clade.name))
                 names[clade.name] = clade
         return names
 

--- a/Tests/test_GACrossover.py
+++ b/Tests/test_GACrossover.py
@@ -347,7 +347,7 @@ class TestCrossover(object):
             new_org1_genome = str(int(org1_genome) + 1)
             new_org2_genome = str(int(org2_genome) + 1)
         else:
-            raise ValueError("Got type %s" % self.type)
+            raise ValueError("Got type {0!s}".format(self.type))
 
         new_org_1.genome = MutableSeq(new_org1_genome,
                                       org_1.genome.alphabet)

--- a/Tests/test_GAMutation.py
+++ b/Tests/test_GAMutation.py
@@ -142,7 +142,7 @@ class TestMutator(object):
                                         org_genome_seq.alphabet)
             return new_org
         else:
-            raise ValueError("Got type %s" % self.type)
+            raise ValueError("Got type {0!s}".format(self.type))
 
 
 class SafeFitnessTest(unittest.TestCase):

--- a/Tests/test_GAOrganism.py
+++ b/Tests/test_GAOrganism.py
@@ -48,16 +48,15 @@ class CreatePopulationTest(unittest.TestCase):
         new_pop = Organism.function_population(genome_generator,
                                                num_orgs, fitness_calculator)
 
-        assert len(new_pop) == num_orgs, "Expected %s organisms, got %s" \
-               % (num_orgs, len(new_pops))
+        assert len(new_pop) == num_orgs, "Expected {0!s} organisms, got {1!s}".format(num_orgs, len(new_pops))
 
         for org in new_pop:
             assert isinstance(org, Organism.Organism), \
-                   "Expected to get an organism, got %r" % org
+                   "Expected to get an organism, got {0!r}".format(org)
 
             exp_fit = fitness_calculator(org.genome)
             assert org.fitness == exp_fit, \
-                   "Expected fitness of %s, got %s" % (org.fitness, exp_fit)
+                   "Expected fitness of {0!s}, got {1!s}".format(org.fitness, exp_fit)
 
     def test_random_population(self):
         """Create a population randomly from a alphabet.
@@ -67,19 +66,18 @@ class CreatePopulationTest(unittest.TestCase):
         new_pop = Organism.random_population(self.alphabet, genome_size,
                                              num_orgs, fitness_calculator)
 
-        assert len(new_pop) == num_orgs, "Expected %s organisms, got %s" \
-               % (num_orgs, len(new_pops))
+        assert len(new_pop) == num_orgs, "Expected {0!s} organisms, got {1!s}".format(num_orgs, len(new_pops))
 
         for org in new_pop:
             assert isinstance(org, Organism.Organism), \
-                   "Expected to get an organism, got %r" % org
+                   "Expected to get an organism, got {0!r}".format(org)
 
             exp_fit = fitness_calculator(org.genome)
             assert org.fitness == exp_fit, \
-                   "Expected fitness of %s, got %s" % (org.fitness, exp_fit)
+                   "Expected fitness of {0!s}, got {1!s}".format(org.fitness, exp_fit)
 
             assert len(org.genome) == genome_size, \
-                   "Expected genome size of %s, got %s" % (len(org.genome),
+                   "Expected genome size of {0!s}, got {1!s}".format(len(org.genome),
                                                            genome_size)
 
     def test_random_population_types(self):
@@ -132,14 +130,14 @@ class OrganismTest(unittest.TestCase):
         """Test the ability to deal with the fitness of the genome.
         """
         assert self.organism.fitness == 1234, \
-               "Unexpected fitness %s" % self.organism.fitness
+               "Unexpected fitness {0!s}".format(self.organism.fitness)
 
         new_genome = MutableSeq("1111", self.alphabet)
         self.organism.genome = new_genome
         self.organism.recalculate_fitness()
 
         assert self.organism.fitness == 1111, \
-               "Unexpected fitness %s" % self.organism.fitness
+               "Unexpected fitness {0!s}".format(self.organism.fitness)
 
     def test_organism_copy(self):
         """Test copying of organisms.

--- a/Tests/test_GAQueens.py
+++ b/Tests/test_GAQueens.py
@@ -40,10 +40,10 @@ VERBOSE = 0
 
 def main(num_queens):
 
-    print("Calculating for %s queens..." % num_queens)
+    print("Calculating for {0!s} queens...".format(num_queens))
 
     num_orgs = 1000
-    print("Generating an initial population of %s organisms..." % num_orgs)
+    print("Generating an initial population of {0!s} organisms...".format(num_orgs))
     queen_alphabet = QueensAlphabet(num_queens)
 
     start_population = Organism.random_population(queen_alphabet, num_queens,
@@ -70,9 +70,9 @@ def main(num_queens):
                 unique_solutions.append(org)
 
     if VERBOSE:
-        print("Search started at %s and ended at %s" % (start_time, end_time))
+        print("Search started at {0!s} and ended at {1!s}".format(start_time, end_time))
         for orgm in unique_solutions:
-            print("We did it! %s" % org)
+            print("We did it! {0!s}".format(org))
             display_board(org.genome)
 
 

--- a/Tests/test_GARepair.py
+++ b/Tests/test_GARepair.py
@@ -53,7 +53,7 @@ class AmbiguousRepairTest(unittest.TestCase):
             new_genome_seq = new_org.genome.toseq()
 
             assert new_genome_seq.count("*") == 2, \
-                   "Did not repair genome, got %s" % str(new_genome_seq)
+                   "Did not repair genome, got {0!s}".format(str(new_genome_seq))
 
     def test_multiple_repair(self):
         """Test repair of multiple ambiguous positions in a genome.
@@ -65,7 +65,7 @@ class AmbiguousRepairTest(unittest.TestCase):
             new_genome_seq = new_org.genome.toseq()
 
             assert new_genome_seq.count("*") == 0, \
-                   "Did not repair genome, got %s" % str(new_genome_seq)
+                   "Did not repair genome, got {0!s}".format(str(new_genome_seq))
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)

--- a/Tests/test_GASelection.py
+++ b/Tests/test_GASelection.py
@@ -99,7 +99,7 @@ class DiversitySelectionTest(unittest.TestCase):
 
         new_org = self.selector._get_new_organism(new_pop, old_pop)
         self.assertEqual(new_org, org,
-                         "Got an unexpected organism %s" % new_org)
+                         "Got an unexpected organism {0!s}".format(new_org))
 
     def test_no_retrieve_organism(self):
         """Test not getting an organism already in the new population."""

--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -63,7 +63,7 @@ print("Testing parsers...")
 for parser in all_parsers:
     for filename in files_to_parse:
         if not os.path.isfile(filename):
-            print("Missing test input file: %s" % filename)
+            print("Missing test input file: {0!s}".format(filename))
             continue
 
         handle = open(filename, 'r')
@@ -79,19 +79,18 @@ for parser in all_parsers:
                 break
 
             if isinstance(parser, GenBank.FeatureParser):
-                print("***Record from %s with the FeatureParser"
-                      % filename.split(os.path.sep)[-1])
-                print("Seq: %r" % cur_record.seq)
-                print("Id: %s" % cur_record.id)
-                print("Name: %s" % cur_record.name)
-                print("Description %s" % cur_record.description)
+                print("***Record from {0!s} with the FeatureParser".format(filename.split(os.path.sep)[-1]))
+                print("Seq: {0!r}".format(cur_record.seq))
+                print("Id: {0!s}".format(cur_record.id))
+                print("Name: {0!s}".format(cur_record.name))
+                print("Description {0!s}".format(cur_record.description))
                 print("Annotations***")
                 ann_keys = sorted(cur_record.annotations)
                 for ann_key in ann_keys:
                     if ann_key != 'references':
-                        print("Key: %s" % ann_key)
-                        print("Value: %s" %
-                              cur_record.annotations[ann_key])
+                        print("Key: {0!s}".format(ann_key))
+                        print("Value: {0!s}".format(
+                              cur_record.annotations[ann_key]))
                     else:
                         print("References*")
                         for reference in cur_record.annotations[ann_key]:
@@ -105,23 +104,22 @@ for parser in all_parsers:
                     else:
                         # Assuming no mixed strand examples...
                         assert feature.strand is not None
-                print("DB cross refs %s" % cur_record.dbxrefs)
+                print("DB cross refs {0!s}".format(cur_record.dbxrefs))
             elif isinstance(parser, GenBank.RecordParser):
-                print("***Record from %s with the RecordParser"
-                      % filename.split(os.path.sep)[-1])
-                print("sequence length: %i" % len(cur_record.sequence))
-                print("locus: %s" % cur_record.locus)
-                print("definition: %s" % cur_record.definition)
-                print("accession: %s" % cur_record.accession)
+                print("***Record from {0!s} with the RecordParser".format(filename.split(os.path.sep)[-1]))
+                print("sequence length: {0:d}".format(len(cur_record.sequence)))
+                print("locus: {0!s}".format(cur_record.locus))
+                print("definition: {0!s}".format(cur_record.definition))
+                print("accession: {0!s}".format(cur_record.accession))
                 for reference in cur_record.references:
-                    print("reference title: %s" % reference.title)
+                    print("reference title: {0!s}".format(reference.title))
 
                 for feature in cur_record.features:
-                    print("feature key: %s" % feature.key)
-                    print("location: %s" % feature.location)
-                    print("num qualifiers: %i" % len(feature.qualifiers))
+                    print("feature key: {0!s}".format(feature.key))
+                    print("location: {0!s}".format(feature.location))
+                    print("num qualifiers: {0:d}".format(len(feature.qualifiers)))
                     for qualifier in feature.qualifiers:
-                        print("key: %s value: %s" % (qualifier.key, qualifier.value))
+                        print("key: {0!s} value: {1!s}".format(qualifier.key, qualifier.value))
 
         handle.close()
 
@@ -145,21 +143,20 @@ def do_comparison(good_record, test_record):
         if not(good_line) and not(test_line):
             break
         if not(good_line):
-            raise AssertionError("Extra info in Test: %r" % test_line)
+            raise AssertionError("Extra info in Test: {0!r}".format(test_line))
         if not(test_line):
-            raise AssertionError("Extra info in Expected: %r" % good_line)
+            raise AssertionError("Extra info in Expected: {0!r}".format(good_line))
         test_normalized = ' '.join(x for x in test_line.split() if x)
         good_normalized = ' '.join(x for x in good_line.split() if x)
         assert test_normalized == good_normalized, \
-               "Expected does not match Test.\nExpect: %r\nTest:   %r\n" % \
-               (good_line, test_line)
+               "Expected does not match Test.\nExpect: {0!r}\nTest:   {1!r}\n".format(good_line, test_line)
 
 
 def t_write_format():
     record_parser = GenBank.RecordParser(debug_level=0)
 
     for file in write_format_files:
-        print("Testing GenBank writing for %s..." % os.path.basename(file))
+        print("Testing GenBank writing for {0!s}...".format(os.path.basename(file)))
         cur_handle = open(os.path.join("GenBank", file), "r")
         compare_handle = open(os.path.join("GenBank", file), "r")
 
@@ -173,7 +170,7 @@ def t_write_format():
             if cur_record is None or compare_record is None:
                 break
 
-            print("\tTesting for %s" % cur_record.version)
+            print("\tTesting for {0!s}".format(cur_record.version))
 
             output_record = str(cur_record) + "\n"
             do_comparison(compare_record, output_record)

--- a/Tests/test_GenomeDiagram.py
+++ b/Tests/test_GenomeDiagram.py
@@ -405,7 +405,7 @@ class SigilsTest(unittest.TestCase):
     def test_all_sigils(self):
         """All sigils."""
         for glyph in ["BOX", "OCTO", "JAGGY", "ARROW", "BIGARROW"]:
-            self.add_track_with_sigils(track_caption='  sigil="%s"' % glyph,
+            self.add_track_with_sigils(track_caption='  sigil="{0!s}"'.format(glyph),
                                        sigil=glyph)
         self.finish("GD_sigils")
 
@@ -545,7 +545,7 @@ class SigilsTest(unittest.TestCase):
         self.gds_features.add_feature(feature, color="lightgreen")
         self.gds_features.add_feature(feature, name="Standless", sigil=glyph,
                                       color="green", arrowhead_length=2.0)
-        self.finish("GD_sigil_long_%s" % glyph)
+        self.finish("GD_sigil_long_{0!s}".format(glyph))
 
     def test_long_arrow_heads(self):
         """Feature ARROW sigil heads within bounding box."""
@@ -642,14 +642,14 @@ class DiagramTest(unittest.TestCase):
             try:
                 gdd.write(filename, output)
                 assert False, \
-                    "Should have rejected %s as an output format" % output
+                    "Should have rejected {0!s} as an output format".format(output)
             except ValueError:
                 # Good!
                 pass
             try:
                 gdd.write_to_string(output)
                 assert False, \
-                    "Should have rejected %s as an output format" % output
+                    "Should have rejected {0!s} as an output format".format(output)
             except ValueError:
                 # Good!
                 pass
@@ -689,7 +689,7 @@ class DiagramTest(unittest.TestCase):
             # of ReportLab.  You need ReportLab 2.4 or later
             try:
                 url = "http://www.ncbi.nlm.nih.gov/entrez/viewer.fcgi" +\
-                      "?db=protein&id=%s" % feature.qualifiers["protein_id"][0]
+                      "?db=protein&id={0!s}".format(feature.qualifiers["protein_id"][0])
             except KeyError:
                 url = None
 
@@ -777,7 +777,7 @@ class DiagramTest(unittest.TestCase):
                 # of ReportLab.  You need ReportLab 2.4 or later
                 try:
                     url = "http://www.ncbi.nlm.nih.gov/entrez/viewer.fcgi" +\
-                          "?db=protein&id=%s" % feature.qualifiers["protein_id"][0]
+                          "?db=protein&id={0!s}".format(feature.qualifiers["protein_id"][0])
                 except KeyError:
                     url = None
 

--- a/Tests/test_GraphicsChromosome.py
+++ b/Tests/test_GraphicsChromosome.py
@@ -249,16 +249,15 @@ class OrganismGraphicTest(unittest.TestCase):
         sys.stdout = save_stdout
 
         self.assertTrue(expected_string in properties,
-               "Unexpected results from dumpProperties: \n %s" % properties)
+               "Unexpected results from dumpProperties: \n {0!s}".format(properties))
 
         properties = test_widget.getProperties()
         self.assertEqual(properties["label_size"], 6,
-               "Unexpected results from getProperties: %s" % properties)
+               "Unexpected results from getProperties: {0!s}".format(properties))
 
         test_widget.setProperties({"start_x_position": 12})
         self.assertEqual(test_widget.start_x_position, 12,
-               "setProperties doesn't seem to work right: %s"
-               % test_widget.start_x_position)
+               "setProperties doesn't seem to work right: {0!s}".format(test_widget.start_x_position))
 
 
 class OrganismSubAnnotationsTest(unittest.TestCase):
@@ -288,7 +287,7 @@ class OrganismSubAnnotationsTest(unittest.TestCase):
         for name, acc, length, features, color in entries:
             if False:
                 # How I generated the values above... and tested passing in SeqFeatures
-                filename = "/Users/pjcock/Documents/comp_genomics/seed/%s.gbk" % acc
+                filename = "/Users/pjcock/Documents/comp_genomics/seed/{0!s}.gbk".format(acc)
                 import os
                 if not os.path.isfile(filename):
                     continue
@@ -416,10 +415,10 @@ class ChromosomeCountTest(unittest.TestCase):
         """Retrieve a color from a count number with the default color scheme.
         """
         test_color = self.count_display._color_from_count(3)
-        assert test_color == colors.blue, "Unexpected color %s" % test_color
+        assert test_color == colors.blue, "Unexpected color {0!s}".format(test_color)
 
         test_color = self.count_display._color_from_count(9)
-        assert test_color == colors.red, "Unexpected color %s" % test_color
+        assert test_color == colors.red, "Unexpected color {0!s}".format(test_color)
 
         try:
             self.count_display._color_from_count(200)

--- a/Tests/test_GraphicsDistribution.py
+++ b/Tests/test_GraphicsDistribution.py
@@ -75,7 +75,7 @@ class BarChartTest(unittest.TestCase):
             dist_info.append(new_info)
 
             distribution = BarChartDistribution(dist_info)
-            distribution.chart_title = "Distribution %s" % (multi + 1)
+            distribution.chart_title = "Distribution {0!s}".format((multi + 1))
             dist_page.distributions.append(distribution)
 
         dist_page.draw(self.multi_page, "Test Multi Bar Chart")

--- a/Tests/test_HMMCasino.py
+++ b/Tests/test_HMMCasino.py
@@ -80,7 +80,7 @@ def _loaded_dice_roll(chance_num, cur_state):
         else:
             return '6'
     else:
-        raise ValueError("Unexpected cur_state %s" % cur_state)
+        raise ValueError("Unexpected cur_state {0!s}".format(cur_state))
 
 
 def generate_rolls(num_rolls):
@@ -161,7 +161,7 @@ def stop_training(log_likelihood_change, num_iterations):
     """Tell the training model when to stop.
     """
     if VERBOSE:
-        print("ll change: %f" % log_likelihood_change)
+        print("ll change: {0:f}".format(log_likelihood_change))
     if log_likelihood_change < 0.01:
         return 1
     elif num_iterations >= 10:
@@ -184,7 +184,7 @@ test_rolls, test_states = generate_rolls(300)
 
 predicted_states, prob = trained_mm.viterbi(test_rolls, DiceTypeAlphabet())
 if VERBOSE:
-    print("Prediction probability: %f" % prob)
+    print("Prediction probability: {0:f}".format(prob))
     Utilities.pretty_print_prediction(test_rolls, test_states, predicted_states)
 
 # -- Baum-Welch training without known state sequences
@@ -202,5 +202,5 @@ test_rolls, test_states = generate_rolls(300)
 
 predicted_states, prob = trained_mm.viterbi(test_rolls, DiceTypeAlphabet())
 if VERBOSE:
-    print("Prediction probability: %f" % prob)
+    print("Prediction probability: {0:f}".format(prob))
     Utilities.pretty_print_prediction(test_rolls, test_states, predicted_states)

--- a/Tests/test_HMMGeneral.py
+++ b/Tests/test_HMMGeneral.py
@@ -37,8 +37,7 @@ class LetterAlphabet(Alphabet.Alphabet):
 def test_assertion(name, result, expected):
     """Helper function to test an assertion and print out a reasonable error.
     """
-    assert result == expected, "Expected %s, got %s for %s" \
-           % (expected, result, name)
+    assert result == expected, "Expected {0!s}, got {1!s} for {2!s}".format(expected, result, name)
 
 
 class MarkovModelBuilderTest(unittest.TestCase):
@@ -414,7 +413,7 @@ class AbstractTrainerTest(unittest.TestCase):
 
         for test_result in result_tests:
             assert results[test_result[0]] == test_result[1], \
-                   "Got %f, expected %f for %s" % (results[test_result[0]],
+                   "Got {0:f}, expected {1:f} for {2!s}".format(results[test_result[0]],
                                                    test_result[1],
                                                    test_result[0])
 
@@ -426,7 +425,7 @@ class AbstractTrainerTest(unittest.TestCase):
         log_prob = self.test_trainer.log_likelihood(probs)
         expected_log_prob = -7.31873556778
         assert abs(expected_log_prob - log_prob) < 0.1, \
-          "Bad probability calculated: %s" % log_prob
+          "Bad probability calculated: {0!s}".format(log_prob)
 
 # run the tests
 if __name__ == "__main__":

--- a/Tests/test_KGML_graphics.py
+++ b/Tests/test_KGML_graphics.py
@@ -55,12 +55,12 @@ __docformat__ = "restructuredtext en"
 class PathwayData(object):
     """Convenience structure for testing pathway data"""
     def __init__(self, name, element_counts, show_pathway_image=False):
-        self.infilename = os.path.join("KEGG", "ko%s.xml" % name)
-        self.outfilename = os.path.join("KEGG", "ko%s.kgml" % name)
+        self.infilename = os.path.join("KEGG", "ko{0!s}.xml".format(name))
+        self.outfilename = os.path.join("KEGG", "ko{0!s}.kgml".format(name))
         self.element_counts = element_counts
-        self.pathway_image = os.path.join("KEGG", "map%s.png" % name)
+        self.pathway_image = os.path.join("KEGG", "map{0!s}.png".format(name))
         self.show_pathway_image = show_pathway_image
-        self.output_stem = "Graphics/map%s" % name
+        self.output_stem = "Graphics/map{0!s}".format(name)
 
 
 class KGMLPathwayTest(unittest.TestCase):

--- a/Tests/test_Location.py
+++ b/Tests/test_Location.py
@@ -24,12 +24,12 @@ between_pos_e = SeqFeature.BetweenPosition(24, left=20, right=24)
 before_pos = SeqFeature.BeforePosition(15)
 after_pos = SeqFeature.AfterPosition(40)
 
-print("Exact: %s" % exact_pos)
-print("Within (as start, %i): %s" % (int(within_pos_s), within_pos_s))
-print("Within (as end, %i): %s" % (int(within_pos_e), within_pos_e))
-print("Between (as end, %i): %s" % (int(between_pos_e), between_pos_e))
-print("Before: %s" % before_pos)
-print("After: %s" % after_pos)
+print("Exact: {0!s}".format(exact_pos))
+print("Within (as start, {0:d}): {1!s}".format(int(within_pos_s), within_pos_s))
+print("Within (as end, {0:d}): {1!s}".format(int(within_pos_e), within_pos_e))
+print("Between (as end, {0:d}): {1!s}".format(int(between_pos_e), between_pos_e))
+print("Before: {0!s}".format(before_pos))
+print("After: {0!s}".format(after_pos))
 
 # put these into Locations
 location1 = SeqFeature.FeatureLocation(exact_pos, within_pos_e)
@@ -37,13 +37,13 @@ location2 = SeqFeature.FeatureLocation(before_pos, between_pos_e)
 location3 = SeqFeature.FeatureLocation(within_pos_s, after_pos)
 
 for location in [location1, location2, location3]:
-    print("Location: %s" % location)
-    print("   Start: %s" % location.start)
-    print("   End  : %s" % location.end)
+    print("Location: {0!s}".format(location))
+    print("   Start: {0!s}".format(location.start))
+    print("   End  : {0!s}".format(location.end))
 
 # --- test non-fuzzy represenations
 print("Testing non-fuzzy representations...")
 for location in [location1, location2, location3]:
-    print("Location: %s" % location)
-    print("  Non-Fuzzy Start: %s" % location.nofuzzy_start)
-    print("  Non-Fuzzy End: %s" % location.nofuzzy_end)
+    print("Location: {0!s}".format(location))
+    print("  Non-Fuzzy Start: {0!s}".format(location.nofuzzy_start))
+    print("  Non-Fuzzy End: {0!s}".format(location.nofuzzy_end))

--- a/Tests/test_MSAProbs_tool.py
+++ b/Tests/test_MSAProbs_tool.py
@@ -74,7 +74,7 @@ class MSAProbsTestErrorConditions(MSAProbsTestCase):
                             "Cannot open input file" in str(err) or
                             "Non-zero return code " in str(err), str(err))
         else:
-            self.fail("Should have failed, returned:\n%s\n%s" % (stdout, stderr))
+            self.fail("Should have failed, returned:\n{0!s}\n{1!s}".format(stdout, stderr))
 
     def test_single_sequence(self):
         """Test an input file containing a single sequence."""
@@ -91,7 +91,7 @@ class MSAProbsTestErrorConditions(MSAProbsTestCase):
                 expected = 139  # TODO: Check return codes on various other platforms
             self.assertEqual(expected, err.returncode)
         else:
-            self.fail("Should have failed, returned:\n%s\n%s" % (stdout, stderr))
+            self.fail("Should have failed, returned:\n{0!s}\n{1!s}".format(stdout, stderr))
 
     def test_invalid_format(self):
         """Test an input file in an invalid format."""
@@ -103,7 +103,7 @@ class MSAProbsTestErrorConditions(MSAProbsTestCase):
         except ApplicationError as err:
             self.assertEqual(err.returncode, 1)
         else:
-            self.fail("Should have failed, returned:\n%s\n%s" % (stdout, stderr))
+            self.fail("Should have failed, returned:\n{0!s}\n{1!s}".format(stdout, stderr))
 
 #################################################################
 

--- a/Tests/test_Mafft_tool.py
+++ b/Tests/test_Mafft_tool.py
@@ -33,7 +33,7 @@ if not mafft_exe:
 
 
 def check_mafft_version(mafft_exe):
-    child = subprocess.Popen("%s --help" % mafft_exe,
+    child = subprocess.Popen("{0!s} --help".format(mafft_exe),
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE,
                              universal_newlines=True,

--- a/Tests/test_NCBI_BLAST_tools.py
+++ b/Tests/test_NCBI_BLAST_tools.py
@@ -98,8 +98,7 @@ class Pairwise(unittest.TestCase):
                                  shell=(sys.platform != "win32"))
         stdoutdata, stderrdata = child.communicate()
         return_code = child.returncode
-        self.assertEqual(return_code, 0, "Got error code %i back from:\n%s"
-                         % (return_code, cline))
+        self.assertEqual(return_code, 0, "Got error code {0:d} back from:\n{1!s}".format(return_code, cline))
         self.assertEqual(10, stdoutdata.count("Query= "))
         if stdoutdata.count("***** No hits found *****") == 7:
             # This happens with BLAST 2.2.26+ which is potentially a bug
@@ -128,8 +127,7 @@ class Pairwise(unittest.TestCase):
                                  shell=(sys.platform != "win32"))
         stdoutdata, stderrdata = child.communicate()
         return_code = child.returncode
-        self.assertEqual(return_code, 0, "Got error code %i back from:\n%s"
-                         % (return_code, cline))
+        self.assertEqual(return_code, 0, "Got error code {0:d} back from:\n{1!s}".format(return_code, cline))
         self.assertEqual(10, stdoutdata.count("Query= "))
         self.assertEqual(0, stdoutdata.count("***** No hits found *****"))
         # TODO - Parse it?
@@ -151,8 +149,7 @@ class Pairwise(unittest.TestCase):
                                  shell=(sys.platform != "win32"))
         stdoutdata, stderrdata = child.communicate()
         return_code = child.returncode
-        self.assertEqual(return_code, 0, "Got error code %i back from:\n%s"
-                         % (return_code, cline))
+        self.assertEqual(return_code, 0, "Got error code {0:d} back from:\n{1!s}".format(return_code, cline))
         self.assertEqual(10, stdoutdata.count("Query= "))
         self.assertEqual(0, stdoutdata.count("***** No hits found *****"))
         # TODO - Parse it?
@@ -174,7 +171,7 @@ class CheckCompleteArgList(unittest.TestCase):
                                  shell=(sys.platform != "win32"))
         stdoutdata, stderrdata = child.communicate()
         self.assertEqual(stderrdata, "",
-                         "%s\n%s" % (str(cline), stderrdata))
+                         "{0!s}\n{1!s}".format(str(cline), stderrdata))
         names_in_tool = set()
         while stdoutdata:
             index = stdoutdata.find("[")

--- a/Tests/test_NCBI_qblast.py
+++ b/Tests/test_NCBI_qblast.py
@@ -121,8 +121,7 @@ class TestQblast(unittest.TestCase):
                 for alignment in record.alignments:
                     print(alignment.hit_id)
             self.assertTrue(found_result,
-                            "Missing all expected hits (%s), instead have: %s"
-                            % (", ".join(expected_hits),
+                            "Missing all expected hits ({0!s}), instead have: {1!s}".format(", ".join(expected_hits),
                                ", ".join(a.hit_id for a in record.alignments)))
 
         # Check the expected result(s) are found in the descriptions
@@ -137,7 +136,7 @@ class TestQblast(unittest.TestCase):
                             or expected_hit in descr.title.split(None, 1)[0].split("|"):
                         found_result = True
                         break
-            assert found_result, "Missing all of %s in descriptions" % expected_hit
+            assert found_result, "Missing all of {0!s} in descriptions".format(expected_hit)
             self.assertTrue(found_result)
 
     def test_parse_qblast_ref_page(self):

--- a/Tests/test_NNExclusiveOr.py
+++ b/Tests/test_NNExclusiveOr.py
@@ -46,7 +46,7 @@ def main():
     for example in examples:
         prediction = network.predict(example.inputs)
         if VERBOSE:
-            print("%s;%s=> %s" % (example.inputs, example.outputs, prediction))
+            print("{0!s};{1!s}=> {2!s}".format(example.inputs, example.outputs, prediction))
 
 
 def stopping_criteria(num_iterations, validation_error, training_error):
@@ -54,7 +54,7 @@ def stopping_criteria(num_iterations, validation_error, training_error):
     """
     if num_iterations % 100 == 0:
         if VERBOSE:
-            print("error: %s" % validation_error)
+            print("error: {0!s}".format(validation_error))
     if num_iterations >= 2000:
         return True
     return False

--- a/Tests/test_NNGene.py
+++ b/Tests/test_NNGene.py
@@ -61,8 +61,7 @@ class PatternIOTest(unittest.TestCase):
         read_motifs = self.pattern_io.read(input_handle)
         input_handle.close()
         self.assertEqual(read_motifs, motifs,
-                         "Failed to get back expected motifs %s, got %s"
-                         % (motifs, read_motifs))
+                         "Failed to get back expected motifs {0!s}, got {1!s}".format(motifs, read_motifs))
 
         # write seqs
         seq_motifs = []
@@ -77,8 +76,7 @@ class PatternIOTest(unittest.TestCase):
         read_motifs = self.pattern_io.read(input_handle)
         input_handle.close()
         self.assertEqual(read_motifs, motifs,
-                         "Failed to get back expected motifs %s from seqs, got %s"
-                         % (motifs, read_motifs))
+                         "Failed to get back expected motifs {0!s} from seqs, got {1!s}".format(motifs, read_motifs))
 
     def test_schema(self):
         """Reading and writing schemas to a file.
@@ -94,8 +92,7 @@ class PatternIOTest(unittest.TestCase):
         read_schemas = self.pattern_io.read(input_handle)
         input_handle.close()
         self.assertEqual(schemas, read_schemas,
-                         "Read incorrect schemas %s, expected %s."
-                         % (read_schemas, schemas))
+                         "Read incorrect schemas {0!s}, expected {1!s}.".format(read_schemas, schemas))
 
         # --- make sure inappropriate alphabets are reported
         schemas = ["GTR", "G*C"]  # '*' not in the unambigous alphabet
@@ -126,8 +123,7 @@ class PatternIOTest(unittest.TestCase):
         read_sigs = self.pattern_io.read(input_handle)
         input_handle.close()
         self.assertEqual(read_sigs, signatures,
-                         "Got back unexpected signatures %s, wanted %s"
-                         % (read_sigs, signatures))
+                         "Got back unexpected signatures {0!s}, wanted {1!s}".format(read_sigs, signatures))
 
 
 class PatternRepositoryTest(unittest.TestCase):
@@ -149,7 +145,7 @@ class PatternRepositoryTest(unittest.TestCase):
 
         self.assertEqual(all_motifs,
                          ["GATC", "GGGG", "GTAG", "AAAA", "ATAT"],
-                         "Unexpected motifs returned %s" % all_motifs)
+                         "Unexpected motifs returned {0!s}".format(all_motifs))
 
     def test_get_random(self):
         """Retrieve random patterns from the repository.
@@ -157,12 +153,11 @@ class PatternRepositoryTest(unittest.TestCase):
         for num_patterns in range(5):
             patterns = self.repository.get_random(num_patterns)
             self.assertEqual(len(patterns), num_patterns,
-                             "Got unexpected number of patterns %s, expected %s"
-                             % (len(patterns), num_patterns))
+                             "Got unexpected number of patterns {0!s}, expected {1!s}".format(len(patterns), num_patterns))
 
             for pattern in patterns:
                 self.assertTrue(pattern in list(self.motifs.keys()),
-                                "Got unexpected pattern %s" % pattern)
+                                "Got unexpected pattern {0!s}".format(pattern))
 
     def test_get_top_percentage(self):
         """Retrieve the top percentge of patterns from the repository.
@@ -170,12 +165,11 @@ class PatternRepositoryTest(unittest.TestCase):
         for num_patterns, percentage in ((1, 0.2), (2, .4), (5, 1.0)):
             patterns = self.repository.get_top_percentage(percentage)
             self.assertEqual(len(patterns), num_patterns,
-                             "Got unexpected number of patterns %s, expected %s"
-                             % (len(patterns), num_patterns))
+                             "Got unexpected number of patterns {0!s}, expected {1!s}".format(len(patterns), num_patterns))
 
             for pattern in patterns:
                 self.assertTrue(pattern in list(self.motifs.keys()),
-                                "Got unexpected pattern %s" % pattern)
+                                "Got unexpected pattern {0!s}".format(pattern))
 
     def test_get_top(self):
         """Retrieve a certain number of the top patterns.
@@ -183,12 +177,11 @@ class PatternRepositoryTest(unittest.TestCase):
         for num_patterns in range(5):
             patterns = self.repository.get_top(num_patterns)
             self.assertEqual(len(patterns), num_patterns,
-                             "Got unexpected number of patterns %s, expected %s"
-                             % (len(patterns), num_patterns))
+                             "Got unexpected number of patterns {0!s}, expected {1!s}".format(len(patterns), num_patterns))
 
             for pattern in patterns:
                 self.assertTrue(pattern in list(self.motifs.keys()),
-                                "Got unexpected pattern %s" % pattern)
+                                "Got unexpected pattern {0!s}".format(pattern))
 
     def test_get_differing(self):
         """Retrieve patterns from both sides of the list (top and bottom).
@@ -196,34 +189,34 @@ class PatternRepositoryTest(unittest.TestCase):
         patterns = self.repository.get_differing(2, 2)
         self.assertEqual(patterns,
                          ["GATC", "GGGG", "AAAA", "ATAT"],
-                         "Got unexpected patterns %s" % patterns)
+                         "Got unexpected patterns {0!s}".format(patterns))
 
     def test_remove_polyA(self):
         """Test the ability to remove A rich patterns from the repository.
         """
         patterns = self.repository.get_all()
         self.assertEqual(len(patterns), 5,
-                         "Unexpected starting: %s" % patterns)
+                         "Unexpected starting: {0!s}".format(patterns))
 
         self.repository.remove_polyA()
 
         patterns = self.repository.get_all()
         self.assertEqual(len(patterns), 3,
-                         "Unexpected ending: %s" % patterns)
+                         "Unexpected ending: {0!s}".format(patterns))
         self.assertEqual(patterns,
                          ["GATC", "GGGG", "GTAG"],
-                         "Unexpected patterns: %s" % patterns)
+                         "Unexpected patterns: {0!s}".format(patterns))
 
     def test_count(self):
         """Retrieve counts for particular patterns in the repository.
         """
         num_times = self.repository.count("GGGG")
         self.assertEqual(num_times, 10,
-                         "Did not count item in the respository: %s" % num_times)
+                         "Did not count item in the respository: {0!s}".format(num_times))
 
         num_times = self.repository.count("NOT_IN_THERE")
         self.assertEqual(num_times, 0,
-                         "Counted items not in repository: %s" % num_times)
+                         "Counted items not in repository: {0!s}".format(num_times))
 
 
 # --- Tests for motifs
@@ -267,7 +260,7 @@ class MotifFinderTest(unittest.TestCase):
         top_motif = motif_repository.get_top(1)
 
         self.assertEqual(top_motif[0], 'TTGGAAAG',
-                         "Got unexpected motif %s" % top_motif[0])
+                         "Got unexpected motif {0!s}".format(top_motif[0]))
 
     def test_find_differences(self):
         """Find the difference in motif counts between two sets of sequences.
@@ -279,9 +272,9 @@ class MotifFinderTest(unittest.TestCase):
         top, bottom = motif_repository.get_differing(1, 1)
 
         self.assertEqual(top, "TTGGAAAG",
-                         "Got unexpected top motif %s" % top)
+                         "Got unexpected top motif {0!s}".format(top))
         self.assertEqual(bottom, "AATGGCAT",
-                         "Got unexpected bottom motif %s" % bottom)
+                         "Got unexpected bottom motif {0!s}".format(bottom))
 
 
 class MotifCoderTest(unittest.TestCase):
@@ -303,8 +296,7 @@ class MotifCoderTest(unittest.TestCase):
             matches = self.coder.representation(seq_to_code)
 
             self.assertEqual(matches, expected,
-                             "Did not match representation, expected %s, got %s"
-                             % (expected, matches))
+                             "Did not match representation, expected {0!s}, got {1!s}".format(expected, matches))
 
 
 # --- Tests for schemas
@@ -336,8 +328,7 @@ class SchemaTest(unittest.TestCase):
             found_matches = self.motif_coder.find_matches(motif,
                                                           self.match_string)
             self.assertEqual(found_matches, expected,
-                             "Expected %s, got %s"
-                             % (expected, found_matches))
+                             "Expected {0!s}, got {1!s}".format(expected, found_matches))
 
     def test_num_matches(self):
         """Find how many matches are present in a sequence.
@@ -346,8 +337,7 @@ class SchemaTest(unittest.TestCase):
             num_matches = self.motif_coder.num_matches(motif,
                                                        self.match_string)
             self.assertEqual(num_matches, len(expected),
-                             "Expected %s, got %s"
-                             % (num_matches, len(expected)))
+                             "Expected {0!s}, got {1!s}".format(num_matches, len(expected)))
 
     def test_find_ambiguous(self):
         """Find the positions of ambiguous items in a sequence.
@@ -360,8 +350,7 @@ class SchemaTest(unittest.TestCase):
         for motif, expected in ambig_info:
             found_positions = self.motif_coder.find_ambiguous(motif)
             self.assertEqual(found_positions, expected,
-                             "Expected %s, got %s for %s"
-                             % (expected, found_positions, motif))
+                             "Expected {0!s}, got {1!s} for {2!s}".format(expected, found_positions, motif))
 
     def test_num_ambiguous(self):
         """Find the number of ambiguous items in a sequence.
@@ -374,8 +363,7 @@ class SchemaTest(unittest.TestCase):
         for motif, expected in ambig_info:
             found_num = self.motif_coder.num_ambiguous(motif)
             self.assertEqual(found_num, expected,
-                             "Expected %s, got %s for %s"
-                             % (expected, found_num, motif))
+                             "Expected {0!s}, got {1!s} for {2!s}".format(expected, found_num, motif))
 
     def test_motif_cache(self):
         """Make sure motif compiled regular expressions are cached properly.
@@ -397,7 +385,7 @@ class SchemaTest(unittest.TestCase):
 
         expected = ["A", "C", "G", "T"]
         self.assertEqual(found_unambig, expected,
-                         "Got %s, expected %s" % (found_unambig, expected))
+                         "Got {0!s}, expected {1!s}".format(found_unambig, expected))
 
 
 class SchemaFinderTest(unittest.TestCase):
@@ -477,14 +465,14 @@ class SchemaCoderTest(unittest.TestCase):
             match_seq = Seq(match_string, IUPAC.unambiguous_dna)
             found_rep = self.motif_coder.representation(match_seq)
             self.assertEqual(found_rep, expected,
-                             "Got %s, expected %s" % (found_rep, expected))
+                             "Got {0!s}, expected {1!s}".format(found_rep, expected))
 
 
 class SchemaMatchingTest(unittest.TestCase):
     """Matching schema to strings works correctly.
     """
     def shortDescription(self):
-        return "%s:%s" % (self.__class__.__name__, self.__doc__)
+        return "{0!s}:{1!s}".format(self.__class__.__name__, self.__doc__)
 
     def runTest(self):
         match = Schema.matches_schema("GATC", "AAAAA")
@@ -545,7 +533,7 @@ class SchemaFactoryTest(unittest.TestCase):
         if VERBOSE:
             print("\nSchemas:")
             for schema in schema_bank.get_all():
-                print("%s: %s" % (schema, schema_bank.count(schema)))
+                print("{0!s}: {1!s}".format(schema, schema_bank.count(schema)))
 
     def test_hard_from_motifs(self):
         """Generating schema from a real life set of motifs.
@@ -555,7 +543,7 @@ class SchemaFactoryTest(unittest.TestCase):
         if VERBOSE:
             print("\nSchemas:")
             for schema in schema_bank.get_top(5):
-                print("%s: %s" % (schema, schema_bank.count(schema)))
+                print("{0!s}: {1!s}".format(schema, schema_bank.count(schema)))
 
     def _load_schema_repository(self):
         """Helper function to load a schema repository from a file.
@@ -602,7 +590,7 @@ class SchemaFactoryTest(unittest.TestCase):
                                       alphabet=IUPAC.unambiguous_dna):
             schema_values = schema_coder.representation(seq_record.seq)
             if VERBOSE:
-                print("Schema values: %s" % schema_values)
+                print("Schema values: {0!s}".format(schema_values))
         fasta_handle.close()
 
 
@@ -655,8 +643,7 @@ class SignatureCoderTest(unittest.TestCase):
             predicted = self.coder.representation(test_seq)
 
             self.assertEqual(predicted, expected,
-                             "Non-expected representation %s for %s, wanted %s"
-                             % (predicted, seq_string, expected))
+                             "Non-expected representation {0!s} for {1!s}, wanted {2!s}".format(predicted, seq_string, expected))
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)

--- a/Tests/test_NNGeneral.py
+++ b/Tests/test_NNGeneral.py
@@ -71,8 +71,7 @@ class ExampleManagerTest(unittest.TestCase):
 
             wrong_percent = abs(expect - actual) / self.num_examples
             assert wrong_percent < .1, \
-                   "Deviation in how examples were added, expect %s, got %s" \
-                   % (expect, actual)
+                   "Deviation in how examples were added, expect {0!s}, got {1!s}".format(expect, actual)
 
     def test_partioning_examples(self):
         """Test that we can change how to partition the test examples.

--- a/Tests/test_PAML_baseml.py
+++ b/Tests/test_PAML_baseml.py
@@ -176,8 +176,7 @@ class ModTest(unittest.TestCase):
         self.assertEqual(sorted(self.bml._options), sorted(target_options))
         for key in target_options:
             self.assertEqual(self.bml._options[key], target_options[key],
-                             "%s: %r vs %r"
-                             % (key, self.bml._options[key], target_options[key]))
+                             "{0!s}: {1!r} vs {2!r}".format(key, self.bml._options[key], target_options[key]))
 
     def testCtlFileExistsOnRead(self):
         self.assertRaises(IOError,
@@ -207,8 +206,7 @@ class ModTest(unittest.TestCase):
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
             model = results_file[5]
-            version_msg = "Improper parsing for model %s version %s" \
-                        % (model, version.replace('_', '.'))
+            version_msg = "Improper parsing for model {0!s} version {1!s}".format(model, version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = baseml.read(results_path)
             # There are 6 top-levels: parameters, tree, lnL, version,
@@ -241,8 +239,7 @@ class ModTest(unittest.TestCase):
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
             model = results_file[5]
-            version_msg = "Improper parsing for model %s version %s" \
-                        % (model, version.replace('_', '.'))
+            version_msg = "Improper parsing for model {0!s} version {1!s}".format(model, version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = baseml.read(results_path)
             # There are 6 top-levels: parameters, tree, lnL, version,
@@ -261,8 +258,7 @@ class ModTest(unittest.TestCase):
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
             n = results_file[5]
-            version_msg = "Improper parsing for nhomo %s version %s" \
-                        % (n, version.replace('_', '.'))
+            version_msg = "Improper parsing for nhomo {0!s} version {1!s}".format(n, version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = baseml.read(results_path)
             # There are 6 top-levels: parameters, tree, lnL, version,
@@ -282,8 +278,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "baseml", "SE")
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
-            version_msg = "Improper parsing for version %s" \
-                        % version.replace('_', '.')
+            version_msg = "Improper parsing for version {0!s}".format(version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = baseml.read(results_path)
             # There are 6 top-levels: parameters, tree, lnL, version,

--- a/Tests/test_PAML_codeml.py
+++ b/Tests/test_PAML_codeml.py
@@ -190,8 +190,7 @@ class ModTest(unittest.TestCase):
         self.assertEqual(sorted(self.cml._options), sorted(target_options))
         for key in target_options:
             self.assertEqual(self.cml._options[key], target_options[key],
-                             "%s: %r vs %r"
-                             % (key, self.cml._options[key], target_options[key]))
+                             "{0!s}: {1!r} vs {2!r}".format(key, self.cml._options[key], target_options[key]))
 
     def testCtlFileExistsOnRead(self):
         self.assertRaises((EnvironmentError, IOError),
@@ -212,8 +211,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "SE")
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
-            version_msg = "Improper parsing for version %s" \
-                        % version.replace('_', '.')
+            version_msg = "Improper parsing for version {0!s}".format(version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             self.assertEqual(len(results), 4, version_msg)
@@ -234,8 +232,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "all_NSsites")
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
-            version_msg = "Improper parsing for version %s" \
-                        % version.replace('_', '.')
+            version_msg = "Improper parsing for version {0!s}".format(version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             # There should be 4 top-level items: 'codon model', 'model',
@@ -267,8 +264,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "NSsite3")
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
-            version_msg = "Improper parsing for version %s" \
-                        % version.replace('_', '.')
+            version_msg = "Improper parsing for version {0!s}".format(version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             # There should be 5 top-level items: 'codon model', 'model',
@@ -298,8 +294,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "branchsiteA")
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
-            version_msg = "Improper parsing for version %s" \
-                        % version.replace('_', '.')
+            version_msg = "Improper parsing for version {0!s}".format(version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             # There are 5 top-level items in this case:
@@ -334,8 +329,7 @@ class ModTest(unittest.TestCase):
             "clademodelC")
         for results_file in os.listdir(cladeC_res_dir):
             version = results_file.split('-')[1].split('.')[0]
-            version_msg = "Improper parsing for version %s" \
-                        % version.replace('_', '.')
+            version_msg = "Improper parsing for version {0!s}".format(version.replace('_', '.'))
             results_path = os.path.join(cladeC_res_dir, results_file)
             results = codeml.read(results_path)
             # 5 top-level items again in this case
@@ -367,8 +361,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "ngene2_mgene02")
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
-            version_msg = "Improper parsing for version %s" \
-                        % version.replace('_', '.')
+            version_msg = "Improper parsing for version {0!s}".format(version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             self.assertEqual(len(results), 4, version_msg)
@@ -390,8 +383,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "ngene2_mgene1")
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
-            version_msg = "Improper parsing for version %s" \
-                        % version.replace('_', '.')
+            version_msg = "Improper parsing for version {0!s}".format(version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             self.assertEqual(len(results), 4, version_msg)
@@ -408,8 +400,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "ngene2_mgene34")
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
-            version_msg = "Improper parsing for version %s" \
-                        % version.replace('_', '.')
+            version_msg = "Improper parsing for version {0!s}".format(version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             self.assertEqual(len(results), 4, version_msg)
@@ -434,8 +425,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "freeratio")
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
-            version_msg = "Improper parsing for version %s" \
-                        % version.replace('_', '.')
+            version_msg = "Improper parsing for version {0!s}".format(version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             self.assertEqual(len(results), 4, version_msg)
@@ -462,8 +452,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "pairwise")
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
-            version_msg = "Improper parsing for version %s" \
-                        % version.replace('_', '.')
+            version_msg = "Improper parsing for version {0!s}".format(version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             # Pairwise models have an extra top-level item: pairwise
@@ -476,8 +465,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "aa_model0")
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
-            version_msg = "Improper parsing for version %s" \
-                        % version.replace('_', '.')
+            version_msg = "Improper parsing for version {0!s}".format(version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             # Amino Acid analysis has different top-levels:
@@ -498,8 +486,7 @@ class ModTest(unittest.TestCase):
         res_dir = os.path.join(self.results_dir, "codeml", "aa_pairwise")
         for results_file in os.listdir(res_dir):
             version = results_file.split('-')[1].split('.')[0]
-            version_msg = "Improper parsing for version %s" \
-                        % version.replace('_', '.')
+            version_msg = "Improper parsing for version {0!s}".format(version.replace('_', '.'))
             results_path = os.path.join(res_dir, results_file)
             results = codeml.read(results_path)
             # Pairwise AA analysis has one top-level fewer than non-pairwise

--- a/Tests/test_PDB.py
+++ b/Tests/test_PDB.py
@@ -1001,7 +1001,7 @@ class IterationTests(unittest.TestCase):
 
     def test_get_atoms(self):
         """Yields all atoms from the structure, excluding duplicates and ALTLOCs which are not parsed."""
-        atoms = ["%12s" % str((atom.id, atom.altloc)) for atom in self.struc.get_atoms()]
+        atoms = ["{0:12!s}".format(str((atom.id, atom.altloc))) for atom in self.struc.get_atoms()]
         self.assertEqual(len(atoms), 756)
 
 

--- a/Tests/test_PhyloXML.py
+++ b/Tests/test_PhyloXML.py
@@ -46,7 +46,7 @@ def _test_read_factory(source, count):
         self.assertEqual(len(phx), count[0])
         self.assertEqual(len(phx.other), count[1])
 
-    test_read.__doc__ = "Read %s to produce a phyloXML object." % fname
+    test_read.__doc__ = "Read {0!s} to produce a phyloXML object.".format(fname)
     return test_read
 
 
@@ -62,7 +62,7 @@ def _test_parse_factory(source, count):
         trees = PhyloXMLIO.parse(source)
         self.assertEqual(len(list(trees)), count)
 
-    test_parse.__doc__ = "Parse the phylogenies in %s." % fname
+    test_parse.__doc__ = "Parse the phylogenies in {0!s}.".format(fname)
     return test_parse
 
 
@@ -83,7 +83,7 @@ def _test_shape_factory(source, shapes):
                 for subclade, len_expect in zip(clade, sub_expect[1]):
                     self.assertEqual(len(subclade), len_expect)
 
-    test_shape.__doc__ = "Check the branching structure of %s." % fname
+    test_shape.__doc__ = "Check the branching structure of {0!s}.".format(fname)
     return test_shape
 
 

--- a/Tests/test_Phylo_CDAO.py
+++ b/Tests/test_Phylo_CDAO.py
@@ -42,7 +42,7 @@ def _test_parse_factory(source):
     def test_parse(self):
         trees = list(bp._io.parse(filename, 'cdao'))
 
-    test_parse.__doc__ = "Parse the phylogenies in %s." % source
+    test_parse.__doc__ = "Parse the phylogenies in {0!s}.".format(source)
     return test_parse
 
 
@@ -71,11 +71,11 @@ def _test_write_factory(source):
                 pass
             else:
                 # Can't sort lists with None on Python 3 ...
-                self.assertFalse(None in p1, "Bad input values for %s: %r" % (prop_name, p1))
-                self.assertFalse(None in p2, "Bad output values for %s: %r" % (prop_name, p2))
+                self.assertFalse(None in p1, "Bad input values for {0!s}: {1!r}".format(prop_name, p1))
+                self.assertFalse(None in p2, "Bad output values for {0!s}: {1!r}".format(prop_name, p2))
                 self.assertEqual(sorted(p1), sorted(p2))
 
-    test_write.__doc__ = "Write and re-parse the phylogenies in %s." % source
+    test_write.__doc__ = "Write and re-parse the phylogenies in {0!s}.".format(source)
     return test_write
 
 
@@ -84,7 +84,7 @@ class ParseTests(unittest.TestCase):
 
 for n, ex in enumerate(cdao_files):
     parse_test = _test_parse_factory(ex)
-    parse_test.__name__ = 'test_parse_%s' % n
+    parse_test.__name__ = 'test_parse_{0!s}'.format(n)
     setattr(ParseTests, parse_test.__name__, parse_test)
 
 
@@ -93,7 +93,7 @@ class WriterTests(unittest.TestCase):
 
 for n, ex in enumerate(cdao_files):
     write_test = _test_write_factory(ex)
-    write_test.__name__ = 'test_write_%s' % n
+    write_test.__name__ = 'test_write_{0!s}'.format(n)
     setattr(WriterTests, write_test.__name__, write_test)
 
 

--- a/Tests/test_Phylo_NeXML.py
+++ b/Tests/test_Phylo_NeXML.py
@@ -63,7 +63,7 @@ def _test_parse_factory(source):
         trees = list(bp._io.parse(filename, 'nexml'))
         self.assertEqual(len(trees), count)
 
-    test_parse.__doc__ = "Parse the phylogenies in %s." % source
+    test_parse.__doc__ = "Parse the phylogenies in {0!s}.".format(source)
     return test_parse
 
 
@@ -97,7 +97,7 @@ def _test_write_factory(source):
         for prop_name in ('name', 'branch_length', 'confidence'):
             assert_property(prop_name)
 
-    test_write.__doc__ = "Write and re-parse the phylogenies in %s." % source
+    test_write.__doc__ = "Write and re-parse the phylogenies in {0!s}.".format(source)
     return test_write
 
 
@@ -106,7 +106,7 @@ class ParseTests(unittest.TestCase):
 
 for n, ex in enumerate(nexml_files):
     parse_test = _test_parse_factory(ex)
-    parse_test.__name__ = 'test_parse_%s' % n
+    parse_test.__name__ = 'test_parse_{0!s}'.format(n)
     setattr(ParseTests, parse_test.__name__, parse_test)
 
 
@@ -119,7 +119,7 @@ for n, ex in enumerate(nexml_files):
         count = tree_counts[ex]
     if count > 0:
         write_test = _test_write_factory(ex)
-        write_test.__name__ = 'test_write_%s' % n
+        write_test.__name__ = 'test_write_{0!s}'.format(n)
         setattr(WriterTests, write_test.__name__, write_test)
 
 

--- a/Tests/test_PopGen_DFDist.py
+++ b/Tests/test_PopGen_DFDist.py
@@ -93,7 +93,7 @@ class AppTest(unittest.TestCase):
                 sample_size=20, mut=0, num_sims=100,
                 data_dir=self.dirname, is_dominant=True)
         self.assertTrue(abs(fst - 0.1) < 0.03,
-                        "Stochastic result, expected %f close to 0.1" % fst)
+                        "Stochastic result, expected {0:f} close to 0.1".format(fst))
 
     def atest_dfdist_force_fst(self):
         """Test dfdist execution approximating Fst.
@@ -106,7 +106,7 @@ class AppTest(unittest.TestCase):
                 sample_size=20, mut=0, num_sims=100,
                 data_dir=self.dirname, is_dominant=True)
         self.assertTrue(abs(fst - 0.09) < 0.05,
-                        "Stochastic result, expected %f close to 0.09" % fst)
+                        "Stochastic result, expected {0:f} close to 0.09".format(fst))
 
     def test_cplot2(self):
         """Test cplot2 execution.

--- a/Tests/test_PopGen_FDist.py
+++ b/Tests/test_PopGen_FDist.py
@@ -88,7 +88,7 @@ class AppTest(unittest.TestCase):
                 sample_size=20, mut=0, num_sims=100,
                 data_dir=self.dirname)
         self.assertTrue(abs(fst - 0.1) < 0.03,
-                        "Stochastic result, expected %f close to 0.1" % fst)
+                        "Stochastic result, expected {0:f} close to 0.1".format(fst))
 
     def test_fdist_force_fst(self):
         """Test fdist execution approximating Fst.
@@ -100,7 +100,7 @@ class AppTest(unittest.TestCase):
                 sample_size=20, mut=0, num_sims=100,
                 data_dir=self.dirname)
         self.assertTrue(abs(fst - 0.09) < 0.05,
-                        "Stochastic result, expected %f close to 0.09" % fst)
+                        "Stochastic result, expected {0:f} close to 0.09".format(fst))
 
     def test_cplot(self):
         """Test cplot execution.

--- a/Tests/test_PopGen_SimCoal_nodepend.py
+++ b/Tests/test_PopGen_SimCoal_nodepend.py
@@ -31,7 +31,7 @@ class TemplateTest(unittest.TestCase):
         handle = open(os.path.join('PopGen', 'simple_100_30.par'))
         new = handle.readlines()
         handle.close()
-        assert old == new, "Error - Old:\n%s\n\nNew:\n%s\n" % (old, new)
+        assert old == new, "Error - Old:\n{0!s}\n\nNew:\n{1!s}\n".format(old, new)
         # assert(os.stat('PopGen' + os.sep + 'simple.par').st_size ==
         #       os.stat('PopGen' + os.sep + 'simple_100_30.par').st_size)
 

--- a/Tests/test_Prank_tool.py
+++ b/Tests/test_Prank_tool.py
@@ -155,21 +155,21 @@ class PrankConversion(unittest.TestCase):
 
     def conversion(self, prank_number, prank_ext, format):
         """Get PRANK to do a conversion, and check it with SeqIO."""
-        filename = "%s.%s" % (self.output, prank_ext)
+        filename = "{0!s}.{1!s}".format(self.output, prank_ext)
         if os.path.isfile(filename):
             os.remove(filename)
         cmdline = PrankCommandline(prank_exe, d=self.input,
                                    convert=True, f=prank_number,
-                                   o='"%s"' % self.output)
+                                   o='"{0!s}"'.format(self.output))
         self.assertEqual(str(cmdline), _escape_filename(prank_exe)
-                         + ' -d=%s' % self.input
-                         + ' -o="%s"' % self.output
-                         + ' -f=%i' % prank_number
+                         + ' -d={0!s}'.format(self.input)
+                         + ' -o="{0!s}"'.format(self.output)
+                         + ' -f={0:d}'.format(prank_number)
                          + ' -convert')
         self.assertEqual(str(eval(repr(cmdline))), str(cmdline))
         message, error = cmdline()
         self.assertTrue("PRANK" in message, message)
-        self.assertTrue(("converting '%s' to '%s'" % (self.input, filename))
+        self.assertTrue(("converting '{0!s}' to '{1!s}'".format(self.input, filename))
                         in message, message)
         self.assertEqual(error, "")
         self.assertTrue(os.path.isfile(filename))

--- a/Tests/test_QCPSuperimposer.py
+++ b/Tests/test_QCPSuperimposer.py
@@ -61,8 +61,8 @@ def simple_matrix_print(matrix):
     versions of the underlying libraries or the compilation options
     they used).
     """
-    return "[%s]" % "\n ".join("[%s]" % " ".join("% 1.4f" % v for v in row)
-                               for row in matrix)
+    return "[{0!s}]".format("\n ".join("[{0!s}]".format(" ".join("{0: 1.4f}".format(v) for v in row))
+                               for row in matrix))
 
 
 # output results
@@ -70,4 +70,4 @@ print(simple_matrix_print(y_on_x1))
 print("")
 print(simple_matrix_print(y_on_x2))
 print("")
-print("%.2f" % rms)
+print("{0:.2f}".format(rms))

--- a/Tests/test_SVDSuperimposer.py
+++ b/Tests/test_SVDSuperimposer.py
@@ -62,8 +62,8 @@ def simple_matrix_print(matrix):
     versions of the underlying libraries or the compilation options
     they used).
     """
-    return "[%s]" % "\n ".join("[%s]" % " ".join("% 1.4f" % v for v in row)
-                               for row in matrix)
+    return "[{0!s}]".format("\n ".join("[{0!s}]".format(" ".join("{0: 1.4f}".format(v) for v in row))
+                               for row in matrix))
 
 
 # output results
@@ -71,4 +71,4 @@ print(simple_matrix_print(y_on_x1))
 print("")
 print(simple_matrix_print(y_on_x2))
 print("")
-print("%.2f" % rms)
+print("{0:.2f}".format(rms))

--- a/Tests/test_SearchIO_model.py
+++ b/Tests/test_SearchIO_model.py
@@ -1102,7 +1102,7 @@ class HSPSingleFragmentCases(unittest.TestCase):
                     self.hsp, seq_type, 'A')
             for attr in read_onlies:
                 self.assertRaises(AttributeError, setattr,
-                        self.hsp, '%s_%s' % (seq_type, attr), 5)
+                        self.hsp, '{0!s}_{1!s}'.format(seq_type, attr), 5)
         self.assertRaises(AttributeError, setattr,
                 self.hsp, 'aln', None)
 
@@ -1179,7 +1179,7 @@ class HSPMultipleFragmentCases(unittest.TestCase):
         """Test HSP query and hit id and description setters"""
         for seq_type in ('query', 'hit'):
             for attr in ('id', 'description'):
-                attr_name = '%s_%s' % (seq_type, attr)
+                attr_name = '{0!s}_{1!s}'.format(seq_type, attr)
                 value = getattr(self.hsp, attr_name)
                 if attr == 'id':
                     # because we happen to have the same value for
@@ -1239,7 +1239,7 @@ class HSPMultipleFragmentCases(unittest.TestCase):
         for seq_type in ('query', 'hit'):
             for attr in read_onlies:
                 self.assertRaises(AttributeError, setattr,
-                        self.hsp, '%s_%s' % (seq_type, attr), 5)
+                        self.hsp, '{0!s}_{1!s}'.format(seq_type, attr), 5)
         self.assertRaises(AttributeError, setattr,
                 self.hsp, 'aln_all', None)
         self.assertRaises(AttributeError, setattr,
@@ -1259,7 +1259,7 @@ class HSPFragmentWithoutSeqCases(unittest.TestCase):
         for seq_type in ('query', 'hit'):
             self.assertTrue(getattr(fragment, seq_type) is None)
             for attr in ('strand', 'frame', 'start', 'end'):
-                attr_name = '%s_%s' % (seq_type, attr)
+                attr_name = '{0!s}_{1!s}'.format(seq_type, attr)
                 self.assertTrue(getattr(fragment, attr_name) is None)
         self.assertTrue(fragment.aln is None)
         self.assertTrue(fragment.alphabet is single_letter_alphabet)
@@ -1448,7 +1448,7 @@ class HSPFragmentCases(unittest.TestCase):
         """Test HSPFragment query and hit id and description setters"""
         for seq_type in ('query', 'hit'):
             for attr in ('id', 'description'):
-                attr_name = '%s_%s' % (seq_type, attr)
+                attr_name = '{0!s}_{1!s}'.format(seq_type, attr)
                 value = getattr(self.fragment, attr_name)
                 if attr == 'id':
                     # because we happen to have the same value for
@@ -1465,7 +1465,7 @@ class HSPFragmentCases(unittest.TestCase):
         """Test HSPFragment query and hit frame setters"""
         attr = 'frame'
         for seq_type in ('query', 'hit'):
-            attr_name = '%s_%s' % (seq_type, attr)
+            attr_name = '{0!s}_{1!s}'.format(seq_type, attr)
             for value in (-3, -2, -1, 0, 1, 2, 3, None):
                 setattr(self.fragment, attr_name, value)
                 self.assertEqual(value, getattr(self.fragment, attr_name))
@@ -1474,7 +1474,7 @@ class HSPFragmentCases(unittest.TestCase):
         """Test HSPFragment query and hit frame setters, invalid values"""
         attr = 'frame'
         for seq_type in ('query', 'hit'):
-            func_name = '_%s_%s_set' % (seq_type, attr)
+            func_name = '_{0!s}_{1!s}_set'.format(seq_type, attr)
             func = getattr(self.fragment, func_name)
             for value in ('3', '+3', '-2', 'plus'):
                 self.assertRaises(ValueError, func, value)
@@ -1483,7 +1483,7 @@ class HSPFragmentCases(unittest.TestCase):
         """Test HSPFragment query and hit strand setters"""
         attr = 'strand'
         for seq_type in ('query', 'hit'):
-            attr_name = '%s_%s' % (seq_type, attr)
+            attr_name = '{0!s}_{1!s}'.format(seq_type, attr)
             for value in (-1, 0, 1, None):
                 setattr(self.fragment, attr_name, value)
                 self.assertEqual(value, getattr(self.fragment, attr_name))
@@ -1492,7 +1492,7 @@ class HSPFragmentCases(unittest.TestCase):
         """Test HSPFragment query and hit strand setters, invalid values"""
         attr = 'strand'
         for seq_type in ('query', 'hit'):
-            func_name = '_%s_%s_set' % (seq_type, attr)
+            func_name = '_{0!s}_{1!s}_set'.format(seq_type, attr)
             func = getattr(self.fragment, func_name)
             for value in (3, 'plus', 'minus', '-', '+'):
                 self.assertRaises(ValueError, func, value)
@@ -1500,39 +1500,39 @@ class HSPFragmentCases(unittest.TestCase):
     def test_strand_set_from_plus_frame(self):
         """Test HSPFragment query and hit strand getters, from plus frame"""
         for seq_type in ('query', 'hit'):
-            attr_name = '%s_strand' % seq_type
+            attr_name = '{0!s}_strand'.format(seq_type)
             self.assertTrue(getattr(self.fragment, attr_name) is None)
-            setattr(self.fragment, '%s_frame' % seq_type, 3)
+            setattr(self.fragment, '{0!s}_frame'.format(seq_type), 3)
             self.assertEqual(1, getattr(self.fragment, attr_name))
 
     def test_strand_set_from_minus_frame(self):
         """Test HSPFragment query and hit strand getters, from minus frame"""
         for seq_type in ('query', 'hit'):
-            attr_name = '%s_strand' % seq_type
+            attr_name = '{0!s}_strand'.format(seq_type)
             self.assertTrue(getattr(self.fragment, attr_name) is None)
-            setattr(self.fragment, '%s_frame' % seq_type, -2)
+            setattr(self.fragment, '{0!s}_frame'.format(seq_type), -2)
             self.assertEqual(-1, getattr(self.fragment, attr_name))
 
     def test_strand_set_from_zero_frame(self):
         """Test HSPFragment query and hit strand getters, from zero frame"""
         for seq_type in ('query', 'hit'):
-            attr_name = '%s_strand' % seq_type
+            attr_name = '{0!s}_strand'.format(seq_type)
             self.assertTrue(getattr(self.fragment, attr_name) is None)
-            setattr(self.fragment, '%s_frame' % seq_type, 0)
+            setattr(self.fragment, '{0!s}_frame'.format(seq_type), 0)
             self.assertEqual(0, getattr(self.fragment, attr_name))
 
     def test_coords_setters_getters(self):
         """Test HSPFragment query and hit coordinate-related setters and getters"""
         for seq_type in ('query', 'hit'):
-            attr_start = '%s_%s' % (seq_type, 'start')
-            attr_end = '%s_%s' % (seq_type, 'end')
+            attr_start = '{0!s}_{1!s}'.format(seq_type, 'start')
+            attr_end = '{0!s}_{1!s}'.format(seq_type, 'end')
             setattr(self.fragment, attr_start, 9)
             setattr(self.fragment, attr_end, 99)
             # check for span value
-            span = getattr(self.fragment, '%s_span' % seq_type)
+            span = getattr(self.fragment, '{0!s}_span'.format(seq_type))
             self.assertEqual(90, span)
             # and range as well
-            range = getattr(self.fragment, '%s_range' % seq_type)
+            range = getattr(self.fragment, '{0!s}_range'.format(seq_type))
             self.assertEqual((9, 99), range)
 
     def test_coords_setters_readonly(self):
@@ -1541,7 +1541,7 @@ class HSPFragmentCases(unittest.TestCase):
         for seq_type in ('query', 'hit'):
             for attr in read_onlies:
                 self.assertRaises(AttributeError, setattr,
-                        self.fragment, '%s_%s' % (seq_type, attr), 5)
+                        self.fragment, '{0!s}_{1!s}'.format(seq_type, attr), 5)
 
 
 if __name__ == "__main__":

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -295,9 +295,9 @@ def compare_record(record_one, record_two):
 def record_summary(record, indent=" "):
     """Returns a concise summary of a SeqRecord object as a string"""
     if record.id == record.name:
-        answer = "%sID and Name='%s',\n%sSeq='" % (indent, record.id, indent)
+        answer = "{0!s}ID and Name='{1!s}',\n{2!s}Seq='".format(indent, record.id, indent)
     else:
-        answer = "%sID = '%s', Name='%s',\n%sSeq='" % (
+        answer = "{0!s}ID = '{1!s}', Name='{2!s}',\n{3!s}Seq='".format(
             indent, record.id, record.name, indent)
     if record.seq is None:
         answer += "None"
@@ -306,7 +306,7 @@ def record_summary(record, indent=" "):
             answer += str(record.seq[:40]) + "..." + str(record.seq[-7:])
         else:
             answer += str(record.seq)
-        answer += "', length=%i" % (len(record.seq))
+        answer += "', length={0:d}".format((len(record.seq)))
     return answer
 
 
@@ -324,13 +324,13 @@ def alignment_summary(alignment, index=" "):
     rec_count = len(alignment)
     for i in range(min(5, alignment_len)):
         answer.append(index + col_summary(alignment[:, i])
-                            + " alignment column %i" % i)
+                            + " alignment column {0:d}".format(i))
     if alignment_len > 5:
         i = alignment_len - 1
         answer.append(index + col_summary("|" * rec_count)
                             + " ...")
         answer.append(index + col_summary(alignment[:, i])
-                            + " alignment column %i" % i)
+                            + " alignment column {0:d}".format(i))
     return "\n".join(answer)
 
 
@@ -343,7 +343,7 @@ def check_simple_write_read(records, indent=" "):
             # Skipping for speed.  Some of the unknown sequences are
             # rather long, and it seems a bit pointless to record them.
             continue
-        print(indent + "Checking can write/read as '%s' format" % format)
+        print(indent + "Checking can write/read as '{0!s}' format".format(format))
 
         # Going to write to a handle...
         if format in SeqIO._BinaryFormats:
@@ -373,7 +373,7 @@ def check_simple_write_read(records, indent=" "):
                 # TypeError: object of type 'NoneType' has no len()
                 print("Failed: Probably len() of None")
             else:
-                print(indent + "Failed: %s" % str(e))
+                print(indent + "Failed: {0!s}".format(str(e)))
             if records[0].seq.alphabet.letters is not None:
                 assert format != t_format, \
                     "Should be able to re-write in the original format!"
@@ -390,8 +390,7 @@ def check_simple_write_read(records, indent=" "):
             # I want to see the output when called from the test harness,
             # run_tests.py (which can be funny about new lines on Windows)
             handle.seek(0)
-            raise ValueError("%s\n\n%s\n\n%s"
-                             % (str(e), repr(handle.read()), repr(records)))
+            raise ValueError("{0!s}\n\n{1!s}\n\n{2!s}".format(str(e), repr(handle.read()), repr(records)))
 
         assert len(records2) == t_count
         for r1, r2 in zip(records, records2):
@@ -418,21 +417,21 @@ def check_simple_write_read(records, indent=" "):
             # valid character sets and the identifier lengths!
             if format in ["phylip", "phylip-sequential"]:
                 assert r1.id.replace("[", "").replace("]", "")[:10] == r2.id, \
-                    "'%s' vs '%s'" % (r1.id, r2.id)
+                    "'{0!s}' vs '{1!s}'".format(r1.id, r2.id)
             elif format == "phylip-relaxed":
                 assert r1.id.replace(" ", "").replace(':', '|') == r2.id, \
-                    "'%s' vs '%s'" % (r1.id, r2.id)
+                    "'{0!s}' vs '{1!s}'".format(r1.id, r2.id)
             elif format == "clustal":
                 assert r1.id.replace(" ", "_")[:30] == r2.id, \
-                    "'%s' vs '%s'" % (r1.id, r2.id)
+                    "'{0!s}' vs '{1!s}'".format(r1.id, r2.id)
             elif format == "stockholm":
                 assert r1.id.replace(" ", "_") == r2.id, \
-                    "'%s' vs '%s'" % (r1.id, r2.id)
+                    "'{0!s}' vs '{1!s}'".format(r1.id, r2.id)
             elif format == "fasta":
                 assert r1.id.split()[0] == r2.id
             else:
                 assert r1.id == r2.id, \
-                    "'%s' vs '%s'" % (r1.id, r2.id)
+                    "'{0!s}' vs '{1!s}'".format(r1.id, r2.id)
 
         if len(records) > 1:
             # Try writing just one record (passing a SeqRecord, not a list)
@@ -460,7 +459,7 @@ for (t_format, t_alignment, t_filename, t_count) in test_files:
     else:
         mode = "r"
 
-    print("Testing reading %s format file %s" % (t_format, t_filename))
+    print("Testing reading {0!s} format file {1!s}".format(t_format, t_filename))
     assert os.path.isfile(t_filename), t_filename
 
     with warnings.catch_warnings():
@@ -473,7 +472,7 @@ for (t_format, t_alignment, t_filename, t_count) in test_files:
         records = list(SeqIO.parse(handle=h, format=t_format))
         h.close()
         assert len(records) == t_count, \
-            "Found %i records but expected %i" % (len(records), t_count)
+            "Found {0:d} records but expected {1:d}".format(len(records), t_count)
 
         # Try using the iterator with a for loop, and a filename not handle
         records2 = []
@@ -550,14 +549,14 @@ for (t_format, t_alignment, t_filename, t_count) in test_files:
             # Check for blanks, or entries with leading/trailing spaces
             for acc in accs:
                 assert acc and acc == acc.strip(), \
-                    "Bad accession in annotations: %s" % repr(acc)
+                    "Bad accession in annotations: {0!s}".format(repr(acc))
             assert len(set(accs)) == len(accs), \
-                "Repeated accession in annotations: %s" % repr(accs)
+                "Repeated accession in annotations: {0!s}".format(repr(accs))
         for ref in record.dbxrefs:
             assert ref and ref == ref.strip(), \
-                "Bad cross reference in dbxrefs: %s" % repr(ref)
+                "Bad cross reference in dbxrefs: {0!s}".format(repr(ref))
         assert len(record.dbxrefs) == len(record.dbxrefs), \
-            "Repeated cross reference in dbxrefs: %s" % repr(record.dbxrefs)
+            "Repeated cross reference in dbxrefs: {0!s}".format(repr(record.dbxrefs))
 
         # Check the lists obtained by the different methods agree
         assert compare_record(record, records2[i])
@@ -611,8 +610,7 @@ for (t_format, t_alignment, t_filename, t_count) in test_files:
         good = nucleotide_alphas
         bad = protein_alphas
     else:
-        assert t_format in no_alpha_formats, "Got %s from %s file" \
-            % (repr(base_alpha), t_format)
+        assert t_format in no_alpha_formats, "Got {0!s} from {1!s} file".format(repr(base_alpha), t_format)
         good = protein_alphas + dna_alphas + rna_alphas + nucleotide_alphas
         bad = []
     for given_alpha in good:
@@ -634,8 +632,7 @@ for (t_format, t_alignment, t_filename, t_count) in test_files:
         try:
             print(next(SeqIO.parse(h, t_format, given_alpha)))
             h.close()
-            assert False, "Forcing wrong alphabet, %s, should fail (%s)" \
-                % (repr(given_alpha), t_filename)
+            assert False, "Forcing wrong alphabet, {0!s}, should fail ({1!s})".format(repr(given_alpha), t_filename)
         except ValueError:
             # Good - should fail
             pass
@@ -643,8 +640,7 @@ for (t_format, t_alignment, t_filename, t_count) in test_files:
     del good, bad, given_alpha, base_alpha
 
     if t_alignment:
-        print("Testing reading %s format file %s as an alignment"
-              % (t_format, t_filename))
+        print("Testing reading {0!s} format file {1!s} as an alignment".format(t_format, t_filename))
 
         alignment = MultipleSeqAlignment(SeqIO.parse(
             handle=t_filename, format=t_format))

--- a/Tests/test_SeqIO_FastaIO.py
+++ b/Tests/test_SeqIO_FastaIO.py
@@ -137,10 +137,10 @@ for filename in single_nucleic_files:
 
     def funct(fn):
         f = lambda x: x.simple_check(fn, generic_nucleotide)
-        f.__doc__ = "Checking nucleotide file %s" % fn
+        f.__doc__ = "Checking nucleotide file {0!s}".format(fn)
         return f
 
-    setattr(TitleFunctions, "test_nuc_%s" % name, funct(filename))
+    setattr(TitleFunctions, "test_nuc_{0!s}".format(name), funct(filename))
     del funct
 
 for filename in multi_dna_files:
@@ -148,10 +148,10 @@ for filename in multi_dna_files:
 
     def funct(fn):
         f = lambda x: x.multi_check(fn, generic_dna)
-        f.__doc__ = "Checking multi DNA file %s" % fn
+        f.__doc__ = "Checking multi DNA file {0!s}".format(fn)
         return f
 
-    setattr(TitleFunctions, "test_mutli_dna_%s" % name, funct(filename))
+    setattr(TitleFunctions, "test_mutli_dna_{0!s}".format(name), funct(filename))
     del funct
 
 for filename in single_amino_files:
@@ -159,10 +159,10 @@ for filename in single_amino_files:
 
     def funct(fn):
         f = lambda x: x.simple_check(fn, generic_nucleotide)
-        f.__doc__ = "Checking protein file %s" % fn
+        f.__doc__ = "Checking protein file {0!s}".format(fn)
         return f
 
-    setattr(TitleFunctions, "test_pro_%s" % name, funct(filename))
+    setattr(TitleFunctions, "test_pro_{0!s}".format(name), funct(filename))
     del funct
 
 for filename in multi_amino_files:
@@ -170,10 +170,10 @@ for filename in multi_amino_files:
 
     def funct(fn):
         f = lambda x: x.multi_check(fn, generic_dna)
-        f.__doc__ = "Checking multi protein file %s" % fn
+        f.__doc__ = "Checking multi protein file {0!s}".format(fn)
         return f
 
-    setattr(TitleFunctions, "test_mutli_pro_%s" % name, funct(filename))
+    setattr(TitleFunctions, "test_mutli_pro_{0!s}".format(name), funct(filename))
     del funct
 
 if __name__ == "__main__":

--- a/Tests/test_SeqIO_QualityIO.py
+++ b/Tests/test_SeqIO_QualityIO.py
@@ -64,19 +64,19 @@ def compare_record(old, new, truncate=None):
     It knows to ignore UnknownSeq objects for string matching (i.e. QUAL files).
     """
     if old.id != new.id:
-        raise ValueError("'%s' vs '%s' " % (old.id, new.id))
+        raise ValueError("'{0!s}' vs '{1!s}' ".format(old.id, new.id))
     if old.description != new.description \
     and (old.id + " " + old.description).strip() != new.description:
-        raise ValueError("'%s' vs '%s' " % (old.description, new.description))
+        raise ValueError("'{0!s}' vs '{1!s}' ".format(old.description, new.description))
     if len(old.seq) != len(new.seq):
-        raise ValueError("%i vs %i" % (len(old.seq), len(new.seq)))
+        raise ValueError("{0:d} vs {1:d}".format(len(old.seq), len(new.seq)))
     if isinstance(old.seq, UnknownSeq) or isinstance(new.seq, UnknownSeq):
         pass
     elif str(old.seq) != str(new.seq):
         if len(old.seq) < 200:
-            raise ValueError("'%s' vs '%s'" % (old.seq, new.seq))
+            raise ValueError("'{0!s}' vs '{1!s}'".format(old.seq, new.seq))
         else:
-            raise ValueError("'%s...' vs '%s...'" % (old.seq[:100], new.seq[:100]))
+            raise ValueError("'{0!s}...' vs '{1!s}...'".format(old.seq[:100], new.seq[:100]))
     if "phred_quality" in old.letter_annotations \
     and "phred_quality" in new.letter_annotations \
     and old.letter_annotations["phred_quality"] != new.letter_annotations["phred_quality"]:
@@ -126,7 +126,7 @@ def compare_record(old, new, truncate=None):
 def compare_records(old_list, new_list, truncate_qual=None):
     """Check two lists of SeqRecords agree, raises a ValueError if mismatch."""
     if len(old_list) != len(new_list):
-        raise ValueError("%i vs %i records" % (len(old_list), len(new_list)))
+        raise ValueError("{0:d} vs {1:d} records".format(len(old_list), len(new_list)))
     for old, new in zip(old_list, new_list):
         if not compare_record(old, new, truncate_qual):
             return False
@@ -194,10 +194,10 @@ tests = [("diff_ids", 2),
          ("trunc_at_qual", 4)]
 for base_name, good_count in tests:
     def funct(name, c):
-        f = lambda x: x.check_all_fail("Quality/error_%s.fastq" % name, c)
-        f.__doc__ = "Reject FASTQ with %s" % name.replace("_", " ")
+        f = lambda x: x.check_all_fail("Quality/error_{0!s}.fastq".format(name), c)
+        f.__doc__ = "Reject FASTQ with {0!s}".format(name.replace("_", " "))
         return f
-    setattr(TestFastqErrors, "test_%s" % (base_name),
+    setattr(TestFastqErrors, "test_{0!s}".format((base_name)),
             funct(base_name, good_count))
     del funct
 
@@ -212,10 +212,10 @@ tests = [("del", 3, 5),
          ("null", 0, 5)]
 for base_name, good_count, full_count in tests:
     def funct(name, c1, c2):
-        f = lambda x: x.check_qual_char("Quality/error_qual_%s.fastq" % name, c1, c2)
-        f.__doc__ = "Reject FASTQ with %s in quality" % name.replace("_", " ")
+        f = lambda x: x.check_qual_char("Quality/error_qual_{0!s}.fastq".format(name), c1, c2)
+        f.__doc__ = "Reject FASTQ with {0!s} in quality".format(name.replace("_", " "))
         return f
-    setattr(TestFastqErrors, "test_qual_%s" % (base_name),
+    setattr(TestFastqErrors, "test_qual_{0!s}".format((base_name)),
             funct(base_name, good_count, full_count))
     del funct
 
@@ -277,11 +277,10 @@ class TestReferenceFastqConversions(unittest.TestCase):
     """Tests where we have reference output."""
     def simple_check(self, base_name, in_variant):
         for out_variant in ["sanger", "solexa", "illumina"]:
-            in_filename = "Quality/%s_original_%s.fastq" \
-                          % (base_name, in_variant)
+            in_filename = "Quality/{0!s}_original_{1!s}.fastq".format(base_name, in_variant)
             self.assertTrue(os.path.isfile(in_filename))
             # Load the reference output...
-            with open("Quality/%s_as_%s.fastq" % (base_name, out_variant),
+            with open("Quality/{0!s}_as_{1!s}.fastq".format(base_name, out_variant),
                       _universal_read_mode) as handle:
                 expected = handle.read()
 
@@ -315,10 +314,10 @@ for base_name, variant in tests:
 
     def funct(bn, var):
         f = lambda x: x.simple_check(bn, var)
-        f.__doc__ = "Reference conversions of %s file %s" % (var, bn)
+        f.__doc__ = "Reference conversions of {0!s} file {1!s}".format(var, bn)
         return f
 
-    setattr(TestReferenceFastqConversions, "test_%s_%s" % (base_name, variant),
+    setattr(TestReferenceFastqConversions, "test_{0!s}_{1!s}".format(base_name, variant),
             funct(base_name, variant))
     del funct
 
@@ -400,16 +399,14 @@ class TestReadWrite(unittest.TestCase):
     """Test can read and write back files."""
     def test_fastq_2000(self):
         """Read and write back simple example with upper case 2000bp read"""
-        data = "@%s\n%s\n+\n%s\n" \
-               % ("id descr goes here", "ACGT" * 500, "!@a~" * 500)
+        data = "@{0!s}\n{1!s}\n+\n{2!s}\n".format("id descr goes here", "ACGT" * 500, "!@a~" * 500)
         handle = StringIO()
         self.assertEqual(1, SeqIO.write(SeqIO.parse(StringIO(data), "fastq"), handle, "fastq"))
         self.assertEqual(data, handle.getvalue())
 
     def test_fastq_1000(self):
         """Read and write back simple example with mixed case 1000bp read"""
-        data = "@%s\n%s\n+\n%s\n" \
-               % ("id descr goes here", "ACGTNncgta" * 100, "abcd!!efgh" * 100)
+        data = "@{0!s}\n{1!s}\n+\n{2!s}\n".format("id descr goes here", "ACGTNncgta" * 100, "abcd!!efgh" * 100)
         handle = StringIO()
         self.assertEqual(1, SeqIO.write(SeqIO.parse(StringIO(data), "fastq"), handle, "fastq"))
         self.assertEqual(data, handle.getvalue())
@@ -417,16 +414,14 @@ class TestReadWrite(unittest.TestCase):
     def test_fastq_dna(self):
         """Read and write back simple example with ambiguous DNA"""
         # First in upper case...
-        data = "@%s\n%s\n+\n%s\n" \
-               % ("id descr goes here",
+        data = "@{0!s}\n{1!s}\n+\n{2!s}\n".format("id descr goes here",
                   ambiguous_dna_letters.upper(),
                   "".join(chr(33 + q) for q in range(len(ambiguous_dna_letters))))
         handle = StringIO()
         self.assertEqual(1, SeqIO.write(SeqIO.parse(StringIO(data), "fastq"), handle, "fastq"))
         self.assertEqual(data, handle.getvalue())
         # Now in lower case...
-        data = "@%s\n%s\n+\n%s\n" \
-               % ("id descr goes here",
+        data = "@{0!s}\n{1!s}\n+\n{2!s}\n".format("id descr goes here",
                   ambiguous_dna_letters.lower(),
                   "".join(chr(33 + q) for q in range(len(ambiguous_dna_letters))))
         handle = StringIO()
@@ -436,16 +431,14 @@ class TestReadWrite(unittest.TestCase):
     def test_fastq_rna(self):
         """Read and write back simple example with ambiguous RNA"""
         # First in upper case...
-        data = "@%s\n%s\n+\n%s\n" \
-               % ("id descr goes here",
+        data = "@{0!s}\n{1!s}\n+\n{2!s}\n".format("id descr goes here",
                   ambiguous_rna_letters.upper(),
                   "".join(chr(33 + q) for q in range(len(ambiguous_rna_letters))))
         handle = StringIO()
         self.assertEqual(1, SeqIO.write(SeqIO.parse(StringIO(data), "fastq"), handle, "fastq"))
         self.assertEqual(data, handle.getvalue())
         # Now in lower case...
-        data = "@%s\n%s\n+\n%s\n" \
-               % ("id descr goes here",
+        data = "@{0!s}\n{1!s}\n+\n{2!s}\n".format("id descr goes here",
                   ambiguous_rna_letters.lower(),
                   "".join(chr(33 + q) for q in range(len(ambiguous_rna_letters))))
         handle = StringIO()
@@ -650,7 +643,7 @@ class MappingTests(unittest.TestCase):
         qual = "".join(chr(33 + q) for q in range(0, 94))
         expected_sol = [min(62, int(round(QualityIO.solexa_quality_from_phred(q))))
                         for q in range(0, 94)]
-        in_handle = StringIO("@Test\n%s\n+\n%s" % (seq, qual))
+        in_handle = StringIO("@Test\n{0!s}\n+\n{1!s}".format(seq, qual))
         out_handle = StringIO()
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", BiopythonWarning)
@@ -672,7 +665,7 @@ class MappingTests(unittest.TestCase):
         qual = "".join(chr(64 + q) for q in range(-5, 63))
         expected_phred = [round(QualityIO.phred_quality_from_solexa(q))
                           for q in range(-5, 63)]
-        in_handle = StringIO("@Test\n%s\n+\n%s" % (seq, qual))
+        in_handle = StringIO("@Test\n{0!s}\n+\n{1!s}".format(seq, qual))
         out_handle = StringIO()
         SeqIO.write(SeqIO.parse(in_handle, "fastq-solexa"),
                     out_handle, "fastq-sanger")
@@ -687,7 +680,7 @@ class MappingTests(unittest.TestCase):
         seq = "N" * 94
         qual = "".join(chr(33 + q) for q in range(0, 94))
         expected_phred = [min(62, q) for q in range(0, 94)]
-        in_handle = StringIO("@Test\n%s\n+\n%s" % (seq, qual))
+        in_handle = StringIO("@Test\n{0!s}\n+\n{1!s}".format(seq, qual))
         out_handle = StringIO()
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always", BiopythonWarning)
@@ -705,7 +698,7 @@ class MappingTests(unittest.TestCase):
         seq = "N" * 63
         qual = "".join(chr(64 + q) for q in range(0, 63))
         expected_phred = list(range(63))
-        in_handle = StringIO("@Test\n%s\n+\n%s" % (seq, qual))
+        in_handle = StringIO("@Test\n{0!s}\n+\n{1!s}".format(seq, qual))
         out_handle = StringIO()
         SeqIO.write(SeqIO.parse(in_handle, "fastq-illumina"),
                     out_handle, "fastq-sanger")

--- a/Tests/test_SeqIO_SeqXML.py
+++ b/Tests/test_SeqIO_SeqXML.py
@@ -167,7 +167,7 @@ class TestReadAndWrite(unittest.TestCase):
             # This would be fine too, but don't get this (do we?)
             pass
         else:
-            raise ValueError("Mising expected <species> tag: %r" % output)
+            raise ValueError("Mising expected <species> tag: {0!r}".format(output))
 
 
 class TestReadCorruptFiles(unittest.TestCase):

--- a/Tests/test_SeqIO_convert.py
+++ b/Tests/test_SeqIO_convert.py
@@ -75,8 +75,7 @@ def check_convert_fails(in_filename, in_format, out_format, alphabet=None):
         assert False, "Convert should have failed!"
     except ValueError as err2:
         assert str(err1) == str(err2), \
-               "Different failures, parse/write:\n%s\nconvert:\n%s" \
-               % (err1, err2)
+               "Different failures, parse/write:\n{0!s}\nconvert:\n{1!s}".format(err1, err2)
 
 
 # TODO - move this to a shared test module...
@@ -87,21 +86,21 @@ def compare_record(old, new, truncate=None):
     It knows to ignore UnknownSeq objects for string matching (i.e. QUAL files).
     """
     if old.id != new.id:
-        raise ValueError("'%s' vs '%s' " % (old.id, new.id))
+        raise ValueError("'{0!s}' vs '{1!s}' ".format(old.id, new.id))
     if old.description != new.description \
     and (old.id + " " + old.description).strip() != new.description \
     and new.description != "<unknown description>" \
     and new.description != "":  # e.g. tab format
-        raise ValueError("'%s' vs '%s' " % (old.description, new.description))
+        raise ValueError("'{0!s}' vs '{1!s}' ".format(old.description, new.description))
     if len(old.seq) != len(new.seq):
-        raise ValueError("%i vs %i" % (len(old.seq), len(new.seq)))
+        raise ValueError("{0:d} vs {1:d}".format(len(old.seq), len(new.seq)))
     if isinstance(old.seq, UnknownSeq) or isinstance(new.seq, UnknownSeq):
         pass
     elif str(old.seq) != str(new.seq):
         if len(old.seq) < 200:
-            raise ValueError("'%s' vs '%s'" % (old.seq, new.seq))
+            raise ValueError("'{0!s}' vs '{1!s}'".format(old.seq, new.seq))
         else:
-            raise ValueError("'%s...' vs '%s...'" % (old.seq[:100], new.seq[:100]))
+            raise ValueError("'{0!s}...' vs '{1!s}...'".format(old.seq[:100], new.seq[:100]))
     if "phred_quality" in old.letter_annotations \
     and "phred_quality" in new.letter_annotations \
     and old.letter_annotations["phred_quality"] != new.letter_annotations["phred_quality"]:
@@ -151,7 +150,7 @@ def compare_record(old, new, truncate=None):
 def compare_records(old_list, new_list, truncate_qual=None):
     """Check two lists of SeqRecords agree, raises a ValueError if mismatch."""
     if len(old_list) != len(new_list):
-        raise ValueError("%i vs %i records" % (len(old_list), len(new_list)))
+        raise ValueError("{0:d} vs {1:d} records".format(len(old_list), len(new_list)))
     for old, new in zip(old_list, new_list):
         if not compare_record(old, new, truncate_qual):
             return False
@@ -186,11 +185,10 @@ for filename, format, alphabet in tests:
 
         def funct(fn, fmt1, fmt2, alpha):
             f = lambda x: x.simple_check(fn, fmt1, fmt2, alpha)
-            f.__doc__ = "Convert %s from %s to %s" % (fn, fmt1, fmt2)
+            f.__doc__ = "Convert {0!s} from {1!s} to {2!s}".format(fn, fmt1, fmt2)
             return f
 
-        setattr(ConvertTests, "test_%s_%s_to_%s"
-                % (filename.replace("/", "_").replace(".", "_"), in_format, out_format),
+        setattr(ConvertTests, "test_{0!s}_{1!s}_to_{2!s}".format(filename.replace("/", "_").replace(".", "_"), in_format, out_format),
                 funct(filename, in_format, out_format, alphabet))
         del funct
 
@@ -231,11 +229,10 @@ for filename, format, alphabet in tests:
 
         def funct(fn, fmt1, fmt2, alpha):
             f = lambda x: x.failure_check(fn, fmt1, fmt2, alpha)
-            f.__doc__ = "Convert %s from %s to %s" % (fn, fmt1, fmt2)
+            f.__doc__ = "Convert {0!s} from {1!s} to {2!s}".format(fn, fmt1, fmt2)
             return f
 
-        setattr(ConvertTests, "test_%s_%s_to_%s"
-                % (filename.replace("/", "_").replace(".", "_"), in_format, out_format),
+        setattr(ConvertTests, "test_{0!s}_{1!s}_to_{2!s}".format(filename.replace("/", "_").replace(".", "_"), in_format, out_format),
                 funct(filename, in_format, out_format, alphabet))
     del funct
 

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -32,7 +32,7 @@ def _get_location_string(feature, record_length):
     using_sub_features = _insdc_feature_location_string(feature, record_length)
     using_compound_location = _insdc_location_string(feature.location, record_length)
     assert using_sub_features == using_compound_location, \
-        "%r vs %r from:\n%s" % (using_sub_features, using_compound_location, feature)
+        "{0!r} vs {1!r} from:\n{2!s}".format(using_sub_features, using_compound_location, feature)
     return using_compound_location
 
 
@@ -55,29 +55,27 @@ def compare_record(old, new, expect_minor_diffs=False):
     and old.id != new.id and old.name != new.name \
     and (old.id not in new.id) and (new.id not in old.id) \
     and (old.id.replace(" ", "_") != new.id.replace(" ", "_")):
-        raise ValueError("'%s' or '%s' vs '%s' or '%s' records"
-                         % (old.id, old.name, new.id, new.name))
+        raise ValueError("'{0!s}' or '{1!s}' vs '{2!s}' or '{3!s}' records".format(old.id, old.name, new.id, new.name))
     if len(old.seq) != len(new.seq):
-        raise ValueError("%i vs %i" % (len(old.seq), len(new.seq)))
+        raise ValueError("{0:d} vs {1:d}".format(len(old.seq), len(new.seq)))
     if isinstance(old.seq, UnknownSeq) \
     and isinstance(new.seq, UnknownSeq):
         # Jython didn't like us comparing the string of very long
         # UnknownSeq object (out of heap memory error)
         if old.seq._character.upper() != new.seq._character:
-            raise ValueError("%s vs %s" % (repr(old.seq), repr(new.seq)))
+            raise ValueError("{0!s} vs {1!s}".format(repr(old.seq), repr(new.seq)))
     elif str(old.seq).upper() != str(new.seq).upper():
         if len(old.seq) < 200:
-            raise ValueError("'%s' vs '%s'" % (old.seq, new.seq))
+            raise ValueError("'{0!s}' vs '{1!s}'".format(old.seq, new.seq))
         else:
-            raise ValueError("'%s...' vs '%s...'" % (old.seq[:100], new.seq[:100]))
+            raise ValueError("'{0!s}...' vs '{1!s}...'".format(old.seq[:100], new.seq[:100]))
     if old.features and new.features:
         if not compare_features(old.features, new.features):
             return False
     # Just insist on at least one word in common:
     if (old.description or new.description) \
     and not set(old.description.split()).intersection(new.description.split()):
-        raise ValueError("%s versus %s"
-                         % (repr(old.description), repr(new.description)))
+        raise ValueError("{0!s} versus {1!s}".format(repr(old.description), repr(new.description)))
     # This only checks common annotation
     # Would a white list be easier?
     for key in set(old.annotations).intersection(new.annotations):
@@ -89,8 +87,7 @@ def compare_record(old, new, expect_minor_diffs=False):
         if key == "comment":
             # Ignore whitespace
             if old.annotations[key].split() != new.annotations[key].split():
-                raise ValueError("Annotation mis-match for comment:\n%s\n%s"
-                                % (old.annotations[key], new.annotations[key]))
+                raise ValueError("Annotation mis-match for comment:\n{0!s}\n{1!s}".format(old.annotations[key], new.annotations[key]))
             continue
         if key == "references":
             if expect_minor_diffs:
@@ -100,7 +97,7 @@ def compare_record(old, new, expect_minor_diffs=False):
             for r1, r2 in zip(old.annotations[key], new.annotations[key]):
                 assert r1.title == r2.title
                 assert r1.authors == r2.authors, \
-                       "Old: '%s'\nNew: '%s'" % (r1.authors, r2.authors)
+                       "Old: '{0!s}'\nNew: '{1!s}'".format(r1.authors, r2.authors)
                 assert r1.journal == r2.journal
                 if r1.consrtm and r2.consrtm:
                     # Not held in EMBL files
@@ -111,15 +108,14 @@ def compare_record(old, new, expect_minor_diffs=False):
                 assert r1.pubmed_id == r2.pubmed_id
             continue
         if repr(old.annotations[key]) != repr(new.annotations[key]):
-            raise ValueError("Annotation mis-match for %s:\n%s\n%s"
-                             % (key, old.annotations[key], new.annotations[key]))
+            raise ValueError("Annotation mis-match for {0!s}:\n{1!s}\n{2!s}".format(key, old.annotations[key], new.annotations[key]))
     return True
 
 
 def compare_records(old_list, new_list, expect_minor_diffs=False):
     """Check two lists of SeqRecords agree, raises a ValueError if mismatch."""
     if len(old_list) != len(new_list):
-        raise ValueError("%i vs %i records" % (len(old_list), len(new_list)))
+        raise ValueError("{0:d} vs {1:d} records".format(len(old_list), len(new_list)))
     for old, new in zip(old_list, new_list):
         if not compare_record(old, new, expect_minor_diffs):
             return False
@@ -129,27 +125,24 @@ def compare_records(old_list, new_list, expect_minor_diffs=False):
 def compare_feature(old, new, ignore_sub_features=False):
     """Check two SeqFeatures agree."""
     if old.type != new.type:
-        raise ValueError("Type %s versus %s" % (repr(old.type), repr(new.type)))
+        raise ValueError("Type {0!s} versus {1!s}".format(repr(old.type), repr(new.type)))
     if old.location.nofuzzy_start != new.location.nofuzzy_start \
     or old.location.nofuzzy_end != new.location.nofuzzy_end:
-        raise ValueError("%s versus %s:\n%s\nvs:\n%s"
-                         % (old.location, new.location, repr(old), repr(new)))
+        raise ValueError("{0!s} versus {1!s}:\n{2!s}\nvs:\n{3!s}".format(old.location, new.location, repr(old), repr(new)))
     if old.strand is not None and old.strand != new.strand:
-        raise ValueError("Different strand:\n%s\nvs:\n%s" % (repr(old), repr(new)))
+        raise ValueError("Different strand:\n{0!s}\nvs:\n{1!s}".format(repr(old), repr(new)))
     if old.ref != new.ref:
-        raise ValueError("Different ref:\n%s\nvs:\n%s" % (repr(old), repr(new)))
+        raise ValueError("Different ref:\n{0!s}\nvs:\n{1!s}".format(repr(old), repr(new)))
     if old.ref_db != new.ref_db:
-        raise ValueError("Different ref_db:\n%s\nvs:\n%s" % (repr(old), repr(new)))
+        raise ValueError("Different ref_db:\n{0!s}\nvs:\n{1!s}".format(repr(old), repr(new)))
     if old.location_operator != new.location_operator:
-        raise ValueError("Different location_operator:\n%s\nvs:\n%s" % (repr(old), repr(new)))
+        raise ValueError("Different location_operator:\n{0!s}\nvs:\n{1!s}".format(repr(old), repr(new)))
     if old.location.start != new.location.start \
     or str(old.location.start) != str(new.location.start):
-        raise ValueError("Start %s versus %s:\n%s\nvs:\n%s"
-                         % (old.location.start, new.location.start, repr(old), repr(new)))
+        raise ValueError("Start {0!s} versus {1!s}:\n{2!s}\nvs:\n{3!s}".format(old.location.start, new.location.start, repr(old), repr(new)))
     if old.location.end != new.location.end \
     or str(old.location.end) != str(new.location.end):
-        raise ValueError("End %s versus %s:\n%s\nvs:\n%s"
-                         % (old.location.end, new.location.end, repr(old), repr(new)))
+        raise ValueError("End {0!s} versus {1!s}:\n{2!s}\nvs:\n{3!s}".format(old.location.end, new.location.end, repr(old), repr(new)))
     if not ignore_sub_features:
         # Using private variable to avoid deprecation warnings,
         if len(old._sub_features) != len(new._sub_features):
@@ -165,15 +158,14 @@ def compare_feature(old, new, ignore_sub_features=False):
             # EMBL and GenBank files are use different references/notes/etc
             continue
         if old.qualifiers[key] != new.qualifiers[key]:
-            raise ValueError("Qualifier mis-match for %s:\n%s\n%s"
-                             % (key, old.qualifiers[key], new.qualifiers[key]))
+            raise ValueError("Qualifier mis-match for {0!s}:\n{1!s}\n{2!s}".format(key, old.qualifiers[key], new.qualifiers[key]))
     return True
 
 
 def compare_features(old_list, new_list, ignore_sub_features=False):
     """Check two lists of SeqFeatures agree, raises a ValueError if mismatch."""
     if len(old_list) != len(new_list):
-        raise ValueError("%i vs %i features" % (len(old_list), len(new_list)))
+        raise ValueError("{0:d} vs {1:d} features".format(len(old_list), len(new_list)))
     for old, new in zip(old_list, new_list):
         # This assumes they are in the same order
         if not compare_feature(old, new, ignore_sub_features):
@@ -1061,7 +1053,7 @@ class NC_000932(unittest.TestCase):
                        "gi|7525057|ref|NP_051038.1|",  # dual-strand
                        "gi|90110725|ref|NP_051109.2|",  # Invalid annotation? No start codon
                        ]
-    __doc__ = "Tests using %s GenBank and FASTA files from the NCBI" % basename
+    __doc__ = "Tests using {0!s} GenBank and FASTA files from the NCBI".format(basename)
     # TODO - neat way to change the docstrings...
 
     def setUp(self):
@@ -1091,7 +1083,7 @@ class NC_000932(unittest.TestCase):
                 pro = nuc.translate(table=self.table, cds=True)
             except TranslationError as e:
                 print(e)
-                print("%r, %r, %r" % (r.id, nuc, self.table))
+                print("{0!r}, {1!r}, {2!r}".format(r.id, nuc, self.table))
                 print(f)
                 raise
             if pro[-1] == "*":
@@ -1105,7 +1097,7 @@ class NC_005816(NC_000932):
     emblname = "AE017046"
     table = 11
     skip_trans_test = []
-    __doc__ = "Tests using %s GenBank and FASTA files from the NCBI" % basename
+    __doc__ = "Tests using {0!s} GenBank and FASTA files from the NCBI".format(basename)
 
     def test_GenBank_vs_EMBL(self):
         if not self.emblname:
@@ -1133,9 +1125,8 @@ class NC_005816(NC_000932):
             if (str(translation) != str(faa.seq)) \
             and (str(translation) != str(faa.seq) + "*"):
                 t = SeqRecord(translation, id="Translation",
-                              description="Table %s" % self.table)
-                raise ValueError("FAA vs FNA translation problem:\n%s\n%s\n%s\n"
-                                 % (fna.format("fasta"),
+                              description="Table {0!s}".format(self.table))
+                raise ValueError("FAA vs FNA translation problem:\n{0!s}\n{1!s}\n{2!s}\n".format(fna.format("fasta"),
                                     t.format("fasta"),
                                     faa.format("fasta")))
 

--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -543,9 +543,9 @@ class IndexDictTests(unittest.TestCase):
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://uniprot.org/uniprot
                 http://www.uniprot.org/support/docs/uniprot.xsd">
-                %s
+                {0!s}
                 </uniprot>
-                """ % _bytes_to_string(raw)
+                """.format(_bytes_to_string(raw))
                 handle = StringIO(raw)
                 rec2 = SeqIO.read(handle, format, alphabet)
             else:
@@ -636,28 +636,25 @@ for filename, format, alphabet in tests:
 
         def funct(fn, fmt, alpha, c):
             f = lambda x: x.simple_check(fn, fmt, alpha, c)
-            f.__doc__ = "Index %s file %s defaults" % (fmt, fn)
+            f.__doc__ = "Index {0!s} file {1!s} defaults".format(fmt, fn)
             return f
-        setattr(IndexDictTests, "test_%s_%s_simple"
-                    % (format, filename.replace("/", "_").replace(".", "_")),
+        setattr(IndexDictTests, "test_{0!s}_{1!s}_simple".format(format, filename.replace("/", "_").replace(".", "_")),
                 funct(filename, format, alphabet, comp))
         del funct
 
         def funct(fn, fmt, alpha, c):
             f = lambda x: x.key_check(fn, fmt, alpha, c)
-            f.__doc__ = "Index %s file %s with key function" % (fmt, fn)
+            f.__doc__ = "Index {0!s} file {1!s} with key function".format(fmt, fn)
             return f
-        setattr(IndexDictTests, "test_%s_%s_keyf"
-                    % (format, filename.replace("/", "_").replace(".", "_")),
+        setattr(IndexDictTests, "test_{0!s}_{1!s}_keyf".format(format, filename.replace("/", "_").replace(".", "_")),
                 funct(filename, format, alphabet, comp))
         del funct
 
         def funct(fn, fmt, alpha, c):
             f = lambda x: x.get_raw_check(fn, fmt, alpha, c)
-            f.__doc__ = "Index %s file %s get_raw" % (fmt, fn)
+            f.__doc__ = "Index {0!s} file {1!s} get_raw".format(fmt, fn)
             return f
-        setattr(IndexDictTests, "test_%s_%s_get_raw"
-                    % (format, filename.replace("/", "_").replace(".", "_")),
+        setattr(IndexDictTests, "test_{0!s}_{1!s}_get_raw".format(format, filename.replace("/", "_").replace(".", "_")),
                 funct(filename, format, alphabet, comp))
         del funct
 

--- a/Tests/test_SeqIO_online.py
+++ b/Tests/test_SeqIO_online.py
@@ -62,7 +62,7 @@ class EntrezTests(unittest.TestCase):
                          (entry in record.id) or
                          ("gi" in record.annotations
                           and record.annotations["gi"] == entry),
-                         "%s got %s, %s" % (entry, record.name, record.id))
+                         "{0!s} got {1!s}, {2!s}".format(entry, record.name, record.id))
             self.assertEqual(len(record), length)
             self.assertEqual(seguid(record.seq), checksum)
 
@@ -77,10 +77,10 @@ for database, formats, entry, length, checksum in [
 
     def funct(d, f, e, l, c):
         method = lambda x: x.simple(d, f, e, l, c)
-        method.__doc__ = "Bio.Entrez.efetch(%r, id=%r, ...)" % (d, e)
+        method.__doc__ = "Bio.Entrez.efetch({0!r}, id={1!r}, ...)".format(d, e)
         return method
 
-    setattr(EntrezTests, "test_%s_%s" % (database, entry),
+    setattr(EntrezTests, "test_{0!s}_{1!s}".format(database, entry),
             funct(database, formats, entry, length, checksum))
     del funct
 del database, formats, entry, length, checksum

--- a/Tests/test_SeqIO_write.py
+++ b/Tests/test_SeqIO_write.py
@@ -47,7 +47,7 @@ test_records = [
     ([SeqRecord(Seq("AATAAACCTTGCTGGCCATTGTGATCCATCCA", Alphabet.generic_dna), id="X",
                 name="The\nMystery\rSequece:\r\nX"),
       SeqRecord(Seq("ACTCAACCTTGCTGGTCATTGTGACCCCAGCA", Alphabet.generic_dna), id="Y",
-                description="an%sevil\rdescription right\nhere" % os.linesep),
+                description="an{0!s}evil\rdescription right\nhere".format(os.linesep)),
       SeqRecord(Seq("TTTCCTCGGAGGCCAATCTGGATCAAGACCAT", Alphabet.generic_dna), id="Z")],
      "3 DNA seq alignment with CR/LF in name/descr",
       [(["genbank"], ValueError, r"Locus identifier 'The\nMystery\rSequece:\r\nX' is too long")]),
@@ -62,10 +62,10 @@ test_records = [
 # Meddle with the annotation too:
 assert test_records[4][1] == "3 DNA seq alignment with CR/LF in name/descr"
 # Add a list of strings,
-test_records[4][0][2].annotations["note"] = ["Note%salso" % os.linesep
+test_records[4][0][2].annotations["note"] = ["Note{0!s}also".format(os.linesep)
                                     + "\r\nhas\n evil line\rbreaks!", "Wow"]
 # Add a simple string
-test_records[4][0][2].annotations["comment"] = "More%sof" % os.linesep \
+test_records[4][0][2].annotations["comment"] = "More{0!s}of".format(os.linesep) \
                                           + "\r\nthese\n evil line\rbreaks!"
 # Add a float too:
 test_records[4][0][2].annotations["weight"] = 2.5
@@ -152,10 +152,10 @@ for (records, descr, errs) in test_records:
         # Assume no errors expected...
         def funct(records, format, descr):
             f = lambda x: x.check(records, format)
-            f.__doc__ = "%s for %s" % (format, descr)
+            f.__doc__ = "{0!s} for {1!s}".format(format, descr)
             return f
         setattr(WriterTests,
-                "test_%s_%s" % (format, descr.replace(" ", "_")),
+                "test_{0!s}_{1!s}".format(format, descr.replace(" ", "_")),
                 funct(records, format, descr))
         # Replace the method with an error specific one?
         for err_formats, err_type, err_msg in errs:
@@ -163,10 +163,10 @@ for (records, descr, errs) in test_records:
                 def funct_e(records, format, descr, err_type, err_msg):
                     f = lambda x: x.check_write_fails(records, format,
                                                        err_type, err_msg)
-                    f.__doc__ = "%s for %s" % (format, descr)
+                    f.__doc__ = "{0!s} for {1!s}".format(format, descr)
                     return f
                 setattr(WriterTests,
-                        "test_%s_%s" % (format, descr.replace(" ", "_")),
+                        "test_{0!s}_{1!s}".format(format, descr.replace(" ", "_")),
                         funct_e(records, format, descr, err_type, err_msg))
                 break
         del funct

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -25,11 +25,11 @@ def u_crc32(seq):
 
 def simple_LCC(s):
     # Avoid cross platforms with printing floats by doing conversion explicitly
-    return "%0.2f" % lcc_simp(s)
+    return "{0:0.2f}".format(lcc_simp(s))
 
 
 def windowed_LCC(s):
-    return ", ".join("%0.2f" % v for v in lcc_mult(s, 20))
+    return ", ".join("{0:0.2f}".format(v) for v in lcc_mult(s, 20))
 
 
 class SeqUtilsTests(unittest.TestCase):
@@ -48,7 +48,7 @@ class SeqUtilsTests(unittest.TestCase):
     def test_codon_usage_ecoli(self):
         """Test Codon Adaptation Index (CAI) using default E. coli data."""
         CAI = CodonAdaptationIndex()
-        self.assertEqual("%0.5f" % CAI.cai_for_gene("ATGCGTATCGATCGCGATACGATTAGGCGGATG"),
+        self.assertEqual("{0:0.5f}".format(CAI.cai_for_gene("ATGCGTATCGATCGCGATACGATTAGGCGGATG")),
                          "0.09978")
 
     def test_codon_usage_custom(self):
@@ -71,7 +71,7 @@ class SeqUtilsTests(unittest.TestCase):
                 # TODO - Use any cds_start option if/when added to deal with the met
                 a = "M" + str(seq[3:].translate(table))
                 b = feature.qualifiers["translation"][0] + "*"
-                self.assertEqual(a, b, "%r vs %r" % (a, b))
+                self.assertEqual(a, b, "{0!r} vs {1!r}".format(a, b))
                 records.append(SeqRecord(seq, id=feature.qualifiers["protein_id"][0],
                                         description=feature.qualifiers["product"][0]))
 
@@ -85,7 +85,7 @@ class SeqUtilsTests(unittest.TestCase):
         # Now check codon usage index (CAI) using this species
         self.assertEqual(record.annotations["source"],
                          "Yersinia pestis biovar Microtus str. 91001")
-        self.assertEqual("%0.5f" % CAI.cai_for_gene("ATGCGTATCGATCGCGATACGATTAGGCGGATG"),
+        self.assertEqual("{0:0.5f}".format(CAI.cai_for_gene("ATGCGTATCGATCGCGATACGATTAGGCGGATG")),
                          "0.67213")
         os.remove(dna_fasta_filename)
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -120,8 +120,7 @@ class StringMethodTests(unittest.TestCase):
                     i = pre_comp_function(i)
                     j = pre_comp_function(j)
                 if i != j:
-                    raise ValueError("%s.%s(%s) = %i, not %i"
-                                     % (repr(example1),
+                    raise ValueError("{0!s}.{1!s}({2!s}) = {3:d}, not {4:d}".format(repr(example1),
                                         method_name,
                                         repr(str2),
                                         i,
@@ -134,8 +133,7 @@ class StringMethodTests(unittest.TestCase):
                         i = pre_comp_function(i)
                         j = pre_comp_function(j)
                     if i != j:
-                        raise ValueError("%s.%s(%s) = %i, not %i"
-                                         % (repr(example1),
+                        raise ValueError("{0!s}.{1!s}({2!s}) = {3:d}, not {4:d}".format(repr(example1),
                                             method_name,
                                             repr(example2),
                                             i,
@@ -152,8 +150,7 @@ class StringMethodTests(unittest.TestCase):
                             i = pre_comp_function(i)
                             j = pre_comp_function(j)
                         if i != j:
-                            raise ValueError("%s.%s(%s, %i) = %i, not %i"
-                                             % (repr(example1),
+                            raise ValueError("{0!s}.{1!s}({2!s}, {3:d}) = {4:d}, not {5:d}".format(repr(example1),
                                                 method_name,
                                                 repr(str2),
                                                 start,
@@ -167,8 +164,7 @@ class StringMethodTests(unittest.TestCase):
                                 i = pre_comp_function(i)
                                 j = pre_comp_function(j)
                             if i != j:
-                                raise ValueError("%s.%s(%s, %i, %i) = %i, not %i"
-                                                 % (repr(example1),
+                                raise ValueError("{0!s}.{1!s}({2!s}, {3:d}, {4:d}) = {5:d}, not {6:d}".format(repr(example1),
                                                     method_name,
                                                     repr(str2),
                                                     start,
@@ -293,8 +289,7 @@ class StringMethodTests(unittest.TestCase):
                 # Silence change in behaviour warning
                 warnings.simplefilter('ignore', BiopythonWarning)
                 self.assertEqual(hash(str(example1)), hash(example1),
-                                 "Hash mismatch, %r for %r vs %r for %r"
-                                 % (hash(str(example1)), id(example1),
+                                 "Hash mismatch, {0!r} for {1!r} vs {2!r} for {3!r}".format(hash(str(example1)), id(example1),
                                     hash(example1), example1))
 
     def test_str_comparison(self):
@@ -305,22 +300,22 @@ class StringMethodTests(unittest.TestCase):
                     warnings.simplefilter('ignore', BiopythonWarning)
                     self.assertEqual(str(example1) == str(example2),
                                      example1 == example2,
-                                     "Checking %r == %r" % (example1, example2))
+                                     "Checking {0!r} == {1!r}".format(example1, example2))
                     self.assertEqual(str(example1) != str(example2),
                                      example1 != example2,
-                                     "Checking %r != %r" % (example1, example2))
+                                     "Checking {0!r} != {1!r}".format(example1, example2))
                     self.assertEqual(str(example1) < str(example2),
                                      example1 < example2,
-                                     "Checking %r < %r" % (example1, example2))
+                                     "Checking {0!r} < {1!r}".format(example1, example2))
                     self.assertEqual(str(example1) <= str(example2),
                                      example1 <= example2,
-                                     "Checking %r <= %r" % (example1, example2))
+                                     "Checking {0!r} <= {1!r}".format(example1, example2))
                     self.assertEqual(str(example1) > str(example2),
                                      example1 > example2,
-                                     "Checking %r > %r" % (example1, example2))
+                                     "Checking {0!r} > {1!r}".format(example1, example2))
                     self.assertEqual(str(example1) >= str(example2),
                                      example1 >= example2,
-                                     "Checking %r >= %r" % (example1, example2))
+                                     "Checking {0!r} >= {1!r}".format(example1, example2))
 
     def test_str_getitem(self):
         """Check slicing and indexing works like a string."""
@@ -533,7 +528,7 @@ class StringMethodTests(unittest.TestCase):
                         Seq(codon, unambiguous_dna)]:
                 try:
                     print(nuc.translate())
-                    self.fail("Translating %s should fail" % codon)
+                    self.fail("Translating {0!s} should fail".format(codon))
                 except TranslationError:
                     pass
 
@@ -554,8 +549,7 @@ class StringMethodTests(unittest.TestCase):
                             self.assertEqual(values, set("*"))
                         elif t == "X":
                             self.assertTrue(len(values) > 1,
-                                "translate('%s') = '%s' not '%s'"
-                                % (c1 + c2 + c3, t, ",".join(values)))
+                                "translate('{0!s}') = '{1!s}' not '{2!s}'".format(c1 + c2 + c3, t, ",".join(values)))
                         elif t == "Z":
                             self.assertEqual(values, set("EQ"))
                         elif t == "B":

--- a/Tests/test_SubsMat.py
+++ b/Tests/test_SubsMat.py
@@ -30,7 +30,7 @@ with open(ctab_file) as handle:
 f.write("Check differences between derived and true frequencies for each\n")
 f.write("letter. Differences should be very small\n")
 for i in ftab_prot.alphabet.letters:
-    f.write("%s %f\n" % (i, abs(ftab_prot[i] - ctab_prot[i])))
+    f.write("{0!s} {1:f}\n".format(i, abs(ftab_prot[i] - ctab_prot[i])))
 
 pickle_file = os.path.join('SubsMat', 'acc_rep_mat.pik')
 # Don't want to use text mode on Python 3,
@@ -44,15 +44,15 @@ obs_freq_mat.print_mat(f=f, format=" %4.3f")
 
 f.write("Diff between supplied and matrix-derived frequencies, should be small\n")
 for i in sorted(ftab_prot):
-    f.write("%s %.2f\n" % (i, abs(ftab_prot[i] - ftab_prot2[i])))
+    f.write("{0!s} {1:.2f}\n".format(i, abs(ftab_prot[i] - ftab_prot2[i])))
 
 s = 0.
 f.write("Calculating sum of letters for an observed frequency matrix\n")
 counts = obs_freq_mat.sum()
 for key in sorted(counts):
-    f.write("%s\t%.2f\n" % (key, counts[key]))
+    f.write("{0!s}\t{1:.2f}\n".format(key, counts[key]))
     s += counts[key]
-f.write("Total sum %.2f should be 1.0\n" % (s))
+f.write("Total sum {0:.2f} should be 1.0\n".format((s)))
 lo_mat_prot = \
 SubsMat.make_log_odds_matrix(acc_rep_mat=acc_rep_mat, round_digit=1)  # ,ftab_prot
 f.write("\nLog odds matrix\n")
@@ -66,11 +66,11 @@ lo_mat_prot.print_full_mat(f=f, format=" %d", alphabet='AVILMCFWYHSTNQKRDEGP')
 f.write("\nTesting MatrixInfo\n")
 for i in MatrixInfo.available_matrices:
     mat = SubsMat.SeqMat(getattr(MatrixInfo, i))
-    f.write("\n%s\n------------\n" % i)
+    f.write("\n{0!s}\n------------\n".format(i))
     mat.print_mat(f=f)
 f.write("\nTesting Entropy\n")
 relative_entropy = lo_mat_prot.calculate_relative_entropy(obs_freq_mat)
-f.write("relative entropy %.3f\n" % relative_entropy)
+f.write("relative entropy {0:.3f}\n".format(relative_entropy))
 
 # Will uncomment the following once the Bio.Tools.Statistics is in place
 f.write("\nmatrix correlations\n")
@@ -78,8 +78,8 @@ blosum90 = SubsMat.SeqMat(MatrixInfo.blosum90)
 blosum30 = SubsMat.SeqMat(MatrixInfo.blosum30)
 try:
     import numpy
-    f.write("BLOSUM30 & BLOSUM90 %.2f\n" % SubsMat.two_mat_correlation(blosum30, blosum90))
-    f.write("BLOSUM90 & BLOSUM30 %.2f\n" % SubsMat.two_mat_correlation(blosum90, blosum30))
+    f.write("BLOSUM30 & BLOSUM90 {0:.2f}\n".format(SubsMat.two_mat_correlation(blosum30, blosum90)))
+    f.write("BLOSUM90 & BLOSUM30 {0:.2f}\n".format(SubsMat.two_mat_correlation(blosum90, blosum30)))
 except ImportError:
     # Need numpy for the two_mat_correlation, but rather than splitting this
     # test into two, and have one raise MissingExternalDependencyError cheat:

--- a/Tests/test_TogoWS.py
+++ b/Tests/test_TogoWS.py
@@ -45,7 +45,7 @@ class TogoFields(unittest.TestCase):
                         'orthology', 'reaction', 'module',
                         'pathway'])
         self.assertTrue(dbs.issuperset(expected),
-                        "Missing DB: %s" % ", ".join(sorted(expected.difference(dbs))))
+                        "Missing DB: {0!s}".format(", ".join(sorted(expected.difference(dbs)))))
 
     def test_pubmed(self):
         """Check supported fields for pubmed database"""
@@ -462,10 +462,9 @@ class TogoSearch(unittest.TestCase):
             raise ValueError("Bad test - TogoWS makes no promises about order")
         search_count = TogoWS.search_count(database, search_term)
         if expected_matches and search_count < len(expected_matches):
-            raise ValueError("Only %i matches, expected at least %i"
-                             % (search_count, len(expected_matches)))
+            raise ValueError("Only {0:d} matches, expected at least {1:d}".format(search_count, len(expected_matches)))
         if search_count > 5000 and not limit:
-            print("%i results, skipping" % search_count)
+            print("{0:d} results, skipping".format(search_count))
             return
         if limit:
             count = min(search_count, limit)
@@ -477,7 +476,7 @@ class TogoSearch(unittest.TestCase):
         self.assertEqual(count, len(search_iter))
         for match in expected_matches:
             self.assertTrue(match in search_iter,
-                            "Expected %s in results but not" % match)
+                            "Expected {0!s} in results but not".format(match))
 
 
 class TogoConvert(unittest.TestCase):

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -85,7 +85,7 @@ def extract_doctests(latex_filename):
             elif line.startswith("%doctest"):
                 if lines:
                     if not lines[0].startswith(">>> "):
-                        raise ValueError("Should start '>>> ' not %r" % lines[0])
+                        raise ValueError("Should start '>>> ' not {0!r}".format(lines[0]))
                     yield name, "".join(lines), folder, deps
                     lines = []
                 deps = [x.strip() for x in line.split()[1:]]
@@ -94,13 +94,13 @@ def extract_doctests(latex_filename):
                     deps = deps[1:]
                 else:
                     folder = ""
-                name = "test_%s_line_%05i" % (base_name, line_number)
+                name = "test_{0!s}_line_{1:05d}".format(base_name, line_number)
                 x = _extract(handle)
                 lines.extend(x)
                 line_number += len(x) + 2
     if lines:
         if not lines[0].startswith(">>> "):
-            raise ValueError("Should start '>>> ' not %r" % lines[0])
+            raise ValueError("Should start '>>> ' not {0!r}".format(lines[0]))
         yield name, "".join(lines), folder, deps
     # yield "dummy", ">>> 2 + 2\n5\n"
 
@@ -141,15 +141,14 @@ for latex in files:
             method = lambda x: None
             if f:
                 p = os.path.join(tutorial_base, f)
-                method.__doc__ = "%s\n\n>>> import os\n>>> os.chdir(%r)\n%s\n" \
-                    % (n, p, d)
+                method.__doc__ = "{0!s}\n\n>>> import os\n>>> os.chdir({1!r})\n{2!s}\n".format(n, p, d)
             else:
-                method.__doc__ = "%s\n\n%s\n" % (n, d)
+                method.__doc__ = "{0!s}\n\n{1!s}\n".format(n, d)
             method._folder = f
             return method
 
         setattr(TutorialDocTestHolder,
-                "doctest_%s" % name.replace(" ", "_"),
+                "doctest_{0!s}".format(name.replace(" ", "_")),
                 funct(name, example, folder))
         del funct
 
@@ -170,8 +169,7 @@ class TutorialTestCase(unittest.TestCase):
                 failures.append(name[30:])
                 # raise ValueError("Tutorial doctest %s failed" % test.name[30:])
         if failures:
-            raise ValueError("%i Tutorial doctests failed: %s" %
-                             (len(failures), ", ".join(failures)))
+            raise ValueError("{0:d} Tutorial doctests failed: {1!s}".format(len(failures), ", ".join(failures)))
 
     def tearDown(self):
         global original_path
@@ -183,10 +181,10 @@ if __name__ == "__main__":
     if missing_deps:
         print("Skipping tests needing the following:")
         for dep in sorted(missing_deps):
-            print(" - %s" % dep)
+            print(" - {0!s}".format(dep))
     print("Running Tutorial doctests...")
     import doctest
     tests = doctest.testmod()
     if tests.failed:
-        raise RuntimeError("%i/%i tests failed" % tests)
+        raise RuntimeError("{0:d}/{1:d} tests failed".format(*tests))
     print("Tests done")

--- a/Tests/test_Uniprot.py
+++ b/Tests/test_Uniprot.py
@@ -273,8 +273,7 @@ class TestUniprot(unittest.TestCase):
                 # TODO - Why is this a list vs str?
                 pass
             elif type(old.annotations[key]) != type(new.annotations[key]):
-                raise TypeError("%s gives %s vs %s" %
-                                 (key, old.annotations[key], new.annotations[key]))
+                raise TypeError("{0!s} gives {1!s} vs {2!s}".format(key, old.annotations[key], new.annotations[key]))
             elif key in ["organism"]:
                 if old.annotations[key] == new.annotations[key]:
                     pass
@@ -286,11 +285,9 @@ class TestUniprot(unittest.TestCase):
             and sorted(old.annotations[key]) == sorted(new.annotations[key]):
                 pass
             else:
-                raise ValueError("%s gives %s vs %s" %
-                                 (key, old.annotations[key], new.annotations[key]))
+                raise ValueError("{0!s} gives {1!s} vs {2!s}".format(key, old.annotations[key], new.annotations[key]))
         self.assertEqual(len(old.features), len(new.features),
-                         "Features in %s, %i vs %i" %
-                         (old.id, len(old.features), len(new.features)))
+                         "Features in {0!s}, {1:d} vs {2:d}".format(old.id, len(old.features), len(new.features)))
         for f1, f2 in zip(old.features, new.features):
             """
             self.assertEqual(f1.location.nofuzzy_start, f2.location.nofuzzy_start,
@@ -301,8 +298,7 @@ class TestUniprot(unittest.TestCase):
                              (f1.location, f1.type, f2.location, f2.type))
             """
             self.assertEqual(repr(f1.location), repr(f2.location),
-                            "%s %s vs %s %s" %
-                            (f1.location, f1.type, f2.location, f2.type))
+                            "{0!s} {1!s} vs {2!s} {3!s}".format(f1.location, f1.type, f2.location, f2.type))
 
     def test_Q13639(self):
         """Compare SwissProt text and uniprot XML versions of Q13639."""

--- a/Tests/test_XXmotif_tool.py
+++ b/Tests/test_XXmotif_tool.py
@@ -95,7 +95,7 @@ class XXmotifTestErrorConditions(XXmotifTestCase):
         except ApplicationError as err:
             self.assertEqual(err.returncode, 255)
         else:
-            self.fail("Should have failed, returned:\n%s\n%s" % (stdout, stderr))
+            self.fail("Should have failed, returned:\n{0!s}\n{1!s}".format(stdout, stderr))
 
     def test_invalid_format(self):
         """Test an input file in an invalid format."""
@@ -109,7 +109,7 @@ class XXmotifTestErrorConditions(XXmotifTestCase):
         except ApplicationError as err:
             self.assertEqual(err.returncode, 255)
         else:
-            self.fail("Should have failed, returned:\n%s\n%s" % (stdout, stderr))
+            self.fail("Should have failed, returned:\n{0!s}\n{1!s}".format(stdout, stderr))
 
     def test_output_directory_with_space(self):
         """Test an output directory containing a space."""

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -83,21 +83,21 @@ alignment = AlignIO.read(os.path.join(test_dir, test_names[0]), "clustal",
 # test the base alignment stuff
 print('all_seqs...')
 for seq_record in alignment:
-    print('description: %s' % seq_record.description)
-    print('seq: %r' % seq_record.seq)
-print('length: %i' % alignment.get_alignment_length())
+    print('description: {0!s}'.format(seq_record.description))
+    print('seq: {0!r}'.format(seq_record.seq))
+print('length: {0:d}'.format(alignment.get_alignment_length()))
 
 print('Calculating summary information...')
 align_info = AlignInfo.SummaryInfo(alignment)
 consensus = align_info.dumb_consensus()
 assert isinstance(consensus, Seq)
-print('consensus: %r' % consensus)
+print('consensus: {0!r}'.format(consensus))
 
 
 print('Replacement dictionary')
 ks = sorted(align_info.replacement_dictionary(['N']))
 for key in ks:
-    print("%s : %s" % (key, align_info.replacement_dictionary(['N'])[key]))
+    print("{0!s} : {1!s}".format(key, align_info.replacement_dictionary(['N'])[key]))
 
 print('position specific score matrix.')
 print('with a supplied consensus sequence...')
@@ -111,10 +111,8 @@ second_seq = alignment[1].seq
 print(align_info.pos_specific_score_matrix(second_seq, ['N']))
 
 print('information content')
-print('part of alignment: %0.2f'
-      % align_info.information_content(5, 50, chars_to_ignore=['N']))
-print('entire alignment: %0.2f'
-      % align_info.information_content(chars_to_ignore=['N']))
+print('part of alignment: {0:0.2f}'.format(align_info.information_content(5, 50, chars_to_ignore=['N'])))
+print('entire alignment: {0:0.2f}'.format(align_info.information_content(chars_to_ignore=['N'])))
 
 print('relative information content')
 e_freq = {'G': 0.25,
@@ -125,14 +123,13 @@ e_freq = {'G': 0.25,
 e_freq_table = FreqTable.FreqTable(e_freq, FreqTable.FREQ,
                                    IUPAC.unambiguous_dna)
 
-print('relative information: %0.2f'
-      % align_info.information_content(e_freq_table=e_freq_table,
-                                       chars_to_ignore=['N']))
+print('relative information: {0:0.2f}'.format(align_info.information_content(e_freq_table=e_freq_table,
+                                       chars_to_ignore=['N'])))
 
-print('Column 1: %s' % align_info.get_column(1))
-print('IC for column 1: %0.2f' % align_info.ic_vector[1])
-print('Column 7: %s' % align_info.get_column(7))
-print('IC for column 7: %0.2f' % align_info.ic_vector[7])
+print('Column 1: {0!s}'.format(align_info.get_column(1)))
+print('IC for column 1: {0:0.2f}'.format(align_info.ic_vector[1]))
+print('Column 7: {0!s}'.format(align_info.get_column(7)))
+print('IC for column 7: {0:0.2f}'.format(align_info.ic_vector[7]))
 print('test print_info_content')
 AlignInfo.print_info_content(align_info)
 print("testing reading and writing fasta format...")
@@ -145,14 +142,14 @@ alignment = AlignIO.read(to_parse, "fasta",
 # test the base alignment stuff
 print('all_seqs...')
 for seq_record in alignment:
-    print('description: %s' % seq_record.description)
-    print('seq: %r' % seq_record.seq)
+    print('description: {0!s}'.format(seq_record.description))
+    print('seq: {0!r}'.format(seq_record.seq))
 
-print('length: %i' % alignment.get_alignment_length())
+print('length: {0:d}'.format(alignment.get_alignment_length()))
 align_info = AlignInfo.SummaryInfo(alignment)
 consensus = align_info.dumb_consensus(ambiguous="N", threshold=0.6)
 assert isinstance(consensus, Seq)
-print('consensus: %r' % consensus)
+print('consensus: {0!r}'.format(consensus))
 
 print(alignment)
 

--- a/Tests/test_bgzf.py
+++ b/Tests/test_bgzf.py
@@ -30,7 +30,7 @@ def _have_bug17666():
     try:
         data = h.read()
         h.close()
-        assert not data, "Should be zero length, not %i" % len(data)
+        assert not data, "Should be zero length, not {0:d}".format(len(data))
         return False
     except TypeError as err:
         # TypeError: integer argument expected, got 'tuple'
@@ -139,7 +139,7 @@ class BgzfTests(unittest.TestCase):
 
                 self.assertEqual(len(old), len(new))
                 self.assertEqual(old[:10], new[:10],
-                                 "%r vs %r, mode %r" % (old[:10], new[:10], mode))
+                                 "{0!r} vs {1!r}, mode {2!r}".format(old[:10], new[:10], mode))
                 self.assertEqual(old, new)
 
     def check_by_char(self, old_file, new_file, old_gzip=False):
@@ -175,7 +175,7 @@ class BgzfTests(unittest.TestCase):
                 self.assertEqual(len(old), len(new))
                 # If bytes vs unicode mismatch, give a short error message:
                 self.assertEqual(old[:10], new[:10],
-                                 "%r vs %r, mode %r" % (old[:10], new[:10], mode))
+                                 "{0!r} vs {1!r}, mode {2!r}".format(old[:10], new[:10], mode))
                 self.assertEqual(old, new)
 
     def check_random(self, filename):

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -1686,7 +1686,7 @@ class MotifTestPWM(unittest.TestCase):
         self.assertAlmostEqual(result[3], -38.04542542, places=5)
         self.assertAlmostEqual(result[4], -20.3014183, places=5)
         self.assertAlmostEqual(result[5], -25.18009186, places=5)
-        self.assertTrue(math.isnan(result[6]), "Expected nan, not %r" % result[6])
+        self.assertTrue(math.isnan(result[6]), "Expected nan, not {0!r}".format(result[6]))
 
 
 if __name__ == "__main__":

--- a/Tests/test_samtools_tool.py
+++ b/Tests/test_samtools_tool.py
@@ -118,15 +118,13 @@ class SamtoolsTestCase(unittest.TestCase):
         cmdline.set_parameter("input_file", self.bamfile1)
         stdout_bam, stderr_bam = cmdline()
         self.assertTrue(stderr_bam.startswith(""),
-                        "SAM file viewing failed: \n%s\nStdout:%s"
-                        % (cmdline, stdout_bam))
+                        "SAM file viewing failed: \n{0!s}\nStdout:{1!s}".format(cmdline, stdout_bam))
         cmdline.set_parameter("input_file", self.samfile1)
         cmdline.set_parameter("S", True)
         stdout_sam, stderr_sam = cmdline()
         self.assertTrue(
             stdout_sam.startswith("HWI-1KL120:88:D0LRBACXX:1:1101:1780:2146"),
-            "SAM file  viewing failed:\n%s\nStderr:%s"
-            % (cmdline, stderr_sam))
+            "SAM file  viewing failed:\n{0!s}\nStderr:{1!s}".format(cmdline, stderr_sam))
 
     def create_fasta_index(self):
         """Creates index for reference fasta sequence."""
@@ -145,8 +143,7 @@ class SamtoolsTestCase(unittest.TestCase):
         cmdline.set_parameter("reference", self.reference)
         stdout, stderr = cmdline()
         self.assertFalse(stderr,
-                         "Samtools faidx failed:\n%s\nStderr:%s"
-                         % (cmdline, stderr))
+                         "Samtools faidx failed:\n{0!s}\nStderr:{1!s}".format(cmdline, stderr))
         self.assertTrue(os.path.isfile(self.referenceindexfile))
 
     def test_calmd(self):
@@ -182,16 +179,14 @@ class SamtoolsTestCase(unittest.TestCase):
         cmdline.set_parameter("out_prefix", "SamBam/out")
         stdout, stderr = cmdline()
         self.assertFalse(stderr,
-                         "Samtools sort failed:\n%s\nStderr:%s"
-                         % (cmdline, stderr))
+                         "Samtools sort failed:\n{0!s}\nStderr:{1!s}".format(cmdline, stderr))
 
     def test_index(self):
         cmdline = SamtoolsIndexCommandline(samtools_exe)
         cmdline.set_parameter("input_bam", self.bamfile1)
         stdout, stderr = cmdline()
         self.assertFalse(stderr,
-                         "Samtools index failed:\n%s\nStderr:%s"
-                         % (cmdline, stderr))
+                         "Samtools index failed:\n{0!s}\nStderr:{1!s}".format(cmdline, stderr))
         self.assertTrue(os.path.exists(self.bamindexfile1))
 
     def test_idxstats(self):
@@ -200,8 +195,7 @@ class SamtoolsTestCase(unittest.TestCase):
         cmdline.set_parameter("input_bam", self.bamfile1)
         stdout, stderr = cmdline()
         self.assertFalse(stderr,
-                         "Samtools idxstats failed:\n%s\nStderr:%s"
-                         % (cmdline, stderr))
+                         "Samtools idxstats failed:\n{0!s}\nStderr:{1!s}".format(cmdline, stderr))
 
     def test_merge(self):
         cmdline = SamtoolsMergeCommandline(samtools_exe)
@@ -210,8 +204,7 @@ class SamtoolsTestCase(unittest.TestCase):
         cmdline.set_parameter("f", True)  # Overwrite out.bam if it exists
         stdout, stderr = cmdline()
         self.assertFalse(stderr,
-                         "Samtools merge failed:\n%s\nStderr:%s"
-                         % (cmdline, stderr))
+                         "Samtools merge failed:\n{0!s}\nStderr:{1!s}".format(cmdline, stderr))
         self.assertTrue(os.path.exists(self.outbamfile))
 
     def test_mpileup(self):

--- a/Tests/test_translate.py
+++ b/Tests/test_translate.py
@@ -61,31 +61,31 @@ assert str(protein) == 'ENSFSLDFLWNPSPSNDAWDSSY'
 # use the standard table
 
 s = "TCAAAAAGGTGCATCTAGATG"
-print("Starting with %s" % s)
+print("Starting with {0!s}".format(s))
 dna = Seq.Seq(s, IUPAC.unambiguous_dna)
 protein = dna.translate(to_stop=True)
 assert isinstance(protein.alphabet, IUPAC.IUPACProtein)
 
-print("%i ungapped residues translated" % len(protein))
+print("{0:d} ungapped residues translated".format(len(protein)))
 
 gapped_protein = dna.translate()
 assert isinstance(gapped_protein.alphabet, Alphabet.HasStopCodon)
 print(str(protein))
 
-print("%i residues translated, including gaps" % len(gapped_protein))
+print("{0:d} residues translated, including gaps".format(len(gapped_protein)))
 print(str(gapped_protein))
 
 # This has "AGG" as a stop codon
 p2 = dna.translate(table=2, to_stop=True)
-print("%i SGC1 has a stop codon" % len(p2))
+print("{0:d} SGC1 has a stop codon".format(len(p2)))
 print(str(p2))
 p2 = dna.translate(table=2)
-print("Actually, there are %i stops." % p2.count("*"))
+print("Actually, there are {0:d} stops.".format(p2.count("*")))
 print(str(p2))
 
 # Make sure I can change the stop character
 p2 = dna.translate(table=2, stop_symbol="+")
-print("Yep, %i stops." % p2.count("+"))
+print("Yep, {0:d} stops.".format(p2.count("+")))
 print(str(p2))
 
 

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ def get_yes_or_no(question, default):
         default_str = 'n'
 
     while True:
-        print("%s %s:" % (question, option_str))
+        print("{0!s} {1!s}:".format(question, option_str))
         if sys.version_info[0] == 3:
             response = input().lower()
         else:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:qc-friends:biopython?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:qc-friends:biopython?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
